### PR TITLE
Ensure indexForName finds exactly one match

### DIFF
--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -241,6 +241,10 @@ template<fixed_string Name, typename PortList>
 consteval int
 indexForName() {
     auto helper = []<std::size_t... Ids>(std::index_sequence<Ids...>) {
+        constexpr int n_matches = ((PortList::template at<Ids>::static_name() == Name) + ...);
+        static_assert(n_matches <= 1, "Multiple ports with that name were found. The name must be unique. You can "
+                                      "still use a port index instead.");
+        static_assert(n_matches == 1, "No port with the given name exists.");
         int result = -1;
         ((PortList::template at<Ids>::static_name() == Name ? (result = Ids) : 0), ...);
         return result;


### PR DESCRIPTION
If not, try to be helpful via static_assert message.

include/ChangeLog:

	* utils.hpp (indexForName): static_assert that the name exists exactly once.