### PR TITLE
Size optimizations, code simplifications

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -8,6 +8,7 @@ function(add_benchmark BM_NAME)
     set_project_warnings(${BM_NAME})
 endfunction()
 
+add_benchmark(bm_buffer)
 add_benchmark(bm_case0)
 add_benchmark(bm_case1)
 

--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -489,6 +489,12 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
             return _data.emplace_back(std::string(name), ResultMap()).second;
         }
 
+        static void
+        add_separator() noexcept {
+            std::lock_guard guard(_lock);
+            _data.emplace_back(std::string{}, ResultMap{});
+        }
+
         [[nodiscard]] static constexpr Data const &
         data() noexcept {
             return _data;
@@ -965,6 +971,14 @@ namespace cfg {
                     }
                     fmt::print("┐\n");
                     first_row = false;
+                } else if (test_name.empty() and result_map.empty()) {
+                    fmt::print("├{1:─^{0}}", name_max_size + 2UL, "");
+                    fmt::print("┼{1:─^{0}}", sizeof("PASS") + 1UL, "");
+                    for (auto const &[metric_key, max_width] : metric_keys) {
+                        fmt::print("┼{1:─^{0}}", max_width + 2UL, "");
+                    }
+                    fmt::print("┤\n");
+                    continue;
                 }
                 fmt::print("│ {1:<{0}} ", name_max_size, test_name);
                 if (result_map.size() == 0) {

--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <boost/ut.hpp>
+#include <charconv>
 #include <chrono>
 #include <iostream>
 #include <map>
@@ -610,6 +611,21 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
                 value *= base;
                 --exponent;
             }
+            if (significant_digits == 0 && exponent > 10) {
+              if (value < 10.0) {
+                significant_digits = 2;
+              } else if (value < 100.0) {
+                significant_digits = 1;
+              }
+            } else if (significant_digits == 1 && value >= 100.0) {
+              --significant_digits;
+            } else if (significant_digits >= 2) {
+              if (value >= 100.0) {
+                significant_digits -= 2;
+              } else if (value >= 10.0) {
+                --significant_digits;
+              }
+            }
 
             return fmt::format("{:.{}f}{}{}{}", value, significant_digits, unit.empty() ? "" : " ",
                                si_prefixes[exponent], unit);
@@ -699,13 +715,25 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
     template<std::size_t N_ITERATIONS = 1LU, typename ResultType = results, fixed_string... meas_marker_names>
     class benchmark : public ut::detail::test {
         std::size_t _n_scale_results;
+        int _precision = 0;
+
     public:
         benchmark() = delete;
 
-        explicit benchmark(std::string_view _name, std::size_t n_scale_results = 1LU) : ut::detail::test{"benchmark",
-                                                                                                         _name},
-                                                                                        _n_scale_results(
-                                                                                                n_scale_results) {}
+        explicit benchmark(std::string_view _name, std::size_t n_scale_results = 1LU)
+            : ut::detail::test{ "benchmark", _name }
+            , _n_scale_results(n_scale_results) {
+            const char *ptr = std::getenv("BM_DIGITS");
+            if (ptr != nullptr) {
+                const std::string_view env{ ptr };
+                auto [_, ec] = std::from_chars(env.data(), env.data() + env.size(), _precision);
+                if (ec == std::errc()) {
+                  _precision = std::clamp(_precision, 1, 6) - 1;
+                } else {
+                    fmt::print("Invalid value for BM_DIGITS: '{}'\n", env);
+                }
+            }
+        }
 
         template<class TestFunction, std::size_t MARKER_SIZE = argument_size<TestFunction>(), bool has_arguments =
         MARKER_SIZE != 0>
@@ -752,8 +780,10 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
                     const perf_metric perf_data = execMetrics.results();
                     result_map.try_emplace("CPU cache misses", perf_data.cache, "", 0);
                     result_map.try_emplace("CPU branch misses", perf_data.branch, "", 0);
-                    result_map.try_emplace("<CPU-I>", static_cast<double>(perf_data.instructions) /
-                                                      static_cast<double>(N_ITERATIONS * _n_scale_results), "", 1);
+                    result_map.try_emplace("<CPU-I>",
+                                           static_cast<double>(perf_data.instructions)
+                                                   / static_cast<double>(N_ITERATIONS * _n_scale_results),
+                                           "", std::max(1, _precision));
                     result_map.try_emplace("CTX-SW", perf_data.ctx_switches, "", 0);
                 }
                 // not time-critical post-processing starts here
@@ -761,30 +791,31 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
                 const auto ns = stop_iter[N_ITERATIONS - 1] - start;
                 const long double duration_s = 1e-9 * static_cast<long double>(ns.count());
 
-                const auto add_statistics = [&duration_s]<typename T>(ResultMap &map, const T &time_diff) {
+                const auto add_statistics = [&]<typename T>(ResultMap &map, const T &time_diff) {
                     if constexpr (N_ITERATIONS != 1) {
                         const auto [min, mean, stddev, median, max] = utils::compute_statistics(time_diff);
-                        map.try_emplace("min", min, "s", 0);
-                        map.try_emplace("mean", mean, "s", 0);
+                        map.try_emplace("min", min, "s", _precision);
+                        map.try_emplace("mean", mean, "s", _precision);
                         if (stddev == 0) {
-                            map.try_emplace("stddev", std::monostate{}, "s", 0);
+                            map.try_emplace("stddev", std::monostate{}, "s", _precision);
                         } else {
-                            map.try_emplace("stddev", stddev, "s", 0);
+                            map.try_emplace("stddev", stddev, "s", _precision);
                         }
-                        map.try_emplace("median", median, "s", 0);
-                        map.try_emplace("max", max, "s", 0);
+                        map.try_emplace("median", median, "s", _precision);
+                        map.try_emplace("max", max, "s", _precision);
                     } else {
-                        map.try_emplace("min", std::monostate{}, "s", 0);
-                        map.try_emplace("mean", duration_s / N_ITERATIONS, "s", 0);
-                        map.try_emplace("stddev", std::monostate{}, "s", 0);
-                        map.try_emplace("median", std::monostate{}, "s", 0);
-                        map.try_emplace("max", std::monostate{}, "s", 0);
+                        map.try_emplace("min", std::monostate{}, "s", _precision);
+                        map.try_emplace("mean", duration_s / N_ITERATIONS, "s", _precision);
+                        map.try_emplace("stddev", std::monostate{}, "s", _precision);
+                        map.try_emplace("median", std::monostate{}, "s", _precision);
+                        map.try_emplace("max", std::monostate{}, "s", _precision);
                     }
                 };
                 add_statistics(result_map, time_differences_ns);
 
-                result_map.try_emplace("total time", duration_s, "s", 0);
-                result_map.try_emplace("ops/s", _n_scale_results * N_ITERATIONS / duration_s, "", 1);
+                result_map.try_emplace("total time", duration_s, "s", _precision);
+                result_map.try_emplace("ops/s", _n_scale_results * N_ITERATIONS / duration_s, "",
+                                       std::max(1, _precision));
 
                 if constexpr (MARKER_SIZE > 0) {
                     auto transposed_map = utils::convert<N_ITERATIONS>(marker_iter);

--- a/bench/bm_buffer.cpp
+++ b/bench/bm_buffer.cpp
@@ -1,0 +1,157 @@
+#include "benchmark.hpp"
+
+#include <barrier>
+#include <boost/ut.hpp>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include <fmt/format.h>
+
+#include <buffer.hpp> // new buffer header interface
+#include <buffer_skeleton.hpp>
+#include <circular_buffer.hpp>
+#include <utils.hpp>
+
+#include <iostream>
+
+using namespace gr;
+
+#if defined __has_include && not __EMSCRIPTEN__
+#if __has_include(<pthread.h>) && __has_include(<sched.h>)
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+
+void
+setCpuAffinity(const int cpuID) // N.B. pthread is not portable
+{
+    const auto nCPU = std::thread::hardware_concurrency();
+    // fmt::print("set CPU affinity to core {}\n", cpuID % nCPU);
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(cpuID % nCPU, &cpuset);
+    int rc = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+    if (rc != 0) {
+        constexpr auto fmt = "pthread_setaffinity_np({} of {}): {} - {}\n";
+        fmt::print(stderr, fmt, cpuID, nCPU, rc, strerror(rc));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20)); // to force re-scheduling
+}
+#else
+void
+setCpuAffinity(const int cpuID) {}
+#endif
+#else
+void
+setCpuAffinity(const int cpuID) {}
+#endif
+
+void
+testNewAPI(Buffer auto &buffer, const std::size_t vector_length, const std::size_t min_samples, const int nProducer,
+           const int nConsumer, const std::string_view name) {
+    fair::meta::precondition(nProducer > 0);
+    fair::meta::precondition(nConsumer > 0);
+
+    constexpr int n_repeat = 8;
+
+    std::barrier barrier(nProducer + nConsumer + 1);
+
+    // init producers
+    std::atomic<int> threadID = 0;
+    std::vector<std::thread> producers;
+    for (int i = 0; i < nProducer; i++) {
+        producers.emplace_back([&]() {
+            // set thread affinity
+            setCpuAffinity(threadID++);
+            barrier.arrive_and_wait();
+            for (int rep = 0; rep < n_repeat; ++rep) {
+                BufferWriter auto writer = buffer.new_writer();
+                std::size_t nSamplesProduced = 0;
+                barrier.arrive_and_wait();
+                while (nSamplesProduced <= (min_samples + nProducer - 1) / nProducer) {
+                    writer.publish([](auto &) {}, vector_length);
+                    nSamplesProduced += vector_length;
+                }
+                barrier.arrive_and_wait();
+            }
+        });
+    }
+
+    // init consumers
+    std::vector<std::thread> consumers;
+    for (int i = 0; i < nConsumer; i++) {
+        consumers.emplace_back([&]() {
+            setCpuAffinity(threadID++);
+            barrier.arrive_and_wait();
+            for (int rep = 0; rep < n_repeat; ++rep) {
+                BufferReader auto reader = buffer.new_reader();
+                std::size_t nSamplesConsumed = 0;
+                barrier.arrive_and_wait();
+                while (nSamplesConsumed < min_samples) {
+                    if (reader.available() < vector_length) {
+                        continue;
+                    }
+                    const auto &input = reader.get(vector_length);
+                    nSamplesConsumed += input.size();
+
+                    if (!reader.consume(input.size())) {
+                        throw std::runtime_error(fmt::format("could not consume {} samples", input.size()));
+                    }
+                }
+                barrier.arrive_and_wait();
+            }
+        });
+    }
+
+    // all producers and consumer are ready, waiting to give the sign
+    barrier.arrive_and_wait();
+    ::benchmark::benchmark<n_repeat>(fmt::format("{:>8}: {} producers -<{:^4}>-> {} consumers", name, nProducer,
+                                                 vector_length, nConsumer),
+                                     min_samples)
+            = [&]() {
+                  barrier.arrive_and_wait();
+                  barrier.arrive_and_wait();
+              };
+
+    // clean up
+    for (std::thread &thread : producers) thread.join();
+    for (std::thread &thread : consumers) thread.join();
+}
+
+inline const boost::ut::suite _buffer_tests = [] {
+    const uint64_t samples = 10'000'000; // minimum number of samples
+    enum class BufferStrategy
+    {
+      posix,
+      portable
+    };
+
+    for (BufferStrategy strategy : { BufferStrategy::posix, BufferStrategy::portable }) {
+        for (int veclen : {1, 1024}) {
+            for (int nP = 1; nP <= 4; nP *= 2) {
+                for (int nR = 1; nR <= 4; nR *= 2) {
+                    const std::size_t size = std::max(4096, veclen) * nR * 10;
+                    auto allocator = std::pmr::polymorphic_allocator<int32_t>();
+                    const bool is_posix = strategy == BufferStrategy::posix;
+                    auto invoke = [&](auto buffer) {
+                        testNewAPI(buffer, veclen, samples, nP, nR, is_posix ? "POSIX" : "portable");
+                    };
+                    if (nP == 1) {
+                        using BufferType = circular_buffer<int32_t, std::dynamic_extent, ProducerType::Single>;
+                        Buffer auto buffer = is_posix ? BufferType(size) : BufferType(size, allocator);
+                        invoke(buffer);
+                    } else {
+                        using BufferType = circular_buffer<int32_t, std::dynamic_extent, ProducerType::Multi>;
+                        Buffer auto buffer = is_posix ? BufferType(size) : BufferType(size, allocator);
+                        invoke(buffer);
+                    }
+                }
+            }
+        }
+    }
+};
+
+int
+main() { /* not needed by the UT framework */
+}

--- a/bench/bm_buffer.cpp
+++ b/bench/bm_buffer.cpp
@@ -129,6 +129,9 @@ inline const boost::ut::suite _buffer_tests = [] {
 
     for (BufferStrategy strategy : { BufferStrategy::posix, BufferStrategy::portable }) {
         for (int veclen : {1, 1024}) {
+            if (not(strategy == BufferStrategy::posix and veclen == 1)) {
+                benchmark::results::add_separator();
+            }
             for (int nP = 1; nP <= 4; nP *= 2) {
                 for (int nR = 1; nR <= 4; nR *= 2) {
                     const std::size_t size = std::max(4096, veclen) * nR * 10;

--- a/include/circular_buffer.hpp
+++ b/include/circular_buffer.hpp
@@ -74,7 +74,7 @@ class double_mapped_memory_resource : public std::pmr::memory_resource {
     [[nodiscard]] void* do_allocate(const std::size_t required_size, std::size_t alignment) override {
 
         const std::size_t size = 2 * required_size;
-        if (size % 2LU != 0LU || size % static_cast<std::size_t>(getpagesize()) != 0LU) {
+        if (size % static_cast<std::size_t>(getpagesize()) != 0LU) {
             throw std::runtime_error(fmt::format("incompatible buffer-byte-size: {} -> {} alignment: {} vs. page size: {}", required_size, size, alignment, getpagesize()));
         }
         const std::size_t size_half = size/2;

--- a/include/circular_buffer.hpp
+++ b/include/circular_buffer.hpp
@@ -192,15 +192,15 @@ class circular_buffer
     using DependendsType    = std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>;
 
     struct buffer_impl {
-        alignas(kCacheLine) Allocator                   _allocator{};
-        alignas(kCacheLine) const bool                  _is_mmap_allocated;
-        alignas(kCacheLine) const std::size_t           _size;
-        alignas(kCacheLine) std::vector<T, Allocator>   _data;
-        alignas(kCacheLine) Sequence                    _cursor;
-        alignas(kCacheLine) WAIT_STRATEGY               _wait_strategy = WAIT_STRATEGY();
-        alignas(kCacheLine) ClaimType                   _claim_strategy;
+        Sequence                    _cursor;
+        Allocator                   _allocator{};
+        const bool                  _is_mmap_allocated;
+        const std::size_t           _size;
+        std::vector<T, Allocator>   _data;
+        WAIT_STRATEGY               _wait_strategy = WAIT_STRATEGY();
+        ClaimType                   _claim_strategy;
         // list of dependent reader indices
-        alignas(kCacheLine) DependendsType              _read_indices{ std::make_shared<std::vector<std::shared_ptr<Sequence>>>() };
+        DependendsType              _read_indices{ std::make_shared<std::vector<std::shared_ptr<Sequence>>>() };
 
         buffer_impl() = delete;
         buffer_impl(const std::size_t min_size, Allocator allocator) : _allocator(allocator), _is_mmap_allocated(dynamic_cast<double_mapped_memory_resource *>(_allocator.resource())),
@@ -229,11 +229,11 @@ class circular_buffer
     class buffer_writer {
         using BufferTypeLocal = std::shared_ptr<buffer_impl>;
 
-        alignas(kCacheLine) BufferTypeLocal             _buffer; // controls buffer life-cycle, the rest are cache optimisations
-        alignas(kCacheLine) bool                        _is_mmap_allocated;
-        alignas(kCacheLine) std::size_t                 _size;
-        alignas(kCacheLine) std::vector<U, Allocator>*  _data;
-        alignas(kCacheLine) ClaimType*                  _claim_strategy;
+        BufferTypeLocal             _buffer; // controls buffer life-cycle, the rest are cache optimisations
+        bool                        _is_mmap_allocated;
+        std::size_t                 _size;
+        std::vector<U, Allocator>*  _data;
+        ClaimType*                  _claim_strategy;
 
     public:
         buffer_writer() = delete;
@@ -344,11 +344,11 @@ class circular_buffer
     {
         using BufferTypeLocal = std::shared_ptr<buffer_impl>;
 
-        alignas(kCacheLine) std::shared_ptr<Sequence>   _read_index = std::make_shared<Sequence>();
-        alignas(kCacheLine) std::int64_t                _read_index_cached;
-        alignas(kCacheLine) BufferTypeLocal             _buffer; // controls buffer life-cycle, the rest are cache optimisations
-        alignas(kCacheLine) std::size_t                 _size;
-        alignas(kCacheLine) std::vector<U, Allocator>*  _data;
+        std::shared_ptr<Sequence>   _read_index = std::make_shared<Sequence>();
+        std::int64_t                _read_index_cached;
+        BufferTypeLocal             _buffer; // controls buffer life-cycle, the rest are cache optimisations
+        std::size_t                 _size;
+        std::vector<U, Allocator>*  _data;
 
     public:
         buffer_reader() = delete;

--- a/include/circular_buffer.hpp
+++ b/include/circular_buffer.hpp
@@ -201,10 +201,12 @@ class circular_buffer
     using DependendsType    = std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>;
 
     struct buffer_impl {
+        using size_type = std::int32_t;
+
         Sequence                    _cursor;
         Allocator                   _allocator{};
         const bool                  _is_mmap_allocated;
-        const std::size_t           _size;
+        const size_type             _size;
         std::vector<T, Allocator>   _data;
         WAIT_STRATEGY               _wait_strategy = WAIT_STRATEGY();
         ClaimType                   _claim_strategy;
@@ -237,10 +239,11 @@ class circular_buffer
     template <typename U = T>
     class buffer_writer {
         using BufferTypeLocal = std::shared_ptr<buffer_impl>;
+        using size_type = typename buffer_impl::size_type;
 
         BufferTypeLocal             _buffer; // controls buffer life-cycle, the rest are cache optimisations
         bool                        _is_mmap_allocated;
-        std::size_t                 _size;
+        size_type                   _size;
         ClaimType*                  _claim_strategy;
 
     public:
@@ -349,11 +352,12 @@ class circular_buffer
     class buffer_reader
     {
         using BufferTypeLocal = std::shared_ptr<buffer_impl>;
+        using size_type = typename buffer_impl::size_type;
 
         std::shared_ptr<Sequence>   _read_index = std::make_shared<Sequence>();
         std::int64_t                _read_index_cached;
         BufferTypeLocal             _buffer; // controls buffer life-cycle, the rest are cache optimisations
-        std::size_t                 _size;
+        size_type                   _size;
 
     public:
         buffer_reader() = delete;

--- a/include/sequence.hpp
+++ b/include/sequence.hpp
@@ -17,8 +17,13 @@ namespace gr {
 #define forceinline inline __attribute__((always_inline))
 #endif
 
-static constexpr const std::size_t kCacheLine
-        = 64; // waiting for clang: std::hardware_destructive_interference_size
+#ifdef __cpp_lib_hardware_interference_size
+using std::hardware_destructive_interference_size;
+using std::hardware_constructive_interference_size;
+#else
+inline constexpr std::size_t hardware_destructive_interference_size = 64;
+inline constexpr std::size_t hardware_constructive_interference_size = 64;
+#endif
 static constexpr const std::int64_t kInitialCursorValue = -1L;
 
 /**
@@ -30,7 +35,7 @@ static constexpr const std::int64_t kInitialCursorValue = -1L;
 // clang-format off
 class Sequence
 {
-    alignas(kCacheLine) std::atomic<std::int64_t> _fieldsValue{};
+    alignas(hardware_destructive_interference_size) std::atomic<std::int64_t> _fieldsValue{};
 
 public:
     Sequence(const Sequence&) = delete;

--- a/test/qa_buffer.cpp
+++ b/test/qa_buffer.cpp
@@ -389,7 +389,7 @@ const boost::ut::suite StreamTagConcept = [] {
     "StreamTagConcept"_test = [] {
         // implements a proof-of-concept how stream-tags could be dealt with
         using namespace gr;
-        struct alignas(gr::kCacheLine) buffer_tag {
+        struct alignas(gr::hardware_destructive_interference_size) buffer_tag {
             // N.B. type need to be favourably sized e.g. 1 or a power of 2
             // -> otherwise the automatic buffer sizes are getting very large
             int64_t index;


### PR DESCRIPTION
A collection of commits that seem to work alright.

Please note, that the new bm_buffer benchmark works for me as defined. However, if you increase the number of samples to process to be larger than the buffer size, then the benchmarks with more than one writer hang. Is the `circular_buffer<int32_t, std::dynamic_extent, ProducerType::Multi>` usage correct for multiple writers?