### PR TITLE
simd simd simd

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -10,3 +10,9 @@ endfunction()
 
 add_benchmark(bm_case0)
 add_benchmark(bm_case1)
+
+add_executable(bm_case1_nosimd bm_case1.cpp)
+target_compile_options(bm_case1_nosimd PRIVATE -Wall -march=native -DDISABLE_SIMD=1)
+target_link_options(bm_case1_nosimd PRIVATE -Wall -march=native)
+target_link_libraries(bm_case1_nosimd PRIVATE graph-prototype refl-cpp fmt ut)
+set_project_warnings(bm_case1_nosimd)

--- a/bench/bm_test_helper.hpp
+++ b/bench/bm_test_helper.hpp
@@ -27,6 +27,14 @@ public:
         return self._n_samples_max - n_samples_produced;
     }
 
+    [[nodiscard]] constexpr auto
+    process_one_simd(auto N) const noexcept -> fair::meta::simdize<T, decltype(N)::value> {
+        n_samples_produced += N;
+        fair::meta::simdize<T, N> x {};
+        benchmark::force_to_memory(x);
+        return x;
+    }
+
     [[nodiscard]] constexpr T
     process_one() const noexcept {
         n_samples_produced++;

--- a/include/vir/simd.h
+++ b/include/vir/simd.h
@@ -24,7 +24,7 @@
 #error "simd requires C++17 or later"
 #endif
 
-#if __has_include (<experimental/simd>) && !defined VIR_DISABLE_STDX_SIMD
+#if __has_include (<experimental/simd>) && !defined VIR_DISABLE_STDX_SIMD && !defined __clang__
 #include <experimental/simd>
 #endif
 


### PR DESCRIPTION
## Whenever possible, process with simd<T> instead of T

some highlights (`-O3 -march=native`):

| Benchmark             | DISABLE_SIMD=1 | DISABLE_SIMD=0 |
| --------------------- | -------------- | -------------- |
| merged src->sink work | 238.1Mops/s    |   5.2Gops/s    |
| merged ^10 - float    |  34.1Mops/s    | 212.4Mops/s    |
| merged ^10 - int      |   9.6Mops/s    |  79.2Mops/s    |
