### PR TITLE
extended BufferWriter API by expert-level get/publish pair

### DIFF
--- a/include/buffer.hpp
+++ b/include/buffer.hpp
@@ -8,7 +8,7 @@
 #include <span>
 
 namespace gr {
-namespace util { // TODO: move this meta-programming helpers to a common header file
+namespace util {
 template <typename T, typename...>
 struct first_template_arg_helper;
 
@@ -64,11 +64,13 @@ template<class Fn, typename T, typename ...Args>
 concept WriterCallback = std::is_invocable_v<Fn, std::span<T>&, std::int64_t, Args...> || std::is_invocable_v<Fn, std::span<T>&, Args...>;
 
 template<class T, typename ...Args>
-concept BufferWriter = requires(T t, const std::size_t n_items, Args ...args) {
+concept BufferWriter = requires(T t, const std::size_t n_items, std::pair<std::size_t, std::int64_t> token, Args ...args) {
     { t.publish([](std::span<util::value_type_t<T>> &/*writable_data*/, Args ...) { /* */ }, n_items, args...) }                                -> std::same_as<void>;
     { t.publish([](std::span<util::value_type_t<T>> &/*writable_data*/, std::int64_t /* writePos */, Args ...) { /* */  }, n_items, args...) }   -> std::same_as<void>;
     { t.try_publish([](std::span<util::value_type_t<T>> &/*writable_data*/, Args ...) { /* */ }, n_items, args...) }                             -> std::same_as<bool>;
     { t.try_publish([](std::span<util::value_type_t<T>> &/*writable_data*/, std::int64_t /* writePos */, Args ...) { /* */  }, n_items, args...) }-> std::same_as<bool>;
+    { t.get(n_items) } -> std::same_as<std::pair<std::span<util::value_type_t<T>>, std::pair<std::size_t, std::int64_t>>>;
+    { t.publish(token, n_items) } -> std::same_as<void>;
     { t.available() }         -> std::same_as<std::size_t>;
     { t.buffer() };
 };


### PR DESCRIPTION
... and some minor code-clean ups.

Basic usage (N.B. similar to BufferReader API):
```cpp
// case 1: reserve more than actually written
auto [data, token] = writer.get(4);
for (std::size_t i = 0; i < data.size(); i++) {
    data[i] = i + 1;
}
writer.publish(token, 2);

auto read_data = reader.get();
expect(eq(2, read_data.size()));
for (std::size_t i = 0; i < data.size(); i++) {
    expect(eq(i + 1, read_data[i])) << "read 1: index " << i;
}
expect(reader.consume(2));
```

N.B. the underlying safety concern of this type of API is that the (expert) user may produce UB if
  * token is modified in the user code
  * if more samples are published than initially reserved (violates write cursor invariant)
  * potentially unsafe in a multiple writer scenario where not all producers publish the exact amount of items they initially reserved.
  
To be reiterated in another PR