### PR TITLE
RAII circular buffer writer split get-publish

### DIFF
--- a/include/buffer.hpp
+++ b/include/buffer.hpp
@@ -69,8 +69,7 @@ concept BufferWriter = requires(T t, const std::size_t n_items, std::pair<std::s
     { t.publish([](std::span<util::value_type_t<T>> &/*writable_data*/, std::int64_t /* writePos */, Args ...) { /* */  }, n_items, args...) }   -> std::same_as<void>;
     { t.try_publish([](std::span<util::value_type_t<T>> &/*writable_data*/, Args ...) { /* */ }, n_items, args...) }                             -> std::same_as<bool>;
     { t.try_publish([](std::span<util::value_type_t<T>> &/*writable_data*/, std::int64_t /* writePos */, Args ...) { /* */  }, n_items, args...) }-> std::same_as<bool>;
-    { t.get(n_items) } -> std::same_as<std::pair<std::span<util::value_type_t<T>>, std::pair<std::size_t, std::int64_t>>>;
-    { t.publish(token, n_items) } -> std::same_as<void>;
+    { t.reserve_output_range(n_items) };
     { t.available() }         -> std::same_as<std::size_t>;
     { t.buffer() };
 };

--- a/include/buffer_skeleton.hpp
+++ b/include/buffer_skeleton.hpp
@@ -71,8 +71,8 @@ class buffer_skeleton
     public:
         [[nodiscard]] buffer_skeleton buffer() const noexcept { return buffer_skeleton(_buffer); };
 
-        [[nodiscard]] constexpr auto get(std::size_t n) noexcept -> std::pair<std::span<U>, std::pair<std::size_t, std::int64_t>> {
-                return { { &_buffer->_data[0], n }, { _buffer->_size -1, -1 }};
+        [[nodiscard]] constexpr auto reserve_output_range(std::size_t n) noexcept -> std::span<U> {
+                return { &_buffer->_data[0], n };
         }
 
         constexpr void publish(std::pair<std::size_t, std::int64_t>, std::size_t) const { /* empty */ }

--- a/test/qa_buffer.cpp
+++ b/test/qa_buffer.cpp
@@ -294,7 +294,7 @@ const boost::ut::suite CircularBufferTests = [] {
         }
 
         // basic expert writer api
-        {
+        for (int k = 0; k < 3; k++) {
             // case 0: write fully reserved data
             auto [data, token] = writer.get(4);
             for (std::size_t i = 0; i < data.size(); i++) {
@@ -308,15 +308,18 @@ const boost::ut::suite CircularBufferTests = [] {
             }
             expect(reader.consume(4));
         }
-        {
+        for (int k = 0; k < 3; k++) {
             // case 1: reserve more than actually written
+            const auto cursor_initial = buffer.cursor_sequence().value();
             auto [data, token] = writer.get(4);
             for (std::size_t i = 0; i < data.size(); i++) {
                 data[i] = static_cast<int>(i + 1);
             }
             writer.publish(token, 2);
+            const auto cursor_after = buffer.cursor_sequence().value();
+            expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
             auto read_data = reader.get();
-            expect(eq(std::size_t{2}, read_data.size()));
+            expect(eq(std::size_t{2}, read_data.size())) << fmt::format("received {} samples instead of expected 2", read_data.size());
             for (std::size_t i = 0; i < data.size(); i++) {
                 expect(eq(static_cast<int>(i + 1), read_data[i])) << "read 1: index " << i;
             }

--- a/test/qa_dynamic_port.cpp
+++ b/test/qa_dynamic_port.cpp
@@ -71,9 +71,9 @@ public:
         if (_counter < count) {
             _counter++;
             auto &writer       = output_port<"value">(this).writer();
-            auto [data, token] = writer.get(1);
+            auto data = writer.reserve_output_range(1);
             data[0]            = val;
-            writer.publish(token, 1);
+            data.publish(1);
 
             return fair::graph::work_return_t::OK;
         } else {


### PR DESCRIPTION
This addresses two things:
  * fix circular_buffer writer split get-partial-publish ... relevant only for single-publisher policy and in case more samples have been allocated than are being published + minor clean-ups sonarlint rightfully complained about
  * changed circular buffer writer split  get-publish interface to using RAII 
    * single- and multi-producer scenario:
       throws a terminal exception in case no data has been published <-> API/programming bug
    * multi-producer scenario:
       throws a terminal exception in case the amount of data reserved and published isn't identical <-> API/programming bug

Unfortunately, I couldn't make this a compile-time expression that checks for that since 'N claimed' is information that is only available during runtime.

Eventually, I'd like to retire the unsafe `buffer_writer::get(...)` in favour of the RAII API. Feedback would be welcome...