### PR TITLE
Make graph owner of all nodes

### DIFF
--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -380,8 +380,8 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(sink)));
 
@@ -398,9 +398,9 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *sink = flow_graph.make_node<test::sink<float>>();
-        auto *cpy = flow_graph.make_node<copy<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &sink = flow_graph.make_node<test::sink<float>>();
+        auto &cpy = flow_graph.make_node<copy<float>>();
 
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(cpy)));
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(cpy).to<"in">(sink)));
@@ -418,22 +418,22 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         std::vector<copy<float, 0, N_MAX, true, true>*> cpy(10);
         for (std::size_t i = 0; i < cpy.size(); i++) {
-            cpy[i] = flow_graph.make_node<copy<float, 0, N_MAX, true, true>>();
+            cpy[i] = std::addressof(flow_graph.make_node<copy<float, 0, N_MAX, true, true>>());
             cpy[i]->set_name(fmt::format("copy {} at {}", i, fair::graph::this_source_location()));
 
             if (i == 0) {
-                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(cpy[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(*cpy[i])));
             } else {
-                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(cpy[i - 1]).to<"in">(cpy[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*cpy[i - 1]).to<"in">(*cpy[i])));
             }
         }
 
-        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(cpy[cpy.size() - 1]).to<"in">(sink)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*cpy[cpy.size() - 1]).to<"in">(sink)));
 
         "runtime   src->copy^10->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() {
             test::n_samples_produced = 0LU;
@@ -448,11 +448,11 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float, 0, 1024>>(N_SAMPLES);
-        auto *b1 = flow_graph.make_node<copy<float, 0, 128>>();
-        auto *b2 = flow_graph.make_node<copy<float, 1024, 1024>>();
-        auto *b3 = flow_graph.make_node<copy<float, 32, 128>>();
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float, 0, 1024>>(N_SAMPLES);
+        auto &b1 = flow_graph.make_node<copy<float, 0, 128>>();
+        auto &b2 = flow_graph.make_node<copy<float, 1024, 1024>>();
+        auto &b3 = flow_graph.make_node<copy<float, 32, 128>>();
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(b1)));
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(b1).to<"in">(b2)));
@@ -473,11 +473,11 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *mult1 = flow_graph.make_node<multiply<float>>(2.0f);
-        auto *mult2 = flow_graph.make_node<multiply<float>>(0.5f);
-        auto *add1 = flow_graph.make_node<add<float, -1>>();
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &mult1 = flow_graph.make_node<multiply<float>>(2.0f);
+        auto &mult2 = flow_graph.make_node<multiply<float>>(0.5f);
+        auto &add1 = flow_graph.make_node<add<float, -1>>();
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(mult1)));
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1).to<"in">(mult2)));
@@ -497,28 +497,28 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         std::vector<multiply<float>*> mult1;
         std::vector<multiply<float>*> mult2;
         std::vector<add<float, -1>*> add1;
         for (std::size_t i = 0; i < 10; i++) {
-            mult1.emplace_back(flow_graph.make_node<multiply<float>>(2.0f, fmt::format("mult1.{}", i)));
-            mult2.emplace_back(flow_graph.make_node<multiply<float>>(0.5f, fmt::format("mult2.{}", i)));
-            add1.emplace_back(flow_graph.make_node<add<float, -1>>());
+            mult1.emplace_back(std::addressof(flow_graph.make_node<multiply<float>>(2.0f, fmt::format("mult1.{}", i))));
+            mult2.emplace_back(std::addressof(flow_graph.make_node<multiply<float>>(0.5f, fmt::format("mult2.{}", i))));
+            add1.emplace_back(std::addressof(flow_graph.make_node<add<float, -1>>()));
         }
 
         for (std::size_t i = 0; i < add1.size(); i++) {
             if (i == 0) {
-                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(*mult1[i])));
             } else {
-                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*add1[i - 1]).to<"in">(*mult1[i])));
             }
-            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1[i]).to<"in">(mult2[i])));
-            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2[i]).to<"in">(add1[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*mult1[i]).to<"in">(*mult2[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*mult2[i]).to<"in">(*add1[i])));
         }
-        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[add1.size() - 1]).to<"in">(sink)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*add1[add1.size() - 1]).to<"in">(sink)));
 
         auto token = flow_graph.init();
         expect(token);
@@ -534,11 +534,11 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *mult1 = flow_graph.make_node<multiply_SIMD<float>>(2.0f);
-        auto *mult2 = flow_graph.make_node<multiply_SIMD<float>>(0.5f);
-        auto *add1 = flow_graph.make_node<add_SIMD<float>>(-1.0f);
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &mult1 = flow_graph.make_node<multiply_SIMD<float>>(2.0f);
+        auto &mult2 = flow_graph.make_node<multiply_SIMD<float>>(0.5f);
+        auto &add1 = flow_graph.make_node<add_SIMD<float>>(-1.0f);
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(mult1)));
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1).to<"in">(mult2)));
@@ -559,28 +559,28 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         std::vector<multiply_SIMD<float>*> mult1;
         std::vector<multiply_SIMD<float>*> mult2;
         std::vector<add_SIMD<float>*> add1;
         for (std::size_t i = 0; i < 10; i++) {
-            mult1.emplace_back(flow_graph.make_node<multiply_SIMD<float>>(2.0f, fmt::format("mult1.{}", i)));
-            mult2.emplace_back(flow_graph.make_node<multiply_SIMD<float>>(0.5f, fmt::format("mult2.{}", i)));
-            add1.emplace_back(flow_graph.make_node<add_SIMD<float>>(-1.0f, fmt::format("add.{}", i)));
+            mult1.emplace_back(std::addressof(flow_graph.make_node<multiply_SIMD<float>>(2.0f, fmt::format("mult1.{}", i))));
+            mult2.emplace_back(std::addressof(flow_graph.make_node<multiply_SIMD<float>>(0.5f, fmt::format("mult2.{}", i))));
+            add1.emplace_back(std::addressof(flow_graph.make_node<add_SIMD<float>>(-1.0f, fmt::format("add.{}", i))));
         }
 
         for (std::size_t i = 0; i < add1.size(); i++) {
             if (i == 0) {
-                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(*mult1[i])));
             } else {
-                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*add1[i - 1]).to<"in">(*mult1[i])));
             }
-            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1[i]).to<"in">(mult2[i])));
-            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2[i]).to<"in">(add1[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*mult1[i]).to<"in">(*mult2[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*mult2[i]).to<"in">(*add1[i])));
         }
-        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[add1.size() - 1]).to<"in">(sink)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*add1[add1.size() - 1]).to<"in">(sink)));
 
         auto token = flow_graph.init();
         expect(token);
@@ -597,13 +597,13 @@ inline const boost::ut::suite _runtime_tests = [] {
     {
         using namespace stdx;
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *convert1 = flow_graph.make_node<convert<float, stdx::native_simd<float>>>();
-        auto *mult1 = flow_graph.make_node<multiply<stdx::native_simd<float>>>(2.0f);
-        auto *mult2 = flow_graph.make_node<multiply<stdx::native_simd<float>>>(0.5f);
-        auto *add1 = flow_graph.make_node<add<stdx::native_simd<float>, -1>>();
-        auto *convert2 = flow_graph.make_node<convert<stdx::native_simd<float>, float>>();
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &convert1 = flow_graph.make_node<convert<float, stdx::native_simd<float>>>();
+        auto &mult1 = flow_graph.make_node<multiply<stdx::native_simd<float>>>(2.0f);
+        auto &mult2 = flow_graph.make_node<multiply<stdx::native_simd<float>>>(0.5f);
+        auto &add1 = flow_graph.make_node<add<stdx::native_simd<float>, -1>>();
+        auto &convert2 = flow_graph.make_node<convert<stdx::native_simd<float>, float>>();
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(convert1)));
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(convert1).to<"in">(mult1)));
@@ -627,10 +627,10 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         fg::graph flow_graph;
-        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
-        auto *convert1 = flow_graph.make_node<convert<float, stdx::native_simd<float>>>();
-        auto *convert2 = flow_graph.make_node<convert<stdx::native_simd<float>, float>>();
-        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto &src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto &convert1 = flow_graph.make_node<convert<float, stdx::native_simd<float>>>();
+        auto &convert2 = flow_graph.make_node<convert<stdx::native_simd<float>, float>>();
+        auto &sink = flow_graph.make_node<test::sink<float>>();
 
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(convert1)));
         expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(convert2).to<"in">(sink)));
@@ -639,22 +639,22 @@ inline const boost::ut::suite _runtime_tests = [] {
         std::vector<multiply<stdx::native_simd<float>>*> mult2;
         std::vector<add<stdx::native_simd<float>, -1>*> add1;
         for (std::size_t i = 0; i < 10; i++) {
-            mult1.emplace_back(flow_graph.make_node<multiply<stdx::native_simd<float>>>(2.0f, fmt::format("mult1.{}", i)));
-            mult2.emplace_back(flow_graph.make_node<multiply<stdx::native_simd<float>>>(0.5f, fmt::format("mult2.{}", i)));
-            add1.emplace_back(flow_graph.make_node<add<stdx::native_simd<float>, -1>>());
+            mult1.emplace_back(std::addressof(flow_graph.make_node<multiply<stdx::native_simd<float>>>(2.0f, fmt::format("mult1.{}", i))));
+            mult2.emplace_back(std::addressof(flow_graph.make_node<multiply<stdx::native_simd<float>>>(0.5f, fmt::format("mult2.{}", i))));
+            add1.emplace_back(std::addressof(flow_graph.make_node<add<stdx::native_simd<float>, -1>>()));
         }
 
         for (std::size_t i = 0; i < add1.size(); i++) {
             if (i == 0) {
-                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(convert1).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(convert1).to<"in">(*mult1[i])));
             } else {
-                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*add1[i - 1]).to<"in">(*mult1[i])));
             }
-            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1[i]).to<"in">(mult2[i])));
-            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2[i]).to<"in">(add1[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*mult1[i]).to<"in">(*mult2[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(*mult2[i]).to<"in">(*add1[i])));
         }
         expect(eq(fg::connection_result_t::SUCCESS,
-                  connect<"out">(add1[add1.size() - 1]).to<"in">(convert2)));
+                  connect<"out">(*add1[add1.size() - 1]).to<"in">(convert2)));
 
         fmt::print("start bm: {} - simd_size: {}\n",
                    "runtime   src->(mult(2.0)->mult(0.5)->add(-1))^10->sink (SIMD alt)",

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -379,13 +379,11 @@ inline const boost::ut::suite _runtime_tests = [] {
     using namespace benchmark;
 
     {
-        test::source<float> src(N_SAMPLES);
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(sink);
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(sink)));
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *sink = flow_graph.make_node<test::sink<float>>();
+
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(sink)));
 
         "runtime   src->sink overhead"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() {
             test::n_samples_produced = 0LU;
@@ -399,16 +397,14 @@ inline const boost::ut::suite _runtime_tests = [] {
     }
 
     {
-        test::source<float> src(N_SAMPLES);
-        test::sink<float> sink;
-        copy<float> cpy;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(cpy);
-        flow_graph.register_node(sink);
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(cpy)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(cpy).to<"in">(sink)));
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *sink = flow_graph.make_node<test::sink<float>>();
+        auto *cpy = flow_graph.make_node<copy<float>>();
+
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(cpy)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(cpy).to<"in">(sink)));
+
         "runtime   src->copy->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
@@ -421,26 +417,23 @@ inline const boost::ut::suite _runtime_tests = [] {
     }
 
     {
-        test::source<float> src(N_SAMPLES);
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(sink);
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *sink = flow_graph.make_node<test::sink<float>>();
 
-        std::vector<copy<float, 0, N_MAX, true, true>> cpy(10);
+        std::vector<copy<float, 0, N_MAX, true, true>*> cpy(10);
         for (std::size_t i = 0; i < cpy.size(); i++) {
-            cpy[i].set_name(fmt::format("copy {} at {}", i, fair::graph::this_source_location()));
-            flow_graph.register_node(cpy[i]);
+            cpy[i] = flow_graph.make_node<copy<float, 0, N_MAX, true, true>>();
+            cpy[i]->set_name(fmt::format("copy {} at {}", i, fair::graph::this_source_location()));
 
             if (i == 0) {
-                expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(cpy[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(cpy[i])));
             } else {
-                expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(cpy[i - 1]).to<"in">(cpy[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(cpy[i - 1]).to<"in">(cpy[i])));
             }
         }
 
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(cpy[cpy.size() - 1]).to<"in">(sink)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(cpy[cpy.size() - 1]).to<"in">(sink)));
 
         "runtime   src->copy^10->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() {
             test::n_samples_produced = 0LU;
@@ -454,22 +447,18 @@ inline const boost::ut::suite _runtime_tests = [] {
     }
 
     {
-        test::source<float, 0, 1024> src(N_SAMPLES);
-        copy<float, 0, 128> b1;
-        copy<float, 1024, 1024> b2;
-        copy<float, 32, 128> b3;
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(b1);
-        flow_graph.register_node(b2);
-        flow_graph.register_node(b3);
-        flow_graph.register_node(sink);
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(b1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(b1).to<"in">(b2)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(b2).to<"in">(b3)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(b3).to<"in">(sink)));
+        auto *src = flow_graph.make_node<test::source<float, 0, 1024>>(N_SAMPLES);
+        auto *b1 = flow_graph.make_node<copy<float, 0, 128>>();
+        auto *b2 = flow_graph.make_node<copy<float, 1024, 1024>>();
+        auto *b3 = flow_graph.make_node<copy<float, 32, 128>>();
+        auto *sink = flow_graph.make_node<test::sink<float>>();
+
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(b1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(b1).to<"in">(b2)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(b2).to<"in">(b3)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(b3).to<"in">(sink)));
+
         "runtime   src(N=1024)->b1(N≤128)->b2(N=1024)->b3(N=32...128)->sink"_benchmark.repeat<N_ITER>(
                 N_SAMPLES) = [&flow_graph]() {
             test::n_samples_produced = 0LU;
@@ -483,22 +472,18 @@ inline const boost::ut::suite _runtime_tests = [] {
     }
 
     {
-        test::source<float> src(N_SAMPLES);
-        multiply<float> mult1(2.0f);
-        multiply<float> mult2(0.5f);
-        add<float, -1> add1;
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(mult1);
-        flow_graph.register_node(mult2);
-        flow_graph.register_node(add1);
-        flow_graph.register_node(sink);
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(mult1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult1).to<"in">(mult2)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult2).to<"in">(add1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(add1).to<"in">(sink)));
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *mult1 = flow_graph.make_node<multiply<float>>(2.0f);
+        auto *mult2 = flow_graph.make_node<multiply<float>>(0.5f);
+        auto *add1 = flow_graph.make_node<add<float, -1>>();
+        auto *sink = flow_graph.make_node<test::sink<float>>();
+
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(mult1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1).to<"in">(mult2)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2).to<"in">(add1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1).to<"in">(sink)));
+
         "runtime   src->mult(2.0)->mult(0.5)->add(-1)->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
@@ -511,38 +496,29 @@ inline const boost::ut::suite _runtime_tests = [] {
     }
 
     {
-        test::source<float> src(N_SAMPLES);
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(sink);
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *sink = flow_graph.make_node<test::sink<float>>();
 
-        std::vector<multiply<float>> mult1;
-        std::vector<multiply<float>> mult2;
-        std::vector<add<float, -1>> add1;
+        std::vector<multiply<float>*> mult1;
+        std::vector<multiply<float>*> mult2;
+        std::vector<add<float, -1>*> add1;
         for (std::size_t i = 0; i < 10; i++) {
-            mult1.emplace_back(2.0f, fmt::format("mult1.{}", i));
-            mult2.emplace_back(0.5f, fmt::format("mult2.{}", i));
-            add1.emplace_back();
-        }
-
-        for (std::size_t i = 0; i < add1.size(); i++) {
-            flow_graph.register_node(mult1[i]);
-            flow_graph.register_node(mult2[i]);
-            flow_graph.register_node(add1[i]);
+            mult1.emplace_back(flow_graph.make_node<multiply<float>>(2.0f, fmt::format("mult1.{}", i)));
+            mult2.emplace_back(flow_graph.make_node<multiply<float>>(0.5f, fmt::format("mult2.{}", i)));
+            add1.emplace_back(flow_graph.make_node<add<float, -1>>());
         }
 
         for (std::size_t i = 0; i < add1.size(); i++) {
             if (i == 0) {
-                expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(mult1[i])));
             } else {
-                expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
             }
-            expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult1[i]).to<"in">(mult2[i])));
-            expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult2[i]).to<"in">(add1[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1[i]).to<"in">(mult2[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2[i]).to<"in">(add1[i])));
         }
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(add1[add1.size() - 1]).to<"in">(sink)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[add1.size() - 1]).to<"in">(sink)));
 
         auto token = flow_graph.init();
         expect(token);
@@ -557,22 +533,17 @@ inline const boost::ut::suite _runtime_tests = [] {
     }
 
     {
-        test::source<float> src(N_SAMPLES);
-        multiply_SIMD<float> mult1(2.0f);
-        multiply_SIMD<float> mult2(0.5f);
-        add_SIMD<float> add1(-1.0f);
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(mult1);
-        flow_graph.register_node(mult2);
-        flow_graph.register_node(add1);
-        flow_graph.register_node(sink);
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(mult1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult1).to<"in">(mult2)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult2).to<"in">(add1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(add1).to<"in">(sink)));
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *mult1 = flow_graph.make_node<multiply_SIMD<float>>(2.0f);
+        auto *mult2 = flow_graph.make_node<multiply_SIMD<float>>(0.5f);
+        auto *add1 = flow_graph.make_node<add_SIMD<float>>(-1.0f);
+        auto *sink = flow_graph.make_node<test::sink<float>>();
+
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(mult1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1).to<"in">(mult2)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2).to<"in">(add1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1).to<"in">(sink)));
 
         auto token = flow_graph.init();
         expect(token);
@@ -587,38 +558,29 @@ inline const boost::ut::suite _runtime_tests = [] {
     }
 
     {
-        test::source<float> src(N_SAMPLES);
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(sink);
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *sink = flow_graph.make_node<test::sink<float>>();
 
-        std::vector<multiply_SIMD<float>> mult1;
-        std::vector<multiply_SIMD<float>> mult2;
-        std::vector<add_SIMD<float>> add1;
+        std::vector<multiply_SIMD<float>*> mult1;
+        std::vector<multiply_SIMD<float>*> mult2;
+        std::vector<add_SIMD<float>*> add1;
         for (std::size_t i = 0; i < 10; i++) {
-            mult1.emplace_back(2.0f, fmt::format("mult1.{}", i));
-            mult2.emplace_back(0.5f, fmt::format("mult2.{}", i));
-            add1.emplace_back(-1.0f, fmt::format("add.{}", i));
-        }
-
-        for (std::size_t i = 0; i < add1.size(); i++) {
-            flow_graph.register_node(mult1[i]);
-            flow_graph.register_node(mult2[i]);
-            flow_graph.register_node(add1[i]);
+            mult1.emplace_back(flow_graph.make_node<multiply_SIMD<float>>(2.0f, fmt::format("mult1.{}", i)));
+            mult2.emplace_back(flow_graph.make_node<multiply_SIMD<float>>(0.5f, fmt::format("mult2.{}", i)));
+            add1.emplace_back(flow_graph.make_node<add_SIMD<float>>(-1.0f, fmt::format("add.{}", i)));
         }
 
         for (std::size_t i = 0; i < add1.size(); i++) {
             if (i == 0) {
-                expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(mult1[i])));
             } else {
-                expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
             }
-            expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult1[i]).to<"in">(mult2[i])));
-            expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult2[i]).to<"in">(add1[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1[i]).to<"in">(mult2[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2[i]).to<"in">(add1[i])));
         }
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(add1[add1.size() - 1]).to<"in">(sink)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[add1.size() - 1]).to<"in">(sink)));
 
         auto token = flow_graph.init();
         expect(token);
@@ -634,28 +596,21 @@ inline const boost::ut::suite _runtime_tests = [] {
 
     {
         using namespace stdx;
-        test::source<float> src(N_SAMPLES);
-        convert<float, stdx::native_simd<float>> convert1;
-        multiply<stdx::native_simd<float>> mult1(2.0f);
-        multiply<stdx::native_simd<float>> mult2(0.5f);
-        add<stdx::native_simd<float>, -1> add1;
-        convert<stdx::native_simd<float>, float> convert2;
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(convert1);
-        flow_graph.register_node(mult1);
-        flow_graph.register_node(mult2);
-        flow_graph.register_node(add1);
-        flow_graph.register_node(convert2);
-        flow_graph.register_node(sink);
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(convert1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(convert1).to<"in">(mult1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult1).to<"in">(mult2)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult2).to<"in">(add1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(add1).to<"in">(convert2)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(convert2).to<"in">(sink)));
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *convert1 = flow_graph.make_node<convert<float, stdx::native_simd<float>>>();
+        auto *mult1 = flow_graph.make_node<multiply<stdx::native_simd<float>>>(2.0f);
+        auto *mult2 = flow_graph.make_node<multiply<stdx::native_simd<float>>>(0.5f);
+        auto *add1 = flow_graph.make_node<add<stdx::native_simd<float>, -1>>();
+        auto *convert2 = flow_graph.make_node<convert<stdx::native_simd<float>, float>>();
+        auto *sink = flow_graph.make_node<test::sink<float>>();
+
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(convert1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(convert1).to<"in">(mult1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1).to<"in">(mult2)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2).to<"in">(add1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1).to<"in">(convert2)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(convert2).to<"in">(sink)));
 
         fmt::print("start bm: {} - simd_size: {}\n", "runtime   src->mult(2.0)->mult(0.5)->add(-1)->sink (SIMD-alt)",
                    ::detail::simd_size<stdx::native_simd<float>>());
@@ -671,45 +626,35 @@ inline const boost::ut::suite _runtime_tests = [] {
     }
 
     {
-        test::source<float> src(N_SAMPLES);
-        convert<float, stdx::native_simd<float>> convert1;
-        convert<stdx::native_simd<float>, float> convert2;
-        test::sink<float> sink;
-
         fg::graph flow_graph;
-        flow_graph.register_node(src);
-        flow_graph.register_node(convert1);
-        flow_graph.register_node(convert2);
-        flow_graph.register_node(sink);
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(convert1)));
-        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(convert2).to<"in">(sink)));
+        auto *src = flow_graph.make_node<test::source<float>>(N_SAMPLES);
+        auto *convert1 = flow_graph.make_node<convert<float, stdx::native_simd<float>>>();
+        auto *convert2 = flow_graph.make_node<convert<stdx::native_simd<float>, float>>();
+        auto *sink = flow_graph.make_node<test::sink<float>>();
 
-        std::vector<multiply<stdx::native_simd<float>>> mult1;
-        std::vector<multiply<stdx::native_simd<float>>> mult2;
-        std::vector<add<stdx::native_simd<float>, -1>> add1;
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(src).to<"in">(convert1)));
+        expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(convert2).to<"in">(sink)));
+
+        std::vector<multiply<stdx::native_simd<float>>*> mult1;
+        std::vector<multiply<stdx::native_simd<float>>*> mult2;
+        std::vector<add<stdx::native_simd<float>, -1>*> add1;
         for (std::size_t i = 0; i < 10; i++) {
-            mult1.emplace_back(2.0f, fmt::format("mult1.{}", i));
-            mult2.emplace_back(0.5f, fmt::format("mult2.{}", i));
-            add1.emplace_back();
-        }
-
-        for (std::size_t i = 0; i < add1.size(); i++) {
-            flow_graph.register_node(mult1[i]);
-            flow_graph.register_node(mult2[i]);
-            flow_graph.register_node(add1[i]);
+            mult1.emplace_back(flow_graph.make_node<multiply<stdx::native_simd<float>>>(2.0f, fmt::format("mult1.{}", i)));
+            mult2.emplace_back(flow_graph.make_node<multiply<stdx::native_simd<float>>>(0.5f, fmt::format("mult2.{}", i)));
+            add1.emplace_back(flow_graph.make_node<add<stdx::native_simd<float>, -1>>());
         }
 
         for (std::size_t i = 0; i < add1.size(); i++) {
             if (i == 0) {
-                expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(convert1).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(convert1).to<"in">(mult1[i])));
             } else {
-                expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
+                expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(add1[i - 1]).to<"in">(mult1[i])));
             }
-            expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult1[i]).to<"in">(mult2[i])));
-            expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(mult2[i]).to<"in">(add1[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult1[i]).to<"in">(mult2[i])));
+            expect(eq(fg::connection_result_t::SUCCESS, connect<"out">(mult2[i]).to<"in">(add1[i])));
         }
         expect(eq(fg::connection_result_t::SUCCESS,
-                  flow_graph.connect<"out">(add1[add1.size() - 1]).to<"in">(convert2)));
+                  connect<"out">(add1[add1.size() - 1]).to<"in">(convert2)));
 
         fmt::print("start bm: {} - simd_size: {}\n",
                    "runtime   src->(mult(2.0)->mult(0.5)->add(-1))^10->sink (SIMD alt)",

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -10,6 +10,8 @@
 
 namespace fair::graph {
 
+class graph;
+
 namespace stdx = vir::stdx;
 using fair::meta::fixed_string;
 
@@ -228,6 +230,7 @@ private:
     setting_map _exec_metrics{}; //  →  std::map<string, pmt> → fair scheduling, 'int' stand-in for pmtv
 
     friend class graph;
+    graph* _owning_graph = nullptr;
 
 public:
     auto &

--- a/test/qa_dynamic_port.cpp
+++ b/test/qa_dynamic_port.cpp
@@ -1,5 +1,3 @@
-
-
 #include <fmt/ranges.h>
 
 #include "buffer.hpp"
@@ -128,12 +126,12 @@ const boost::ut::suite PortApiTests = [] {
         graph flow;
 
         // Generators
-        auto* answer = flow.make_node<repeater_source<int, 42>>();
-        auto* number = flow.make_node<repeater_source<int, 6>>();
+        auto& answer = flow.make_node<repeater_source<int, 42>>();
+        auto& number = flow.make_node<repeater_source<int, 6>>();
 
-        auto* scaled = flow.make_node<scale<int, 2>>();
-        auto* added = flow.make_node<adder<int>>();
-        auto* out = flow.make_node<cout_sink<int>>();
+        auto& scaled = flow.make_node<scale<int, 2>>();
+        auto& added = flow.make_node<adder<int>>();
+        auto& out = flow.make_node<cout_sink<int>>();
 
         expect(eq(connection_result_t::SUCCESS, connect<"value">(number).to<"original">(scaled)));
         expect(eq(connection_result_t::SUCCESS, connect<"scaled">(scaled).to<"addend0">(added)));

--- a/test/qa_dynamic_port.cpp
+++ b/test/qa_dynamic_port.cpp
@@ -124,29 +124,22 @@ const boost::ut::suite PortApiTests = [] {
         using port_direction_t::INPUT;
         using port_direction_t::OUTPUT;
 
-        scale<int, 2>            scaled;
-        adder<int>               added;
-        cout_sink<int>           out;
-
-        repeater_source<int, 42> answer;
-        repeater_source<int, 6>  number;
-
         // Nodes need to be alive for as long as the flow is
         graph flow;
 
         // Generators
-        flow.register_node(answer);
-        flow.register_node(number);
+        auto* answer = flow.make_node<repeater_source<int, 42>>();
+        auto* number = flow.make_node<repeater_source<int, 6>>();
 
-        flow.register_node(scaled);
-        flow.register_node(added);
-        flow.register_node(out);
+        auto* scaled = flow.make_node<scale<int, 2>>();
+        auto* added = flow.make_node<adder<int>>();
+        auto* out = flow.make_node<cout_sink<int>>();
 
-        expect(eq(connection_result_t::SUCCESS, flow.connect<"value">(number).to<"original">(scaled)));
-        expect(eq(connection_result_t::SUCCESS, flow.connect<"scaled">(scaled).to<"addend0">(added)));
-        expect(eq(connection_result_t::SUCCESS, flow.connect<"value">(answer).to<"addend1">(added)));
+        expect(eq(connection_result_t::SUCCESS, connect<"value">(number).to<"original">(scaled)));
+        expect(eq(connection_result_t::SUCCESS, connect<"scaled">(scaled).to<"addend0">(added)));
+        expect(eq(connection_result_t::SUCCESS, connect<"value">(answer).to<"addend1">(added)));
 
-        expect(eq(connection_result_t::SUCCESS, flow.connect<"sum">(added).to<"sink">(out)));
+        expect(eq(connection_result_t::SUCCESS, connect<"sum">(added).to<"sink">(out)));
 
         auto token = flow.init();
         expect(token);


### PR DESCRIPTION
- nodes are created with graph::make_node function
- it is no longer needed to specify the graph when making connections