### PR TITLE
update restyled.io to clang-format 15

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,7 +24,7 @@ AlignOperands: AlignAfterOperator
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowAllArgumentsOnNextLine: true
-#PackConstructorInitializers: PCIS_CurrentLine # starting with clang 14
+PackConstructorInitializers: CurrentLine
 AllowAllConstructorInitializersOnNextLine: true
 AllowShortLambdasOnASingleLine: All
 AllowShortCaseLabelsOnASingleLine: true
@@ -103,8 +103,8 @@ PenaltyExcessCharacter: 50
 PenaltyReturnTypeOnItsOwnLine: 300
 PointerAlignment: Right
 ReflowComments: true
-# (v15) RequiresClausePosition: OwnLine
-# (v14) SeparateDefinitionBlocks: Always
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Always
 SortIncludes: CaseInsensitive
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: true

--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -93,7 +93,7 @@ ignore_labels:
 # re-specify the default in your own config if you prefer to avoid update
 # surprises.
 #
-restylers_version: "20191031"
+restylers_version: "v0.222.0"
 
 # Restylers to run, and how
 #
@@ -180,28 +180,3 @@ restylers_version: "20191031"
 # for info see: https://github.com/restyled-io/restyler/issues/134
 # N.B. the docker image version can be controlled via PRs:
 # https://github.com/restyled-io/restylers/tree/main/clang-format
-restylers:
-  - name: clang-format
-    image: 'restyled/restyler-clang-format:13.0.1'
-    command:
-      - clang-format
-      - "-i"
-    arguments: []
-    include:
-      - "**/*.c"
-      - "**/*.cc"
-      - "**/*.cpp"
-      - "**/*.cxx"
-      - "**/*.c++"
-      - "**/*.C"
-      - "**/*.cs"
-      - "**/*.h"
-      - "**/*.hh"
-      - "**/*.hpp"
-      - "**/*.hxx"
-      - "**/*.h++"
-      - "**/*.H"
-      - "**/*.java"
-      - "**/*.js"
-      - "**/*.m"
-    interpreters: []


### PR DESCRIPTION
Upgrades clang-format v15 for the features requested in #1.