### PR TITLE
added optional BENCHMARK_NO_PERF_COUNTER

### DIFF
--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -16,7 +16,7 @@
 #include <fmt/color.h>
 #include <fmt/format.h>
 
-#if __has_include(<unistd.h>)  && __has_include(<sys/ioctl.h>)  && __has_include(<sys/syscall.h>) && __has_include(<linux/perf_event.h>)
+#if __has_include(<unistd.h>)  && __has_include(<sys/ioctl.h>)  && __has_include(<sys/syscall.h>) && __has_include(<linux/perf_event.h>) && !defined(BENCHMARK_NO_PERF_COUNTER)
 #define HAS_LINUX_PERFORMANCE_HEADER
 #include <linux/perf_event.h>
 #include <sys/ioctl.h>

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -1,3 +1,4 @@
+//#define BENCHMARK_NO_PERF_COUNTER 1
 #include "benchmark.hpp"
 
 #include <algorithm>


### PR DESCRIPTION
... suppressing the Linux specific CPU/Kernel performance metrics even if the headers are available.

The existing version is already guarded for use in non-Linux environments but this can be set when it is known in advance that the user does not have sufficient rights to execute those kernel calls.