### PR TITLE
Use do-not-optimize inline-asm for more realistic results

### DIFF
--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -36,25 +36,37 @@ namespace benchmark {
 
 #if defined(__GNUC__) or defined(__clang__) and not defined(_LIBCPP_VERSION)
 
+#if defined(__x86_64__) or defined(__i686__)
+#define SIMD_REG "x,"
+#else
+#define SIMD_REG
+#endif
+
     template<typename T>
     void
     do_not_optimize(T const &val) {
-        // NOLINTNEXTLINE(hicpp-no-assembler)
-        asm volatile("" : : "r,m"(val) : "memory");
+        if constexpr (sizeof(T) >= 16 || std::is_floating_point_v<T>) {
+            // NOLINTNEXTLINE(hicpp-no-assembler)
+            asm volatile("" ::SIMD_REG "m"(val));
+        } else {
+            // NOLINTNEXTLINE(hicpp-no-assembler)
+            asm volatile("" ::"g,m"(val));
+        }
     }
 
     template<typename T>
     void
     do_not_optimize(T &val) {
-#if defined(__clang__)
-        // NOLINTNEXTLINE(hicpp-no-assembler)
-        asm volatile("" : "+r,m"(val) : : "memory");
-#else
-        // NOLINTNEXTLINE(hicpp-no-assembler)
-        asm volatile("" : "+m,r"(val) : : "memory");
-#endif
+        if constexpr (sizeof(T) >= 16 || std::is_floating_point_v<T>) {
+            // NOLINTNEXTLINE(hicpp-no-assembler)
+            asm volatile("" : "+" SIMD_REG "g,m"(val));
+        } else {
+            // NOLINTNEXTLINE(hicpp-no-assembler)
+            asm volatile("" : "+g,m"(val));
+        }
     }
 
+#undef SIMD_REG
 #else
 #pragma optimize("", off)
 

--- a/bench/bm_test_helper.hpp
+++ b/bench/bm_test_helper.hpp
@@ -25,7 +25,9 @@ public:
     [[nodiscard]] constexpr T
     process_one() const noexcept {
         n_samples_produced++;
-        return T{};
+        T x{};
+        benchmark::do_not_optimize(x);
+        return x;
     }
 
     fair::graph::work_return_t


### PR DESCRIPTION
1. If an inline-asm statement clobbers all memory then we don't see realistic benchmark measurements because the optimizer is inhibited from doing certain optimizations. The result is very different depending on the order. The constexpr cases suffered most because the optimizer was inhibited in every single iteration.

2. The source produces only zero-initialized samples. The optimizer was able to see that. And it may or may not have used that knowledge, rendering all previous results as quasi-random. Use inline asm to only inhibit const-prop, nothing else.

ChangeLog:

	* bench/benchmark.hpp (do_not_optimize): Optimal do-not-optimize implementation. Do not invalidate all memory in the process.
	* bench/bm_test_helper.hpp (source::process_one): Taint the constructed sample using benchmark::do_not_optimize.