### PR TITLE
CI: enable emscripten build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
           # - name: Ubuntu Latest clang16
           #   os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
           #   compiler: clang16
-          # - name: Ubuntu Latest emscripten
-          #   os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
-          #   compiler: emscripten
+          - name: Ubuntu Latest emscripten
+            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+            compiler: emscripten
         # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
         cmake-build-type: [ Release, Debug ]
 
@@ -101,7 +101,7 @@ jobs:
       shell: bash
       run: |
         source ~/emsdk/emsdk_env.sh
-        emcmake cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=${{ matrix.configurations.name == env.REFERENCE_CONFIG &&  matrix.cmake-build-type == 'Debug'}}
+        emcmake cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=OFF
 
     - name: Build
       if: matrix.configurations.compiler != 'emscripten'
@@ -117,7 +117,15 @@ jobs:
         emmake make
 
     - name: execute binary
-      if: matrix.configurations.name != env.REFERENCE_CONFIG || matrix.cmake-build-type != 'Debug'
+      if: matrix.configurations.compiler != 'emscripten'
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ../build/src/main
+      run: ./src/main
+
+    - name: execute binary
+      if: matrix.configurations.compiler == 'emscripten'
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: |
+        source ~/emsdk/emsdk_env.sh
+        ${EMSDK_NODE} ./src/main.js

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@ cmake_minimum_required(VERSION 3.19)
 project(graph-prototype CXX)
 set(CMAKE_CXX_STANDARD 20)
 
+if (EMSCRIPTEN)
+    set(CMAKE_EXECUTABLE_SUFFIX ".js")
+endif()
+
 include(cmake/CompilerWarnings.cmake)
 include(FetchContent)
 FetchContent_Declare(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,5 +49,6 @@ int main() {
         r += z;
     }
 
+    fmt::print("Result of graph execution: {}\n", r);
     return r == 20 ? 0 : 1;
 }


### PR DESCRIPTION
Add's a CI run compiling to emscripten and running the resulting wasm binary from node.