### PR TITLE
Try to stay in 100 columns

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,7 +16,7 @@
 ---
 Language: Cpp
 AccessModifierOffset: -4
-AlignAfterOpenBracket: DontAlign
+AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: AcrossEmptyLines
 AlignConsecutiveDeclarations: AcrossEmptyLines
 AlignEscapedNewlines: DontAlign
@@ -31,9 +31,9 @@ AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Always
 AllowShortLoopsOnASingleLine: true
-AlwaysBreakAfterReturnType: None
+AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
@@ -60,7 +60,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: true
 BreakStringLiterals: true
-ColumnLimit: 0
+ColumnLimit: 100
 CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
@@ -103,6 +103,8 @@ PenaltyExcessCharacter: 50
 PenaltyReturnTypeOnItsOwnLine: 300
 PointerAlignment: Right
 ReflowComments: true
+# (v15) RequiresClausePosition: OwnLine
+# (v14) SeparateDefinitionBlocks: Always
 SortIncludes: CaseInsensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: true

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -11,10 +11,7 @@ namespace fair::graph {
 template<typename T>
 concept any_node = true;
 
-enum class port_direction {
-    in,
-    out
-};
+enum class port_direction { in, out };
 
 template<port_direction D, int I, typename T>
 struct port_id {
@@ -30,14 +27,17 @@ struct portlist {
     //
     using typelist      = meta::typelist<Types...>;
     using tuple_type    = std::tuple<Types...>;
-    using tuple_or_type = std::conditional_t<sizeof...(Types) == 1, typename typelist::template at<0>, tuple_type>;
+    using tuple_or_type = std::conditional_t<sizeof...(Types) == 1,
+                                             typename typelist::template at<0>, tuple_type>;
 
     template<int I>
     using at = port_id<D, I, typename typelist::template at<I>>;
 
     template<typename I>
     constexpr at<I::value>
-    operator[](I) const { return {}; }
+    operator[](I) const {
+        return {};
+    }
 
     template<typename... Other>
     static constexpr inline bool are_equal = std::same_as<typelist, meta::typelist<Other...>>;
@@ -50,9 +50,7 @@ struct portlist {
 };
 
 template<port_direction D, typename... Types>
-struct portlist<D, meta::typelist<Types...>>
-    : portlist<D, Types...> {
-};
+struct portlist<D, meta::typelist<Types...>> : portlist<D, Types...> {};
 
 template<typename... Types>
 using make_input_ports = portlist<port_direction::in, Types...>;
@@ -71,28 +69,40 @@ public:
 };
 
 template<any_node Left, any_node Right, int OutId, int InId>
-class merged_node : public node<merged_node<Left, Right, OutId, InId>,
-                            make_input_ports<meta::concat<typename Left::input_ports::typelist, meta::remove_at<InId, typename Right::input_ports::typelist>>>,
-                            make_output_ports<meta::concat<typename Left::output_ports::typelist, typename Right::output_ports::typelist>>> {
+class merged_node
+    : public node<merged_node<Left, Right, OutId, InId>,
+                  make_input_ports<
+                          meta::concat<typename Left::input_ports::typelist,
+                                       meta::remove_at<InId, typename Right::input_ports::typelist>>>,
+                  make_output_ports<meta::concat<typename Left::output_ports::typelist,
+                                                 typename Right::output_ports::typelist>>> {
 private:
     using base = node<merged_node,
-            make_input_ports<meta::concat<typename Left::input_ports::typelist, meta::remove_at<InId, typename Right::input_ports::typelist>>>,
-            make_output_ports<meta::concat<typename Left::output_ports::typelist, typename Right::output_ports::typelist>>>;
+                      make_input_ports<meta::concat<
+                              typename Left::input_ports::typelist,
+                              meta::remove_at<InId, typename Right::input_ports::typelist>>>,
+                      make_output_ports<meta::concat<typename Left::output_ports::typelist,
+                                                     typename Right::output_ports::typelist>>>;
 
     Left  left;
     Right right;
 
     template<std::size_t... Is>
-    constexpr auto apply_left(auto &&input_tuple, std::index_sequence<Is...>) {
+    constexpr auto
+    apply_left(auto &&input_tuple, std::index_sequence<Is...>) {
         return left.process_one(std::get<Is>(input_tuple)...);
     }
 
     template<std::size_t... Is, std::size_t... Js>
-    constexpr auto apply_right(auto &&input_tuple, const typename Left::output_ports::tuple_or_type &tmp, std::index_sequence<Is...>, std::index_sequence<Js...>) {
+    constexpr auto
+    apply_right(auto &&input_tuple, const typename Left::output_ports::tuple_or_type &tmp,
+                std::index_sequence<Is...>, std::index_sequence<Js...>) {
         constexpr int first_offset  = Left::input_ports::size;
         constexpr int second_offset = Left::input_ports::size + sizeof...(Is);
-        static_assert(second_offset + sizeof...(Js) == std::tuple_size_v<std::remove_cvref_t<decltype(input_tuple)>>);
-        return right.process_one(std::get<first_offset + Is>(input_tuple)..., tmp, std::get<second_offset + Js>(input_tuple)...);
+        static_assert(second_offset + sizeof...(Js)
+                      == std::tuple_size_v<std::remove_cvref_t<decltype(input_tuple)>>);
+        return right.process_one(std::get<first_offset + Is>(input_tuple)..., tmp,
+                                 std::get<second_offset + Js>(input_tuple)...);
     }
 
 public:
@@ -100,39 +110,39 @@ public:
     using output_ports = typename base::output_ports;
     using return_type  = typename output_ports::tuple_or_type;
 
-    constexpr merged_node(Left l, Right r)
-        : left(std::move(l)), right(std::move(r)) {}
+    constexpr merged_node(Left l, Right r) : left(std::move(l)), right(std::move(r)) {}
 
     template<typename... Ts>
-        requires input_ports::template
-    are_equal<std::remove_cvref_t<Ts>...> constexpr typename output_ports::tuple_or_type process_one(Ts &&...inputs) {
+
+    requires input_ports::template are_equal<std::remove_cvref_t<Ts>...> constexpr
+            typename output_ports::tuple_or_type
+            process_one(Ts &&...inputs) {
         if constexpr (Left::output_ports::size == 1 && Right::output_ports::size == 1) {
             static_assert(std::tuple_size_v<return_type> == 2);
             return_type ret;
             auto       &left_out  = std::get<0>(ret);
             auto       &right_out = std::get<1>(ret);
-            left_out              = apply_left(std::forward_as_tuple(std::forward<Ts>(inputs)...), std::make_index_sequence<Left::input_ports::size()>());
-            right_out             = apply_right(
-                    std::forward_as_tuple(std::forward<Ts>(inputs)...), left_out,
-                    std::make_index_sequence<InId>(),
-                    std::make_index_sequence<Right::input_ports::size() - InId - 1>());
+            left_out              = apply_left(std::forward_as_tuple(std::forward<Ts>(inputs)...),
+                                               std::make_index_sequence<Left::input_ports::size()>());
+            right_out
+                    = apply_right(std::forward_as_tuple(std::forward<Ts>(inputs)...), left_out,
+                                  std::make_index_sequence<InId>(),
+                                  std::make_index_sequence<Right::input_ports::size() - InId - 1>());
 
             return ret;
         } else {
             auto left_out = [&]() {
                 auto tmp = apply_left(std::forward_as_tuple(std::forward<Ts>(inputs)...),
-                        std::make_index_sequence<Left::input_ports::size()>());
-                if constexpr (Left::output_ports::size == 1)
-                    return std::make_tuple(std::move(tmp));
+                                      std::make_index_sequence<Left::input_ports::size()>());
+                if constexpr (Left::output_ports::size == 1) return std::make_tuple(std::move(tmp));
                 else
                     return tmp;
             }();
             auto right_out = [&]() {
-                auto tmp = apply_right(
-                        std::forward_as_tuple(std::forward<Ts>(inputs)...),
-                        std::get<OutId>(left_out),
-                        std::make_index_sequence<InId>(),
-                        std::make_index_sequence<Right::input_ports::size() - InId - 1>());
+                auto tmp = apply_right(std::forward_as_tuple(std::forward<Ts>(inputs)...),
+                                       std::get<OutId>(left_out), std::make_index_sequence<InId>(),
+                                       std::make_index_sequence<Right::input_ports::size() - InId
+                                                                - 1>());
                 if constexpr (Right::output_ports::size == 1)
                     return std::make_tuple(std::move(tmp));
                 else
@@ -144,8 +154,13 @@ public:
 };
 
 template<int OutId, int InId, any_node A, any_node B>
-    requires std::same_as<typename std::remove_cvref_t<A>::output_ports::template at<OutId>::type, typename std::remove_cvref_t<B>::input_ports::template at<InId>::type>
-[[gnu::always_inline]] constexpr auto merge(A &&a, B &&b) -> merged_node<std::remove_cvref_t<A>, std::remove_cvref_t<B>, OutId, InId> { return { std::forward<A>(a), std::forward<B>(b) }; }
+
+requires std::same_as<typename std::remove_cvref_t<A>::output_ports::template at<OutId>::type,
+                      typename std::remove_cvref_t<B>::input_ports::template at<
+                              InId>::type> [[gnu::always_inline]] constexpr auto
+merge(A &&a, B &&b) -> merged_node<std::remove_cvref_t<A>, std::remove_cvref_t<B>, OutId, InId> {
+    return { std::forward<A>(a), std::forward<B>(b) };
+}
 } // namespace fair::graph
 
 #endif // GRAPH_PROTOTYPE_GRAPH_HPP

--- a/include/typelist.hpp
+++ b/include/typelist.hpp
@@ -56,9 +56,9 @@ struct concat_impl<A, B, C> {
 
 template<typename A, typename B, typename C, typename D, typename... More>
 struct concat_impl<A, B, C, D, More...> {
-    using type = typename concat_impl<typename concat_impl<A, B>::type,
-            typename concat_impl<C, D>::type,
-            typename concat_impl<More...>::type>::type;
+    using type =
+            typename concat_impl<typename concat_impl<A, B>::type, typename concat_impl<C, D>::type,
+                                 typename concat_impl<More...>::type>::type;
 };
 } // namespace detail
 
@@ -105,23 +105,23 @@ struct splitter<4> {
 template<>
 struct splitter<8> {
     template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5,
-            typename T6, typename T7, typename...>
+             typename T6, typename T7, typename...>
     using first = typelist<T0, T1, T2, T3, T4, T5, T6, T7>;
+
     template<typename, typename, typename, typename, typename, typename, typename, typename,
-            typename... Ts>
+             typename... Ts>
     using second = typelist<Ts...>;
 };
 
 template<>
 struct splitter<16> {
     template<typename T0, typename T1, typename T2, typename T3, typename T4, typename T5,
-            typename T6, typename T7, typename T8, typename T9, typename T10, typename T11,
-            typename T12, typename T13, typename T14, typename T15, typename...>
-    using first = typelist<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14,
-            T15>;
-    template<typename, typename, typename, typename, typename, typename, typename, typename,
-            typename, typename, typename, typename, typename, typename, typename, typename,
-            typename... Ts>
+             typename T6, typename T7, typename T8, typename T9, typename T10, typename T11,
+             typename T12, typename T13, typename T14, typename T15, typename...>
+    using first = typelist<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>;
+
+    template<typename, typename, typename, typename, typename, typename, typename, typename, typename,
+             typename, typename, typename, typename, typename, typename, typename, typename... Ts>
     using second = typelist<Ts...>;
 };
 
@@ -133,7 +133,7 @@ struct splitter {
 
     template<typename... Ts>
     using first = concat<typename A::template first<Ts...>,
-            typename B::template first<typename A::template second<Ts...>>>;
+                         typename B::template first<typename A::template second<Ts...>>>;
 
     template<typename... Ts>
     using second = typename B::template second<typename A::template second<Ts...>>;
@@ -162,8 +162,7 @@ using remove_at = concat<left_of<Idx, List>, right_of<Idx, List>>;
 // first_type ////////////
 namespace detail {
 template<typename List>
-struct first_type_impl {
-};
+struct first_type_impl {};
 
 template<typename T0, typename... Ts>
 struct first_type_impl<typelist<T0, Ts...>> {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,13 +4,16 @@
 #include "graph.hpp"
 
 template<typename T, int Depth>
-    requires(Depth > 0)
-class delay : public fair::graph::node<delay<T, Depth>, fair::graph::make_input_ports<T>, fair::graph::make_output_ports<T>> {
+requires(Depth > 0)
+class delay
+    : public fair::graph::node<delay<T, Depth>, fair::graph::make_input_ports<T>,
+                               fair::graph::make_output_ports<T>> {
     std::array<T, Depth> buffer = {};
     int                  pos    = 0;
 
 public:
-    [[nodiscard]] constexpr T process_one(T in) noexcept {
+    [[nodiscard]] constexpr T
+    process_one(T in) noexcept {
         T ret       = buffer[pos];
         buffer[pos] = in;
         if (pos == Depth - 1) {
@@ -23,18 +26,27 @@ public:
 };
 
 template<typename T, typename R = decltype(std::declval<T>() + std::declval<T>())>
-class adder : public fair::graph::node<adder<T>, fair::graph::make_input_ports<T, T>, fair::graph::make_output_ports<R>> {
+class adder : public fair::graph::node<adder<T>, fair::graph::make_input_ports<T, T>,
+                                       fair::graph::make_output_ports<R>> {
 public:
-    [[nodiscard]] constexpr R process_one(T a, T b) const noexcept { return a + b; }
+    [[nodiscard]] constexpr R
+    process_one(T a, T b) const noexcept {
+        return a + b;
+    }
 };
 
 template<typename T, T Scale, typename R = decltype(std::declval<T>() * std::declval<T>())>
-class scale : public fair::graph::node<scale<T, Scale, R>, fair::graph::make_input_ports<T>, fair::graph::make_output_ports<R>> {
+class scale : public fair::graph::node<scale<T, Scale, R>, fair::graph::make_input_ports<T>,
+                                       fair::graph::make_output_ports<R>> {
 public:
-    [[nodiscard]] constexpr R process_one(T a) const noexcept { return a * Scale; }
+    [[nodiscard]] constexpr R
+    process_one(T a) const noexcept {
+        return a * Scale;
+    }
 };
 
-int main() {
+int
+main() {
     using fair::graph::merge;
     // declare flow-graph: 2 x in -> adder -> scale-by-2 -> scale-by-minus1 -> output
     auto merged = merge<0, 0>(scale<int, -1>(), merge<0, 0>(scale<int, 2>(), adder<int>()));


### PR DESCRIPTION
Limiting to 100 (plus some slack) typically removes the need for vertical scrolling, making it more readable in GitHub patch reviews, copy&paste to Mattermost, etc. and generally makes reading those long lines easier.

To actually make broken long lines easier to read, enable AlignAfterOpenBracket.

To find function names quickly enable AlwaysBreakAfterReturnType. Especially with long return types (or decl-specifiers) it otherwise can take way too long to find the function name.

Additionally, keep template heads on their own lines. I would equally prefer to have requires clauses on their own lines, but we'd need clang 15.

ChangeLog:

	* .clang-format: Change rules to insert readable breaks in otherwise long lines.
	* include/graph.hpp: Re-apply clang-format.
	* include/typelist.hpp: Ditto.
	* src/main.cpp: Ditto.