### PR TITLE
Add generic process_batch with automatic explicit SIMD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,8 +60,9 @@ template<typename T, typename R = decltype(std::declval<T>() + std::declval<T>()
 class adder : public fair::graph::node<adder<T>, fair::graph::make_input_ports<T, T>,
                                        fair::graph::make_output_ports<R>> {
 public:
-    [[nodiscard]] constexpr R
-    process_one(T a, T b) const noexcept {
+    template<fair::graph::detail::t_or_simd<T> V>
+    [[nodiscard]] constexpr auto
+    process_one(V a, V b) const noexcept {
         return a + b;
     }
 };
@@ -70,8 +71,9 @@ template<typename T, T Scale, typename R = decltype(std::declval<T>() * std::dec
 class scale : public fair::graph::node<scale<T, Scale, R>, fair::graph::make_input_ports<T>,
                                        fair::graph::make_output_ports<R>> {
 public:
-    [[nodiscard]] constexpr R
-    process_one(T a) const noexcept {
+    template<fair::graph::detail::t_or_simd<T> V>
+    [[nodiscard]] constexpr auto
+    process_one(V a) const noexcept {
         return a * Scale;
     }
 };


### PR DESCRIPTION
The new node::process_batch function calls process_one for processing as many elements as given via the input ranges. The function expects all input ranges to be of the same size. This is encoded as a pre-condition in the function body.

The first argument to process_batch is a buffer that provides simple span<return_type> access. This is still an *incorrect* solution since return_type is a std::tuple of all output port types. A correct solution provides access to a span per type in the return_type tuple.

If all input and output ranges are contiguous ranges, and if all input and output port types are vectorizable (in the std::experimental::simd definition), then process_batch calls process_one with simd<T> arguments instead of T. This is still missing a correct constraint on the process_one function, testing whether it actually works with simd arguments.

ChangeLog:

	* src/main.cpp (adder::process_one): Accept simd<T, Abi> or T.
	(scale::process_one): Accept simd<T, Abi> or T.
	* include/graph.h (detail::precondition): New.
	(port_data): New.
	(node::process_batch_simd_epilogue): New.
	(node::process_batch): New.
	(merged_node::process_one): Accept simd<T, Abi> or T.
	* include/typelist.h (meta::transform_types): New.
	(meta::transform_value_type): New.
	(meta::reduce): New.
	(typelist::construct): New.