### PR TITLE
CMake: remove duplicated code and use targets consistently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ if (EMSCRIPTEN)
 endif()
 
 include(cmake/CompilerWarnings.cmake)
+
 include(FetchContent)
 FetchContent_Declare(
         fmt
@@ -29,27 +30,8 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(fmt refl-cpp ut)
 
-add_compile_options(-Wall -Wextra
-        # -Werror # Make all warnings into errors.
-        -Wshadow # warn the user if a variable declaration shadows one from a parent context
-        -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor.
-        -Wold-style-cast # warn for c-style casts
-        -Wcast-align # warn for potential performance problem casts
-        -Wunused # warn on anything being unused
-        -Woverloaded-virtual # warn if you overload (not override) a virtual function
-        -pedantic -Wpedantic # warn if non-standard C++ is used
-        -Wconversion # warn on type conversions that may lose data
-        -Wsign-conversion # warn on sign conversions
-        -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
-        -Wduplicated-cond # warn if if / else chain has duplicated conditions
-        -Wduplicated-branches # warn if if / else chain has duplicated conditions
-        -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
-        -Wnull-dereference # warn if a null dereference is detected
-        -Wuseless-cast # warn if you perform a cast to the same type
-        -Wdouble-promotion # warn if float is implicitly promoted to double
-        -Wformat=2 # warn on security issues around functions that format output (i.e., printf)
-        -Wimplicit-fallthrough # Warns when case statements fall-through.
-        )
+add_subdirectory(include)
+add_subdirectory(src)
 
 option(ENABLE_TESTING "Enable Test Builds" ON)
 if (ENABLE_TESTING AND UNIX AND NOT APPLE)
@@ -59,9 +41,3 @@ if (ENABLE_TESTING AND UNIX AND NOT APPLE)
     message("Building Benchmarks.")
     add_subdirectory(bench)
 endif ()
-
-add_subdirectory(include)
-add_subdirectory(src)
-target_include_directories(main PUBLIC ./include)
-target_link_libraries(main PUBLIC fmt::fmt refl-cpp::refl-cpp)
-set_project_warnings(main)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,12 +1,11 @@
-include_directories("../include")
-
 function(add_benchmark BM_NAME)
     add_executable(${BM_NAME} ${BM_NAME}.cpp)
     target_compile_options(${BM_NAME} PRIVATE -Wall -march=native)
     target_link_options(${BM_NAME} PRIVATE -Wall -march=native)
     # target_compile_options(${BM_NAME} PRIVATE -Wall -march=native -fsanitize=address)
     # target_link_options(${BM_NAME} PRIVATE -Wall -march=native -fsanitize=address)
-    target_link_libraries(${BM_NAME} PRIVATE core refl-cpp fmt ut)
+    target_link_libraries(${BM_NAME} PRIVATE graph-prototype refl-cpp fmt ut)
+    set_project_warnings(${BM_NAME})
 endfunction()
 
 add_benchmark(bm_case0)

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -48,6 +48,7 @@ function(set_project_warnings project_name)
       -Wdouble-promotion # warn if float is implicit promoted to double
       -Wformat=2 # warn on security issues around functions that format output (ie printf)
       -Wno-unknown-pragmas # ignore IDE, GCC/CLANG specific pragmas
+      -Wimplicit-fallthrough # Warns when case statements fall-through.
   )
 
   if(WARNINGS_AS_ERRORS)
@@ -57,7 +58,6 @@ function(set_project_warnings project_name)
 
   set(GCC_WARNINGS
       ${CLANG_WARNINGS}
-      -Wno-unknown-pragmas # disable warning since clang-tidy suppression pragmas -- while necessary -- are unknown to gcc
       -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
       -Wduplicated-cond # warn if if / else chain has duplicated conditions
       -Wduplicated-branches # warn if if / else branches have duplicated code

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,10 +1,10 @@
 # setup header only library
-add_library(core INTERFACE)
-target_include_directories(core INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/>)
-target_link_libraries(core INTERFACE refl-cpp::refl-cpp)
+add_library(graph-prototype INTERFACE)
+target_include_directories(graph-prototype INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include/>)
+target_link_libraries(graph-prototype INTERFACE refl-cpp::refl-cpp)
 
 install(
-        TARGETS core
+        TARGETS graph-prototype
         EXPORT graphTargets
         PUBLIC_HEADER DESTINATION include/
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_executable(main main.cpp)
+target_include_directories(main PUBLIC ./include)
+target_link_libraries(main PUBLIC graph-prototype fmt::fmt refl-cpp::refl-cpp)
+set_project_warnings(main)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 
 #include <cassert>
 
-#include "graph.hpp"
+#include <graph.hpp>
 
 namespace fg = fair::graph;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,15 +1,13 @@
-include_directories("../include")
-
 add_executable(qa_buffer qa_buffer.cpp)
-target_include_directories(qa_buffer INTERFACE ../include)
-target_link_libraries(qa_buffer PRIVATE fmt ut)
+target_link_libraries(qa_buffer PRIVATE graph-prototype fmt ut)
+set_project_warnings(qa_buffer)
 
 function(add_ut_test TEST_NAME)
     add_executable(${TEST_NAME} ${TEST_NAME}.cpp)
-    target_include_directories(${TEST_NAME} INTERFACE ../include)
     target_compile_options(${TEST_NAME} PRIVATE -fsanitize=address -Wall)
     target_link_options(${TEST_NAME} PRIVATE -fsanitize=address -Wall)
-    target_link_libraries(${TEST_NAME} PRIVATE fmt refl-cpp ut)
+    target_link_libraries(${TEST_NAME} PRIVATE graph-prototype fmt refl-cpp ut)
+    set_project_warnings(${TEST_NAME})
 endfunction()
 
 add_ut_test(qa_dynamic_port)


### PR DESCRIPTION
- remove global include directories and use targets consistently
- define compiler warnings in one place only (deduplicated into cmake/CompilerWarnings.cmake)