### PR TITLE
added self-contained SIMD tests to bm_case1 benchmarks

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -62,7 +62,7 @@ template<typename CharT, std::size_t N>
 fixed_string(const CharT (&str)[N]) -> fixed_string<CharT, N - 1>;
 
 template<typename T>
-[[nodiscard]] constexpr std::string
+[[nodiscard]] std::string
 type_name() noexcept {
 #ifndef __EMSCRIPTEN__
     std::string type_name = typeid(T).name();


### PR DESCRIPTION
implemented cases include:
  * node internally translating T -> native_simd<T> -> T
  * cascade doing a 'T -> native_simd<T>' -> simd_processing -> 'native_simd<T> -> T' to amortize the conversion between 'T<->native_simd<T>'

for both 'mult*mult*add' as well as '(mult*mult*add)^10' test cases

Signed-off-by: Ralph J. Steinhagen <r.steinhagen@gsi.de>