### PR TITLE
Basic meson build support

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -1,0 +1,139 @@
+name: Meson
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ created ]
+
+jobs:
+  build:
+    name: "${{ matrix.configurations.name }} | ${{ matrix.meson-build-type }}"
+    environment: configure coverage
+    runs-on: ${{ matrix.configurations.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        configurations:
+          - name: Ubuntu gcc12
+            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+            compiler: gcc
+          - name: Ubuntu clang15
+            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+            compiler: clang15
+          - name: Ubuntu Latest clang16
+            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+            compiler: clang16
+          # - name: Ubuntu Latest emscripten
+          #   os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+          #   compiler: emscripten
+        # Customize the meson build type here (Release, Debug, RelWithDebInfo, etc.)
+        meson-build-type: [ release, debug ]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+
+    - name: Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: cache-fetchContent-cache
+      with:
+        path: ${{runner.workspace}}/build/_deps
+        key: ${{ runner.os }}-${{ matrix.configurations.compiler }}-${{ matrix.meson-build-type }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('cmake/Dependencies.cmake') }}
+
+    - name: Install gcc-12
+      if: matrix.configurations.compiler == 'gcc'
+      run: |
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa # provides newer gcc 12.2.0 instead of 12.1.0
+        sudo apt-get install -y gcc-12 g++-12
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
+
+#    - name: Install clang-15
+#      if: matrix.configurations.compiler == 'clang15'
+#      run: |
+#        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+#        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
+#        sudo apt update
+#        sudo apt install -y clang-15 libc++-15-dev libc++abi-15-dev
+#        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 110
+
+    - name: Install clang-15
+      if: matrix.configurations.compiler == 'clang15'
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
+        sudo apt update
+        sudo apt install -y clang-15 libc++-15-dev libc++abi-15-dev
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 110
+
+    - name: Install clang-16
+      if: matrix.configurations.compiler == 'clang16'
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
+        sudo apt update
+        sudo apt install -y clang-16 libc++-16-dev libc++abi-16-dev
+        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-16 110
+
+    - name: Install emscripten
+      if: matrix.configurations.compiler == 'emscripten'
+      run: |
+        cd
+        git clone https://github.com/emscripten-core/emsdk.git
+        cd emsdk
+        # Download and install the latest SDK tools.
+        ./emsdk install latest
+        # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
+        ./emsdk activate latest
+        # Activate PATH and other environment variables in the current terminal
+        source ./emsdk_env.sh
+
+    - name: Install Meson
+      if: matrix.configurations.compiler != 'emscripten'
+      shell: bash
+      run: |-
+        sudo apt install python3-pip ninja-build
+        pip install meson
+
+    - name: Configure Meson
+      if: matrix.configurations.compiler != 'emscripten'
+      shell: bash
+      run: meson setup ../build --buildtype=${{matrix.meson-build-type}} -Db_coverage=${{ matrix.configurations.name == env.REFERENCE_CONFIG &&  matrix.meson-build-type == 'debug'}}
+
+    # - name: Configure Meson Emscripten
+    #   if: matrix.configurations.compiler == 'emscripten'
+    #   shell: bash
+    #   run: |
+    #     source ~/emsdk/emsdk_env.sh
+    #     meson setup ../build -DEMSCRIPTEN --buildtype=${{ matrix.meson-build-type }} -Db_coverage=false
+
+    - name: Build
+      if: matrix.configurations.compiler != 'emscripten'
+      shell: bash
+      run: cd ../build && ninja
+
+    # - name: Build Emscripten
+    #   if: matrix.configurations.compiler == 'emscripten'
+    #   shell: bash
+    #   run: |
+    #     source ~/emsdk/emsdk_env.sh
+    #     cd ../build
+    #     emmake make
+
+    - name: execute binary
+      if: matrix.configurations.compiler != 'emscripten'
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: ./src/main
+
+    # - name: execute binary
+    #   if: matrix.configurations.compiler == 'emscripten'
+    #   working-directory: ${{runner.workspace}}/build
+    #   shell: bash
+    #   run: |
+    #     source ~/emsdk/emsdk_env.sh
+    #     ${EMSDK_NODE} ./src/main.js

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -45,6 +45,14 @@ jobs:
         path: ${{runner.workspace}}/build/_deps
         key: ${{ runner.os }}-${{ matrix.configurations.compiler }}-${{ matrix.meson-build-type }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('cmake/Dependencies.cmake') }}
 
+    - name: Install PMT meson build deps
+      run: |
+        DEBIAN_FRONTEND=noninteractive \
+        sudo apt-get install -qy \
+        pybind11-dev \
+        libgtest-dev \
+        python3-numpy
+
     - name: Install gcc-12
       if: matrix.configurations.compiler == 'gcc'
       run: |

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -26,9 +26,9 @@ jobs:
           - name: Ubuntu Latest clang16
             os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
             compiler: clang16
-          # - name: Ubuntu Latest emscripten
-          #   os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
-          #   compiler: emscripten
+          - name: Ubuntu Latest emscripten
+            os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
+            compiler: emscripten
         # Customize the meson build type here (Release, Debug, RelWithDebInfo, etc.)
         meson-build-type: [ release, debug ]
 
@@ -51,15 +51,6 @@ jobs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa # provides newer gcc 12.2.0 instead of 12.1.0
         sudo apt-get install -y gcc-12 g++-12
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 110 --slave /usr/bin/g++ g++ /usr/bin/g++-12 --slave /usr/bin/gcov gcov /usr/bin/gcov-12
-
-#    - name: Install clang-15
-#      if: matrix.configurations.compiler == 'clang15'
-#      run: |
-#        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-#        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
-#        sudo apt update
-#        sudo apt install -y clang-15 libc++-15-dev libc++abi-15-dev
-#        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 110
 
     - name: Install clang-15
       if: matrix.configurations.compiler == 'clang15'
@@ -91,9 +82,13 @@ jobs:
         ./emsdk activate latest
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk_env.sh
+        emcc -v
+        tee emscripten-toolchain.ini <<EOF >/dev/null
+        [constants]
+        toolchain = '$(pwd)/${{ env.EM_CACHE_FOLDER }}/upstream/emscripten/'
+        EOF
 
     - name: Install Meson
-      if: matrix.configurations.compiler != 'emscripten'
       shell: bash
       run: |-
         sudo apt install python3-pip ninja-build
@@ -104,25 +99,25 @@ jobs:
       shell: bash
       run: meson setup ../build --buildtype=${{matrix.meson-build-type}} -Db_coverage=${{ matrix.configurations.name == env.REFERENCE_CONFIG &&  matrix.meson-build-type == 'debug'}}
 
-    # - name: Configure Meson Emscripten
-    #   if: matrix.configurations.compiler == 'emscripten'
-    #   shell: bash
-    #   run: |
-    #     source ~/emsdk/emsdk_env.sh
-    #     meson setup ../build -DEMSCRIPTEN --buildtype=${{ matrix.meson-build-type }} -Db_coverage=false
+    - name: Configure Meson Emscripten
+      if: matrix.configurations.compiler == 'emscripten'
+      shell: bash
+      run: |
+        source ~/emsdk/emsdk_env.sh
+        meson setup ../build --cross-file ~/emsdk/emscripten-toolchain.ini --cross-file emscripten-build.ini --buildtype=${{ matrix.meson-build-type }} -Db_coverage=false
 
     - name: Build
       if: matrix.configurations.compiler != 'emscripten'
       shell: bash
       run: cd ../build && ninja
 
-    # - name: Build Emscripten
-    #   if: matrix.configurations.compiler == 'emscripten'
-    #   shell: bash
-    #   run: |
-    #     source ~/emsdk/emsdk_env.sh
-    #     cd ../build
-    #     emmake make
+    - name: Build Emscripten
+      if: matrix.configurations.compiler == 'emscripten'
+      shell: bash
+      run: |
+        source ~/emsdk/emsdk_env.sh
+        cd ../build
+        ninja
 
     - name: execute binary
       if: matrix.configurations.compiler != 'emscripten'
@@ -130,10 +125,10 @@ jobs:
       shell: bash
       run: ./src/main
 
-    # - name: execute binary
-    #   if: matrix.configurations.compiler == 'emscripten'
-    #   working-directory: ${{runner.workspace}}/build
-    #   shell: bash
-    #   run: |
-    #     source ~/emsdk/emsdk_env.sh
-    #     ${EMSDK_NODE} ./src/main.js
+    - name: execute binary
+      if: matrix.configurations.compiler == 'emscripten'
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: |
+        source ~/emsdk/emsdk_env.sh
+        ${EMSDK_NODE} ./src/main.js

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -70,7 +70,7 @@ jobs:
         sudo apt install -y clang-16 libc++-16-dev libc++abi-16-dev
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-16 110
 
-    - name: Install emscripten
+    - name: Install emscripten 
       if: matrix.configurations.compiler == 'emscripten'
       run: |
         cd

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -104,7 +104,7 @@ jobs:
       shell: bash
       run: |
         source ~/emsdk/emsdk_env.sh
-        meson setup ../build --cross-file ~/emsdk/emscripten-toolchain.ini --cross-file emscripten-build.ini --buildtype=${{ matrix.meson-build-type }} -Db_coverage=false
+        meson setup ../build --cross-file ~/emsdk/emscripten-toolchain.ini --cross-file emscripten-build.ini --buildtype=${{ matrix.meson-build-type }} -Db_coverage=false -Dpmt:enable_python=false -Dpmt:enable_testing=false
 
     - name: Build
       if: matrix.configurations.compiler != 'emscripten'

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -97,7 +97,7 @@ jobs:
     - name: Configure Meson
       if: matrix.configurations.compiler != 'emscripten'
       shell: bash
-      run: meson setup ../build --buildtype=${{matrix.meson-build-type}} -Db_coverage=${{ matrix.configurations.name == env.REFERENCE_CONFIG &&  matrix.meson-build-type == 'debug'}}
+      run: meson setup ../build --buildtype=${{matrix.meson-build-type}} -Db_coverage=${{ matrix.configurations.name == env.REFERENCE_CONFIG &&  matrix.meson-build-type == 'debug'}} -Dpmt:enable_python=false -Dpmt:enable_testing=false
 
     - name: Configure Meson Emscripten
       if: matrix.configurations.compiler == 'emscripten'

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ CMakeLists.txt.user
 
 # python venv files
 virtualenv/
+
+emscripten-toolchain.ini

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -4,14 +4,12 @@ bm_names = [
     'bm_case1'
 ]
 
-include_directories = ['../include']
-deps = [fmt_dep, ut_dep, reflcpp_dep]
+deps = [graph_dep, fmt_dep, ut_dep, reflcpp_dep]
 cpp_args = '-march=native'
 foreach bm_name : bm_names
 bm_exe = executable(bm_name, bm_name + '.cpp',
   cpp_args : cpp_args,
   link_args : cpp_args,
-  include_directories : include_directories, 
   dependencies : [deps],
   install: false)
 endforeach

--- a/bench/meson.build
+++ b/bench/meson.build
@@ -1,0 +1,17 @@
+
+bm_names = [
+    'bm_case0',
+    'bm_case1'
+]
+
+include_directories = ['../include']
+deps = [fmt_dep, ut_dep, reflcpp_dep]
+cpp_args = '-march=native'
+foreach bm_name : bm_names
+bm_exe = executable(bm_name, bm_name + '.cpp',
+  cpp_args : cpp_args,
+  link_args : cpp_args,
+  include_directories : include_directories, 
+  dependencies : [deps],
+  install: false)
+endforeach

--- a/emscripten-build.ini
+++ b/emscripten-build.ini
@@ -1,0 +1,41 @@
+[constants]
+cflags = []
+ldflags = ['-v']
+# 'toolchain' must be supplied somehow
+# either replace this with the /absolute/path/to/emsdk
+# ... or supply a second machine file with this variable defined
+#toolchain = ''
+
+[binaries]
+ar = toolchain / 'emar'
+c = toolchain / 'emcc'
+cpp = toolchain / 'em++'
+ranlib = toolchain / 'emranlib'
+file_packager = toolchain / 'tools/file_packager'
+
+[properties]
+needs_exe_wrapper = true
+source_map_base = 'http://localhost:6931/'
+
+[built-in options]
+b_ndebug = 'true'
+b_pie = false
+b_pch = true
+b_staticpic = false
+c_args = cflags
+c_link_args = ldflags
+c_thread_count = 0
+cpp_args = cflags
+cpp_eh = 'none'
+cpp_link_args = ldflags
+cpp_rtti = false
+cpp_thread_count = 0
+default_library = 'static'
+optimization = 's'
+wrap_mode = 'forcefallback'
+
+[host_machine]
+cpu = 'mvp'
+cpu_family = 'wasm32'
+endian = 'little'
+system = 'emscripten'

--- a/emscripten-build.ini
+++ b/emscripten-build.ini
@@ -16,6 +16,7 @@ file_packager = toolchain / 'tools/file_packager'
 [properties]
 needs_exe_wrapper = true
 source_map_base = 'http://localhost:6931/'
+EMSCRIPTEN = true
 
 [built-in options]
 b_ndebug = 'true'

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,23 @@
+header_files = [
+    'vir/detail.h',
+    'vir/simd_bit.h',
+    'vir/simd_bitset.h',
+    'vir/simd_cast.h',
+    'vir/simd_float_ops.h',
+    'vir/simd_resize.h',
+    'vir/simd.h',
+    'buffer_skeleton.hpp',
+    'buffer.hpp',
+    'circular_buffer.hpp',
+    'claim_strategy.hpp',
+    'graph.hpp',
+    'node_traits.hpp',
+    'node.hpp',
+    'port_traits.hpp',
+    'port.hpp',
+    'sequence.hpp',
+    'typelist.hpp',
+    'utils.hpp',
+    'wait_strategy.hpp'
+]
+install_headers(header_files, subdir : 'graph-prototype')

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,3 +1,6 @@
+
+graph_dep = declare_dependency(include_directories: '.', dependencies : [fmt_dep, reflcpp_dep])
+
 header_files = [
     'vir/detail.h',
     'vir/simd_bit.h',
@@ -20,4 +23,4 @@ header_files = [
     'utils.hpp',
     'wait_strategy.hpp'
 ]
-install_headers(header_files, subdir : 'graph-prototype')
+install_headers(header_files, subdir : 'graph-prototype', preserve_path: true)

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,5 +1,5 @@
 
-graph_dep = declare_dependency(include_directories: '.', dependencies : [fmt_dep, reflcpp_dep])
+graph_dep = declare_dependency(include_directories: '.', dependencies : [fmt_dep, reflcpp_dep, pmt_dep])
 
 header_files = [
     'vir/detail.h',

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ cmake = import('cmake')
 libreflcpp = cmake.subproject('refl-cpp')
 reflcpp_dep = libreflcpp.dependency('refl-cpp')
 
+subdir('include')
+subdir('src')
 if (get_option('enable_testing'))
   subdir('test')
   subdir('bench')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,12 @@
+project('graph-prototype', 'cpp',
+  version : '0.1',
+  default_options : ['warning_level=3', 'cpp_std=gnu++20'])
+
+fmt_dep = dependency('fmt', version:'8.1.1')
+ut_dep = dependency('boost.ut')
+
+cmake = import('cmake')
+libreflcpp = cmake.subproject('refl-cpp')
+reflcpp_dep = libreflcpp.dependency('refl-cpp')
+
+subdir('bench')

--- a/meson.build
+++ b/meson.build
@@ -9,4 +9,7 @@ cmake = import('cmake')
 libreflcpp = cmake.subproject('refl-cpp')
 reflcpp_dep = libreflcpp.dependency('refl-cpp')
 
-subdir('bench')
+if (get_option('enable_testing'))
+  subdir('test')
+  subdir('bench')
+endif

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,14 @@ reflcpp_dep = libreflcpp.dependency('refl-cpp')
 libpmtv = subproject('pmt')
 pmt_dep = libpmtv.get_variable('pmt_dep')
 
+
+graph_prototype_options = []
+if meson.is_cross_build()
+  if meson.get_external_property('EMSCRIPTEN', false)
+    graph_prototype_options = ['-s','ALLOW_MEMORY_GROWTH=1']
+  endif 
+endif
+
 subdir('include')
 subdir('src')
 if (get_option('enable_testing'))

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,19 @@
 project('graph-prototype', 'cpp',
   version : '0.1',
-  default_options : ['warning_level=3', 'cpp_std=gnu++20'])
+  default_options : ['warning_level=0', 'cpp_std=gnu++20'])
+
+clang_warnings = ['-Wall', '-Wextra', '-Wshadow','-Wnon-virtual-dtor','-Wold-style-cast','-Wcast-align','-Wunused','-Woverloaded-virtual','-Wpedantic','-Wconversion','-Wsign-conversion','-Wnull-dereference','-Wdouble-promotion','-Wformat=2','-Wno-unknown-pragmas','-Wimplicit-fallthrough']
+gcc_warnings = clang_warnings + ['-Wmisleading-indentation','-Wduplicated-cond','-Wduplicated-branches','-Wlogical-op','-Wuseless-cast','-Wno-interference-size']
+
+compiler = meson.get_compiler('cpp')
+if compiler.get_id() == 'gcc'
+    message('Compiler: GCC')
+    add_global_arguments(gcc_warnings, language: 'cpp')
+elif compiler.get_id() == 'clang'
+    message('Compiler: LLVM/clang')
+    add_global_arguments(gcc_warnings, language: 'cpp')
+endif
+
 
 fmt_dep = dependency('fmt', version:'8.1.1')
 ut_dep = dependency('boost.ut')

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,8 @@ ut_dep = dependency('boost.ut')
 cmake = import('cmake')
 libreflcpp = cmake.subproject('refl-cpp')
 reflcpp_dep = libreflcpp.dependency('refl-cpp')
+libpmtv = subproject('pmt')
+pmt_dep = libpmtv.get_variable('pmt_dep')
 
 subdir('include')
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('enable_testing', type : 'boolean', value : true, description : 'Enable Testing and Benchmarks')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,3 @@
 main_exe = executable('main', 'main.cpp',
-  include_directories : '../include', 
-  dependencies : [fmt_dep, ut_dep, reflcpp_dep],
+  dependencies : [graph_dep, fmt_dep, reflcpp_dep],
   install: false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,4 @@
+main_exe = executable('main', 'main.cpp',
+  include_directories : '../include', 
+  dependencies : [fmt_dep, ut_dep, reflcpp_dep],
+  install: false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,7 @@
+
+cpp_args = graph_prototype_options
 main_exe = executable('main', 'main.cpp',
   dependencies : [graph_dep, fmt_dep, reflcpp_dep],
+  cpp_args: graph_prototype_options,
+  link_args: graph_prototype_options,
   install: false)

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,3 @@
+fmt-*/
+boost.ut*/
+refl-cpp*/

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,3 +1,4 @@
 fmt-*/
 boost.ut*/
 refl-cpp*/
+packagecache/

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -2,3 +2,5 @@ fmt-*/
 boost.ut*/
 refl-cpp*/
 packagecache/
+pmt*/
+CLI11-*/

--- a/subprojects/README.md
+++ b/subprojects/README.md
@@ -1,0 +1,7 @@
+This folder is used for dynamic fetching of content from meson.wrap
+Everything should be in .gitignore except for *.wrap files
+
+Ideally all the dependencies here would live in 
+https://mesonbuild.com/Wrapdb-projects.html
+
+But would need patch files and upstreamed to the wrapdb

--- a/subprojects/boost.ut.wrap
+++ b/subprojects/boost.ut.wrap
@@ -1,0 +1,5 @@
+
+[wrap-git]
+url=https://github.com/boost-ext/ut
+revision=265199e173b16a75670fae62fc2446b9dffad39e
+depth=1

--- a/subprojects/cli11.wrap
+++ b/subprojects/cli11.wrap
@@ -1,0 +1,2 @@
+[wrap-redirect]
+filename = pmt/subprojects/cli11.wrap

--- a/subprojects/cli11.wrap
+++ b/subprojects/cli11.wrap
@@ -1,2 +1,9 @@
-[wrap-redirect]
-filename = pmt/subprojects/cli11.wrap
+[wrap-file]
+directory = CLI11-2.3.2
+source_url = https://github.com/CLIUtils/CLI11/archive/refs/tags/v2.3.2.tar.gz
+source_filename = CLI11-2.3.2.tar.gz
+source_hash = aac0ab42108131ac5d3344a9db0fdf25c4db652296641955720a4fbe52334e22
+wrapdb_version = 2.3.2-1
+
+[provide]
+cli11 = CLI11_dep

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = fmt-8.1.1
+source_url = https://github.com/fmtlib/fmt/archive/8.1.1.tar.gz
+source_filename = fmt-8.1.1.tar.gz
+source_hash = 3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346
+patch_filename = fmt_8.1.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_8.1.1-2/get_patch
+patch_hash = cd001046281330a8862591780a9ea71a1fa594edd0d015deb24e44680c9ea33b
+wrapdb_version = 8.1.1-2
+
+[provide]
+fmt = fmt_dep

--- a/subprojects/pmt.wrap
+++ b/subprojects/pmt.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/gnuradio/pmt
+revision = HEAD 

--- a/subprojects/refl-cpp.wrap
+++ b/subprojects/refl-cpp.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url=https://github.com/veselink1/refl-cpp.git
+revision=27fbd7d2e6d86bc135b87beef6b5f7ce53afd4fc
+depth=1

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,22 @@
+include_directories = ['../include']
+
+buffer_test_exe = executable('qa_buffer', 'qa_buffer.cpp',
+  include_directories : include_directories, 
+  dependencies : [fmt_dep, ut_dep],
+  install: false)
+test('qa_buffer', buffer_test_exe)
+
+ut_test_names = [
+    'qa_dynamic_port',
+]
+deps = [fmt_dep, ut_dep, reflcpp_dep]
+cpp_args = '-fsanitize=address'
+foreach test_name : ut_test_names
+ut_test_exe = executable(test_name, test_name + '.cpp',
+  cpp_args : cpp_args,
+  link_args : cpp_args,
+  include_directories : include_directories, 
+  dependencies : [deps],
+  install: false)
+test(test_name, ut_test_exe)
+endforeach

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,22 +1,18 @@
-include_directories = ['../include']
-
+deps = [graph_dep, fmt_dep, ut_dep]
 buffer_test_exe = executable('qa_buffer', 'qa_buffer.cpp',
-  include_directories : include_directories, 
-  dependencies : [fmt_dep, ut_dep],
+  dependencies : deps,
   install: false)
 test('qa_buffer', buffer_test_exe)
 
 ut_test_names = [
     'qa_dynamic_port',
 ]
-deps = [fmt_dep, ut_dep, reflcpp_dep]
-cpp_args = '-fsanitize=address'
+deps = deps + reflcpp_dep
+
 foreach test_name : ut_test_names
 ut_test_exe = executable(test_name, test_name + '.cpp',
-  cpp_args : cpp_args,
-  link_args : cpp_args,
-  include_directories : include_directories, 
-  dependencies : [deps],
+  override_options: ['b_sanitize=address'],
+  dependencies : deps,
   install: false)
 test(test_name, ut_test_exe)
 endforeach


### PR DESCRIPTION
This PR adds basic meson build support for graph-prototype (not everything is in place yet that exists in the CMake)

To build:
```bash
cd graph-prototype
meson setup build_meson --buildtype=release
# meson setup build_meson --buildtype=release -denable_testing=false # to disable testing
cd build_meson
ninja
```

Issues and TODO
- [x] Compiling in debug mode (not specifying buildtype, or buildtype=debug) causes a compiler segfault
- [x] WASM support
- [x] Warnings configuration from CompilerWarnings.cmake
- [ ] The if blocks around Apple/MSVC, etc.
