### PR TITLE
CI: use ubuntu toolchains ppa for gcc 12.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Install gcc-12
       if: matrix.configurations.compiler == 'gcc'
       run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa # provides newer gcc 12.2.0 instead of 12.1.0
         sudo apt-get install -y gcc-12 g++-12
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
 


### PR DESCRIPTION
Uses the ubuntu-toolchain [PPA](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/ppa) which provides newer versions of gcc than the ones from the regular repositories.

Switches from `gcc 12.1.0-2ubuntu1~22.04` (the default on ubuntu 22.04LTS jammy) to `gcc 12.2.0-3ubuntu1~22.04`.

The newest ubuntu kinetic 22.10 would also provide gcc 12.2.0-3ubuntu1 and the ubuntu lunar development version provides gcc 12.2.0-10ubuntu1 but there is no offiicial github actions runner image for these releases.