### PR TITLE
reordered/removed header duplicates v3

### DIFF
--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -3,7 +3,6 @@
 
 #include <circular_buffer.hpp> // localinclude
 #include <buffer.hpp> // localinclude
-#include <utils.hpp> // localinclude
 #include <typelist.hpp> // localinclude
 #include <port.hpp> // localinclude
 #include <node.hpp> // localinclude

--- a/include/merged_node.hpp
+++ b/include/merged_node.hpp
@@ -1,8 +1,7 @@
 #ifndef GNURADIO_MERGED_NODE_HPP
 #define GNURADIO_MERGED_NODE_HPP
 
-#include <utils.hpp> // localinclude
-#include <node.hpp>
+#include <node.hpp> // localinclude
 
 namespace fair::graph {
 

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -5,7 +5,6 @@
 
 #include <typelist.hpp> // localinclude
 #include <port.hpp> // localinclude
-#include <utils.hpp> // localinclude
 
 #include <fmt/format.h>
 


### PR DESCRIPTION
to enable single-header-only feature again

Signed-off-by: Ralph J. Steinhagen <r.steinhagen@gsi.de>