### PR TITLE
added handling of stream/message tags

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,7 +24,7 @@ AlignOperands: AlignAfterOperator
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowAllArgumentsOnNextLine: true
-PackConstructorInitializers: CurrentLine
+PackConstructorInitializers: NextLine
 AllowAllConstructorInitializersOnNextLine: true
 AllowShortLambdasOnASingleLine: All
 AllowShortCaseLabelsOnASingleLine: true
@@ -154,8 +154,8 @@ BraceWrapping:
   BeforeCatch: false
   BeforeElse: false
   IndentBraces: false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: All
 BreakBeforeBraces: Custom

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         pmt
         GIT_REPOSITORY https://github.com/gnuradio/pmt.git
-        GIT_TAG 6a6ba288840c1cb0c1091347530aec578ab60c8e # main 03/2023
+        GIT_TAG f7a789d699fd7806fb3a35ed3c00d013023f2553 # main 29/03/2023
 )
 
 FetchContent_Declare(

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -184,8 +184,8 @@ public:
 
     fair::graph::work_return_t
     work() noexcept {
-        auto      &out_port   = output_port<"out">(this);
-        auto      &in_port    = input_port<"in">(this);
+        auto      &out_port   = output_port<0>(this);
+        auto      &in_port    = input_port<0>(this);
 
         auto      &reader     = in_port.streamReader();
         auto      &writer     = out_port.streamWriter();
@@ -275,8 +275,8 @@ public:
 
     fair::graph::work_return_t
     work() noexcept { // TODO - make this an alternate version to 'process_one'
-        auto      &out_port   = output_port<"out">(this);
-        auto      &in_port    = input_port<"in">(this);
+        auto      &out_port   = out;
+        auto      &in_port    = in;
 
         auto      &reader     = in_port.streamReader();
         auto      &writer     = out_port.streamWriter();

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -14,7 +14,8 @@
 namespace fg                           = fair::graph;
 
 inline constexpr std::size_t N_ITER    = 10;
-inline constexpr std::size_t N_SAMPLES = gr::util::round_up(1'000'000, 1024);
+//inline constexpr std::size_t N_SAMPLES = gr::util::round_up(1'000'000, 1024);
+inline constexpr std::size_t N_SAMPLES = gr::util::round_up(10'000, 1024);
 
 template<typename T, char op>
 class math_op : public fg::node<math_op<T, op>, fg::IN<T, 0, N_MAX, "in">, fg::OUT<T, 0, N_MAX, "out">> {

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -187,8 +187,8 @@ public:
         auto      &out_port   = output_port<"out">(this);
         auto      &in_port    = input_port<"in">(this);
 
-        auto      &reader     = in_port.reader();
-        auto      &writer     = out_port.writer();
+        auto      &reader     = in_port.streamReader();
+        auto      &writer     = out_port.streamWriter();
         const auto n_readable = std::min(reader.available(), in_port.max_buffer_size());
         const auto n_writable = std::min(writer.available(), out_port.max_buffer_size());
         if (n_readable == 0) {
@@ -278,8 +278,8 @@ public:
         auto      &out_port   = output_port<"out">(this);
         auto      &in_port    = input_port<"in">(this);
 
-        auto      &reader     = in_port.reader();
-        auto      &writer     = out_port.writer();
+        auto      &reader     = in_port.streamReader();
+        auto      &writer     = out_port.streamWriter();
         const auto n_readable = std::min(reader.available(), in_port.max_buffer_size());
         const auto n_writable = std::min(writer.available(), out_port.max_buffer_size());
         if (n_readable == 0) {
@@ -341,8 +341,8 @@ public:
         auto      &out_port   = output_port<"out">(this);
         auto      &in_port    = input_port<"in">(this);
 
-        auto      &reader     = in_port.reader();
-        auto      &writer     = out_port.writer();
+        auto      &reader     = in_port.streamReader();
+        auto      &writer     = out_port.streamWriter();
         const auto n_readable = std::min(reader.available(), in_port.max_buffer_size());
         const auto n_writable = std::min(writer.available(), out_port.max_buffer_size());
         if (n_readable < to_simd_size) {

--- a/bench/bm_test_helper.hpp
+++ b/bench/bm_test_helper.hpp
@@ -47,7 +47,7 @@ public:
     work() {
         const std::size_t n_to_publish = _n_samples_max - n_samples_produced;
         if (n_to_publish > 0) {
-            auto &port   = output_port<"out">(this);
+            auto &port   = out;
             auto &writer = port.streamWriter();
 
             if constexpr (use_bulk_operation) {

--- a/bench/bm_test_helper.hpp
+++ b/bench/bm_test_helper.hpp
@@ -48,7 +48,7 @@ public:
         const std::size_t n_to_publish = _n_samples_max - n_samples_produced;
         if (n_to_publish > 0) {
             auto &port   = output_port<"out">(this);
-            auto &writer = port.writer();
+            auto &writer = port.streamWriter();
 
             if constexpr (use_bulk_operation) {
                 std::size_t n_write = std::clamp(n_to_publish, 0UL, std::min(writer.available(), port.max_buffer_size()));

--- a/include/circular_buffer.hpp
+++ b/include/circular_buffer.hpp
@@ -384,6 +384,8 @@ class circular_buffer
             }
         }
 
+        [[nodiscard]] constexpr std::int64_t position() const noexcept { return _buffer->_cursor.value(); }
+
         [[nodiscard]] constexpr std::size_t available() const noexcept {
             return _claim_strategy->getRemainingCapacity(*_buffer->_read_indices);
         }

--- a/include/dataset.hpp
+++ b/include/dataset.hpp
@@ -6,7 +6,7 @@
 #include <chrono>
 #include <map>
 #include <pmtv/pmt.hpp>
-#include <node.hpp>
+#include <reflection.hpp>
 
 namespace graph::dataset {
 using namespace std::chrono_literals;

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -77,7 +77,7 @@ class dynamic_port {
 
         // internal runtime polymorphism access
         [[nodiscard]] virtual bool
-        update_reader_internal(void *buffer_other) noexcept
+        update_reader_internal(internal_port_buffers buffer_other) noexcept
                 = 0;
     };
 
@@ -88,13 +88,13 @@ class dynamic_port {
         using PortType = std::decay_t<T>;
         std::conditional_t<owning, PortType, PortType &> _value;
 
-        [[nodiscard]] void *
+        [[nodiscard]] internal_port_buffers
         writer_handler_internal() noexcept {
             return _value.writer_handler_internal();
         };
 
         [[nodiscard]] bool
-        update_reader_internal(void *buffer_other) noexcept override {
+        update_reader_internal(internal_port_buffers buffer_other) noexcept override {
             if constexpr (T::IS_INPUT) {
                 return _value.update_reader_internal(buffer_other);
             } else {
@@ -122,7 +122,7 @@ class dynamic_port {
                         requires { arg.writer_handler_internal(); }, "'private void* writer_handler_internal()' not implemented");
             } else {
                 static_assert(
-                        requires { arg.update_reader_internal(std::declval<void *>()); }, "'private bool update_reader_internal(void* buffer)' not implemented");
+                        requires { arg.update_reader_internal(std::declval<internal_port_buffers>()); }, "'private bool update_reader_internal(void* buffer)' not implemented");
             }
         }
 
@@ -132,7 +132,7 @@ class dynamic_port {
                         requires { arg.writer_handler_internal(); }, "'private void* writer_handler_internal()' not implemented");
             } else {
                 static_assert(
-                        requires { arg.update_reader_internal(std::declval<void *>()); }, "'private bool update_reader_internal(void* buffer)' not implemented");
+                        requires { arg.update_reader_internal(std::declval<internal_port_buffers>()); }, "'private bool update_reader_internal(void* buffer)' not implemented");
             }
         }
 
@@ -182,7 +182,7 @@ class dynamic_port {
     };
 
     bool
-    update_reader_internal(void *buffer_other) noexcept {
+    update_reader_internal(internal_port_buffers buffer_other) noexcept {
         return _accessor->update_reader_internal(buffer_other);
     }
 

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -9,7 +9,7 @@
 #include <node_traits.hpp> // localinclude
 
 #include <fmt/format.h>
-#include <refl.hpp>
+#include <reflection.hpp>
 
 namespace fair::graph {
 
@@ -771,131 +771,6 @@ static_assert(traits::node::can_process_simd<copy>);
 static_assert(traits::node::can_process_simd<decltype(merge_by_index<0, 0>(copy(), copy()))>);
 }
 #endif
-
-
-/**
- *
- *                                |￣￣￣￣￣￣￣￣￣￣￣￣￣￣|
- *                                |     !!!Horray!!!      |
- *                                |      you made it!     |
- *                                |                       |
- *                                |        Warning!       |
- *                                |  Beneath are dragons! |
- *                                |＿＿＿＿＿＿＿＿＿＿＿＿＿＿|
- *                                    (\__/)  ||
- *                                    (•ㅅ•)  ||
- *                                    /  　  づ
- * ******************************************************************************************************************
- *
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⠄⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⡧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡱⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠊⠶⣂⣠⢠⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡑⡑⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣿⣼⡾⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠂⠑⡳⠀⣀⠠⠤⠠⡀⠀⠀⠀⠀⠀⢿⣿⣿⣿⣿⣷⣤⡀⡄⠚⢸⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠁⠁⠀⠀⠀⠙⡕⠀⠀⠀⠀⢻⣿⣿⣿⣿⢿⢧⡭⣶⣿⣿⣿⣷⣶⣶⣤⡀⣀⢄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠪⠤⡠⣙⣿⡿⡫⠉⣿⣭⡞⣿⣿⣿⣿⣿⣿⣿⣷⠂⠨⣌⠚⡴⠂⠤⣀⢀⡂⢢⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠀⠀⠁⠀⠀⠈⢩⣿⢿⣿⣿⡋⣿⣿⣧⣀⠛⠛⠟⢿⢹⣿⣷⣶⣶⣤⡁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣦⣾⠿⣷⣯⣿⣿⣿⢤⣿⣿⣿⣶⣶⣤⣭⣒⣕⡁⠛⠛⠂⠝⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣞⣿⣾⣿⣿⠿⠿⠿⣅⡐⣶⣿⣿⣿⣿⣿⣿⣿⡏⣿⣿⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⣀⠅⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⣿⣿⣿⣿⣷⣿⣶⣿⣿⣿⣿⣿⡿⣿⣿⣷⢿⣿⡄⠀⠛⠂⠀⠀⠀⠀⠀⠀⠀⠀⢀⢤⠀⠀⠀⢀⠠⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠜⢠⢁⡁⠒⡈⠐⠒⠒⠛⠊
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⢀⣕⢂⣬⣶⠒⠠⠀⣿⣿⠉⣿⡇⣿⣿⢻⣿⣿⣿⣿⣿⣿⣿⣿⣷⠙⠛⡄⠀⠀⠀⠀⠀⠄⣀⢤⣴⣶⣶⡶⣿⣾⣿⣶⣶⣿⣶⣶⡂⡔⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⣸⢃⣼⠫⢓⠬⠤⠄⠶⠒⠀
- *    ⠀⠀⠀⠀⠀⠀⠴⠂⣼⣿⡄⣿⠁⣴⣷⠾⠁⠉⠛⠏⣿⠛⠿⣷⡍⣿⣿⢿⣿⣿⣿⣈⠛⡄⠀⠀⠀⠀⠀⣀⡼⣶⣿⣷⣿⣿⣯⣿⢷⣟⣿⡻⣿⣯⣿⣿⣿⣿⣾⣖⠒⠤⠀⠀⠀⠀⠀⠀⣤⠛⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⠀⡀⣿⠁⠁⣒⢒⡠⡀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⢻⣿⣿⣿⠛⣀⡤⢱⠀⠀⠀⠉⠃⠀⠈⣳⣿⡿⣿⠿⣿⠟⠀⠀⣀⣤⠀⠀⠁⣬⣿⣿⣿⣿⣿⣟⡿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⣿⣿⣿⡿⠮⡂⠀⣀⠀⢀⣼⠏⡖⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⠀⠀⠀⠢⠂⣞⡿⠰⠠⢀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣿⣿⡿⠛⠛⠛⠃⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⡫⡱⠀⣾⠁⣀⠀⢴⣾⣿⣿⣷⣿⣿⣿⣿⣿⠟⠛⠉⠉⠁⢀⣉⡙⠛⣿⣿⣿⣿⣿⣯⣿⣿⣶⣧⣶⣟⣁⣾⠁⠀⠀⠀⠀⠀⣰⠃⣶⣷⣶⣶⣶⣶⣈⡄⢀⠒⣤⣶⣿⠁⡉⢒⠁⠑⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⣠⣿⠋⠙⣿⣿⣶⣄⠀⠀⠀⠀⠀⣴⣿⣿⢿⣿⣿⣿⠟⠀⢀⣾⣁⠀⠄⣴⣿⣿⣷⣿⣿⣿⣿⠟⠁⠀⠀⠀⢀⠀⣿⠉⢿⣿⢙⣐⡈⠻⣿⣿⣿⣿⣿⣿⣿⣿⣭⢩⠂⠀⠀⠀⣀⠀⡠⣵⣯⣷⣗⣿⣿⣽⣽⣿⣯⣿⣿⠯⠛⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠃⣒⢿⡏⠀⠀⠈⠛⣽⡽⠿⣿⣿⣿⣿⣿⣿⣿⣯⣿⣿⣤⣷⠿⣯⠟⢠⣢⣿⢿⣿⣿⣿⣽⣿⠟⠀⠀⠀⠀⠀⠀⠋⣦⣍⣻⣮⣿⣿⠋⠀⠀⡴⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⣶⣥⣬⣿⣿⣿⣿⣿⠿⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⣿⣏⣶⣤⣿⢿⣿⣿⣿⣿⣿⡿⠁⠀⠀⠀⠀⠀⠀⠀⢺⠋⠋⠉⠛⣿⣿⣯⢿⢿⣿⣯⣿⡿⢻⣿⣿⣽⢷⢿⣿⠿⣯⣿⣿⣿⣿⣿⡿⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠻⣿⣿⣍⠙⣿⣿⣿⣿⣿⣿⢿⣿⣽⣿⣿⢿⣿⣿⣿⣷⣿⡿⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣆⡀⠁⠙⣿⣿⣧⡀⠛⣿⣿⣿⢿⣿⣿⣿⣿⣿⡟⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⢻⣄⠙⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠿⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣌⠝⠋⠀⠀⠉⠉⠉⠛⠁⠀⠀⠙⢿⣟⣟⣿⠛⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⢿⣿⣿⣿⣿⣿⣿⠿⣟⣿⣭⠤⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠤⣤⡘⣿⣯⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⠤⣤⠴⣒⣀⣄⠀⠀⣿⡿⣿⡻⣿⣧⣿⣿⠛⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣶⣥⣈⢿⣦⣿⣿⠃⠀⢀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣟⠀⠛⣿⣦⣸⣿⠁⢀⣤⣿⣿⢿⣿⢿⣿⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢧⣁⣉⣭⣿⣿⠿⠛⠛⠛⠛⣹⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡞⡻⣿⣷⣶⣿⣿⣿⣾⣿⣿⣽⡿⠟⠋⠁⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡈⢋⣴⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⢶⢷⣿⡿⠛⠛⠛⢿⣦⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠁⠈⠊⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⢄⠀⠀⠀⠀⠀⠀⠉⠛⡿⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- *
- * The following macros are helpers to wrap around the existing refl-cpp macros: https://github.com/veselink1/refl-cpp
- * The are basically needed to do a struct member-field introspections, to support
- *   a) compile-time serialiser generation between std::map<std::string, pmt::pmtv> <-> user-defined settings structs
- *   b) allow for block ports being defined a member fields rather than as NTTPs of the node<T, ...> template
-
- * Their use is limited to the namespace scope where the block is defined (i.e. not across .so boundaries) and will be
- * supplanted once the compile-time reflection language feature is merged with the C++ standard, e.g.
- * Matúš Chochlík, Axel Naumann, David Sankel: Static reflection, P0194R3, ISO/IEC JTC1 SC22 WG21
- *    https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0194r3.html
- *
- *  These macros need to be defined in a global scope due to relying on template specialisation that cannot be done in
- *  any other namespace than the one they were declared -- for illustration see, for example:
- *  https://github.com/veselink1/refl-cpp/issues/59
- *  https://compiler-explorer.com/z/MG7fxzK4j
- *
- *  For practical purposes, the macro can be defined either at the end of the struct declaring namespace or the specific
- *  namespace exited/re-enteres such as
- *  @code
- *  namespace private::library {
- *     struct my_struct {
- *         int field_a;
- *         std::string field_b;
- *     };
- *  }
- *  ENABLE_REFLECTION(private::library:my_struct, field_a, field_b)
- *  namespace private::library {
- *   // ...
- *  @endcode
- *
- *  And please, if you want to accelerator the compile-time reflection process, please give your support and shout-out
- *  to the above authors, and contact your C++ STD Committee representative that this feature should not be delayed.
- */
-
-
-/**
- * This macro can be used for simple non-templated structs and classes, e.g.
- * @code
- * struct my_struct {
- *     int field_a;
- *      std::string field_b;
- * };
- * ENABLE_REFLECTION(private::library:my_struct, field_a, field_b)
- */
-#define ENABLE_REFLECTION(TypeName, ...) \
-    REFL_TYPE(TypeName __VA_OPT__(, )) \
-    REFL_DETAIL_FOR_EACH(REFL_DETAIL_EX_1_field __VA_OPT__(, ) __VA_ARGS__) \
-    REFL_END
-
-/**
- * This macro can be used for arbitrary templated structs and classes, that depend
- * on mixed typename and NTTP parameters
- * @code
- * template<typename T, std::size_t size>
- * struct custom_struct {
- *     T field_a;
- *     T field_b;
- *
- *     [[nodiscard]] constexpr std::size_t size() const noexcept { return size; }
- * };
- * ENABLE_REFLECTION_FOR_TEMPLATE_FULL(typename T, std::size_t size), (custom_struct<T, size>), field_a, field_a);
- */
-#define ENABLE_REFLECTION_FOR_TEMPLATE_FULL(TemplateDef, TypeName, ...) \
-    REFL_TEMPLATE(TemplateDef, TypeName __VA_OPT__(, )) \
-    REFL_DETAIL_FOR_EACH(REFL_DETAIL_EX_1_field __VA_OPT__(, ) __VA_ARGS__) \
-    REFL_END
-
-/**
- * This macro can be used for simple templated structs and classes, that depend
- * only on pure typename-template lists
- * @code
- * template<typename T>
- * struct my_templated_struct {
- *     T field_a;
- *     T field_b;
- * };
- * ENABLE_REFLECTION_FOR_TEMPLATE(my_templated_struct, field_a, field_b);
- */
-#define ENABLE_REFLECTION_FOR_TEMPLATE(Type, ...) \
-    ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename ...Ts), (Type<Ts...>), __VA_ARGS__)
 
 } // namespace fair::graph
 

--- a/include/node_traits.hpp
+++ b/include/node_traits.hpp
@@ -1,7 +1,7 @@
 #ifndef GNURADIO_NODE_NODE_TRAITS_HPP
 #define GNURADIO_NODE_NODE_TRAITS_HPP
 
-#include <refl.hpp>
+#include <reflection.hpp>
 
 #include <port.hpp> // localinclude
 #include <port_traits.hpp> // localinclude

--- a/include/port.hpp
+++ b/include/port.hpp
@@ -1,12 +1,13 @@
 #ifndef GNURADIO_PORT_HPP
 #define GNURADIO_PORT_HPP
 
-#include <variant>
 #include <complex>
 #include <span>
+#include <variant>
 
-#include "utils.hpp"
 #include "circular_buffer.hpp"
+#include "tag.hpp"
+#include "utils.hpp"
 
 namespace fair::graph {
 
@@ -18,7 +19,10 @@ using supported_type = std::variant<uint8_t, uint32_t, int8_t, int16_t, int32_t,
 
 enum class port_direction_t { INPUT, OUTPUT, ANY }; // 'ANY' only for query and not to be used for port declarations
 enum class connection_result_t { SUCCESS, FAILED };
-enum class port_type_t { STREAM, MESSAGE }; // TODO: Think of a better name
+enum class port_type_t {
+    STREAM, /*!< used for single-producer-only ond usually synchronous one-to-one or one-to-many communications */
+    MESSAGE /*!< used for multiple-producer one-to-one, one-to-many, many-to-one, or many-to-many communications */
+};
 enum class port_domain_t { CPU, GPU, NET, FPGA, DSP, MLU };
 
 template<class T>
@@ -32,10 +36,46 @@ concept Port = requires(T t, const std::size_t n_items) { // dynamic definitions
                    { t.disconnect() } -> std::same_as<connection_result_t>;
                };
 
+/**
+ * @brief internal port buffer handler
+ *
+ * N.B. void* needed for type-erasure/Python compatibility/wrapping
+ */
+struct internal_port_buffers {
+    void* streamHandler;
+    void* tagHandler;
+};
 
+/**
+ * @brief 'ports' are interfaces that allows data to flow between blocks in a graph, similar to RF connectors.
+ * Each block can have zero or more input/output ports. When connecting ports, either a single-step or a two-step
+ * connection method can be used. Ports belong to a computing domain, such as CPU, GPU, or FPGA, and transitions
+ * between domains require explicit data conversion.
+ * Each port consists of a synchronous performance-optimised streaming and asynchronous tag communication component:
+ *                                                                                      ┌───────────────────────
+ *         ───────────────────┐                                       ┌─────────────────┤  <node/block definition>
+ *             output-port    │                                       │    input-port   │  ...
+ *          stream-buffer<T>  │>───────┬─────────────────┬───────────>│                 │
+ *          tag-buffer<tag_t> │      tag#0             tag#1          │                 │
+ *                            │                                       │                 │
+ *         ───────────────────┘                                       └─────────────────┤
+ *
+ * Tags contain the index ID of the sending/receiving stream sample <T> they are attached to. Node implementations
+ * may choose to chunk the data based on the MIN_SAMPLES/MAX_SAMPLES criteria only, or in addition break-up the stream
+ * so that there is only one tag per scheduler iteration. Multiple tags on the same sample shall be merged to one.
+ *
+ * @tparam T the data type of the port. It can be any copyable preferably cache-aligned (i.e. 64 byte-sized) type.
+ * @tparam PortName a string to identify the port, notably to be used in an UI- and hand-written explicit code context.
+ * @tparam PortType STREAM  or MESSAGE
+ * @tparam PortDirection either input or output
+ * @tparam MIN_SAMPLES specifies the minimum number of samples the port/block requires for processing in one scheduler iteration
+ * @tparam MAX_SAMPLES specifies the maximum number of samples the port/block can process in one scheduler iteration
+ * @tparam BufferType user-extendable buffer implementation for the streaming data
+ * @tparam TagBufferType user-extendable buffer implementation for the tag data
+ */
 template<typename T, fixed_string PortName, port_type_t PortType, port_direction_t PortDirection, // TODO: sort default arguments
-         std::size_t MIN_SAMPLES = std::dynamic_extent, std::size_t MAX_SAMPLES = std::dynamic_extent,
-         gr::Buffer BufferType = gr::circular_buffer<T>>
+         std::size_t MIN_SAMPLES = std::dynamic_extent, std::size_t MAX_SAMPLES = std::dynamic_extent, gr::Buffer BufferType = gr::circular_buffer<T>,
+         gr::Buffer TagBufferType = gr::circular_buffer<tag_t>>
 class port {
 public:
     static_assert(PortDirection != port_direction_t::ANY, "ANY reserved for queries and not port direction declarations");
@@ -47,21 +87,25 @@ public:
 
     using port_tag                  = std::true_type;
 
-    template <fixed_string NewName>
+    template<fixed_string NewName>
     using with_name = port<T, NewName, PortType, PortDirection, MIN_SAMPLES, MAX_SAMPLES, BufferType>;
 
 private:
-    using ReaderType          = decltype(std::declval<BufferType>().new_reader());
-    using WriterType          = decltype(std::declval<BufferType>().new_writer());
-    using IoType              = std::conditional_t<IS_INPUT, ReaderType, WriterType>;
+    using ReaderType           = decltype(std::declval<BufferType>().new_reader());
+    using WriterType           = decltype(std::declval<BufferType>().new_writer());
+    using IoType               = std::conditional_t<IS_INPUT, ReaderType, WriterType>;
+    using TagReaderType        = decltype(std::declval<TagBufferType>().new_reader());
+    using TagWriterType        = decltype(std::declval<TagBufferType>().new_writer());
+    using TagIoType            = std::conditional_t<IS_INPUT, TagReaderType, TagWriterType>;
 
-    std::string  _name        = static_cast<std::string>(PortName);
-    std::int16_t _priority    = 0; // → dependents of a higher-prio port should be scheduled first (Q: make this by order of ports?)
-    std::size_t  _min_samples = (MIN_SAMPLES == std::dynamic_extent ? 1 : MIN_SAMPLES);
-    std::size_t  _max_samples = MAX_SAMPLES;
-    bool         _connected   = false;
+    std::string  _name         = static_cast<std::string>(PortName);
+    std::int16_t _priority     = 0; // → dependents of a higher-prio port should be scheduled first (Q: make this by order of ports?)
+    std::size_t  _min_samples  = (MIN_SAMPLES == std::dynamic_extent ? 1 : MIN_SAMPLES);
+    std::size_t  _max_samples  = MAX_SAMPLES;
+    bool         _connected    = false;
 
-    IoType       _ioHandler   = new_io_handler();
+    IoType       _ioHandler    = new_io_handler();
+    TagIoType    _tagIoHandler = new_tag_io_handler();
 
 public:
     [[nodiscard]] constexpr auto
@@ -73,17 +117,29 @@ public:
         }
     }
 
-    [[nodiscard]] void *
+    [[nodiscard]] constexpr auto
+    new_tag_io_handler() const noexcept {
+        if constexpr (IS_INPUT) {
+            return TagBufferType(65536).new_reader();
+        } else {
+            return TagBufferType(65536).new_writer();
+        }
+    }
+
+    [[nodiscard]] internal_port_buffers
     writer_handler_internal() noexcept {
         static_assert(IS_OUTPUT, "only to be used with output ports");
-        return static_cast<void *>(std::addressof(_ioHandler));
+        return { static_cast<void *>(std::addressof(_ioHandler)), static_cast<void *>(std::addressof(_tagIoHandler)) };
     }
 
     [[nodiscard]] bool
-    update_reader_internal(void *buffer_writer_handler_other) noexcept {
+    update_reader_internal(internal_port_buffers buffer_writer_handler_other) noexcept {
         static_assert(IS_INPUT, "only to be used with input ports");
 
-        if (buffer_writer_handler_other == nullptr) {
+        if (buffer_writer_handler_other.streamHandler == nullptr) {
+            return false;
+        }
+        if (buffer_writer_handler_other.tagHandler == nullptr) {
             return false;
         }
 
@@ -91,33 +147,25 @@ public:
         //       this will fail. We need to add a check that two ports that
         //       connect to each other use the same buffer type
         //       (std::any could be a viable approach)
-        auto typed_buffer_writer = static_cast<WriterType *>(buffer_writer_handler_other);
-        setBuffer(typed_buffer_writer->buffer());
+        auto typed_buffer_writer     = static_cast<WriterType *>(buffer_writer_handler_other.streamHandler);
+        auto typed_tag_buffer_writer = static_cast<TagWriterType *>(buffer_writer_handler_other.tagHandler);
+        setBuffer(typed_buffer_writer->buffer(), typed_tag_buffer_writer->buffer());
         return true;
     }
 
 public:
     port()             = default;
-
     port(const port &) = delete;
-
     auto
     operator=(const port &)
             = delete;
 
     port(std::string port_name, std::int16_t priority = 0, std::size_t min_samples = 0_UZ, std::size_t max_samples = SIZE_MAX) noexcept
-        : _name(std::move(port_name))
-        , _priority{ priority }
-        , _min_samples(min_samples)
-        , _max_samples(max_samples) {
+        : _name(std::move(port_name)), _priority{ priority }, _min_samples(min_samples), _max_samples(max_samples) {
         static_assert(PortName.empty(), "port name must be exclusively declared via NTTP or constructor parameter");
     }
 
-    constexpr port(port &&other) noexcept
-        : _name(std::move(other._name))
-        , _priority{ other._priority }
-        , _min_samples(other._min_samples)
-        , _max_samples(other._max_samples) {}
+    constexpr port(port &&other) noexcept : _name(std::move(other._name)), _priority{ other._priority }, _min_samples(other._min_samples), _max_samples(other._max_samples) {}
 
     constexpr port &
     operator=(port &&other) {
@@ -128,6 +176,7 @@ public:
         std::swap(_max_samples, tmp._max_samples);
         std::swap(_connected, tmp._connected);
         std::swap(_ioHandler, tmp._ioHandler);
+        std::swap(_tagIoHandler, tmp._tagIoHandler);
         return *this;
     }
 
@@ -196,7 +245,8 @@ public:
             return connection_result_t::SUCCESS;
         } else {
             try {
-                _ioHandler = BufferType(min_size).new_writer();
+                _ioHandler    = BufferType(min_size).new_writer();
+                _tagIoHandler = TagBufferType(min_size).new_writer();
             } catch (...) {
                 return connection_result_t::FAILED;
             }
@@ -204,43 +254,73 @@ public:
         return connection_result_t::SUCCESS;
     }
 
-    [[nodiscard]] BufferType
+    [[nodiscard]] auto
     buffer() {
-        return _ioHandler.buffer();
+        struct port_buffers {
+            BufferType streamBuffer;
+            TagBufferType tagBufferType;
+        } ;
+        return port_buffers{ _ioHandler.buffer(), _tagIoHandler.buffer() };
     }
 
     void
-    setBuffer(gr::Buffer auto buffer) noexcept {
+    setBuffer(gr::Buffer auto streamBuffer, gr::Buffer auto tagBuffer) noexcept {
         if constexpr (IS_INPUT) {
-            _ioHandler = std::move(buffer.new_reader());
-            _connected = true;
+            _ioHandler    = std::move(streamBuffer.new_reader());
+            _tagIoHandler = std::move(tagBuffer.new_reader());
+            _connected    = true;
         } else {
-            _ioHandler = std::move(buffer.new_writer());
+            _ioHandler    = std::move(streamBuffer.new_writer());
+            _tagIoHandler = std::move(tagBuffer.new_reader());
         }
     }
 
     [[nodiscard]] constexpr const ReaderType &
-    reader() const noexcept {
-        static_assert(!IS_OUTPUT, "reader() not applicable for outputs (yet)");
+    streamReader() const noexcept {
+        static_assert(!IS_OUTPUT, "streamReader() not applicable for outputs (yet)");
         return _ioHandler;
     }
 
     [[nodiscard]] constexpr ReaderType &
-    reader() noexcept {
-        static_assert(!IS_OUTPUT, "reader() not applicable for outputs (yet)");
+    streamReader() noexcept {
+        static_assert(!IS_OUTPUT, "streamReader() not applicable for outputs (yet)");
         return _ioHandler;
     }
 
     [[nodiscard]] constexpr const WriterType &
-    writer() const noexcept {
-        static_assert(!IS_INPUT, "writer() not applicable for inputs (yet)");
+    streamWriter() const noexcept {
+        static_assert(!IS_INPUT, "streamWriter() not applicable for inputs (yet)");
         return _ioHandler;
     }
 
     [[nodiscard]] constexpr WriterType &
-    writer() noexcept {
-        static_assert(!IS_INPUT, "writer() not applicable for inputs (yet)");
+    streamWriter() noexcept {
+        static_assert(!IS_INPUT, "streamWriter() not applicable for inputs (yet)");
         return _ioHandler;
+    }
+
+    [[nodiscard]] constexpr const TagReaderType &
+    tagReader() const noexcept {
+        static_assert(!IS_OUTPUT, "tagReader() not applicable for outputs (yet)");
+        return _tagIoHandler;
+    }
+
+    [[nodiscard]] constexpr TagReaderType &
+    tagReader() noexcept {
+        static_assert(!IS_OUTPUT, "tagReader() not applicable for outputs (yet)");
+        return _tagIoHandler;
+    }
+
+    [[nodiscard]] constexpr const TagWriterType &
+    tagWriter() const noexcept {
+        static_assert(!IS_INPUT, "tagWriter() not applicable for inputs (yet)");
+        return _tagIoHandler;
+    }
+
+    [[nodiscard]] constexpr TagWriterType &
+    tagWriter() noexcept {
+        static_assert(!IS_INPUT, "tagWriter() not applicable for inputs (yet)");
+        return _tagIoHandler;
     }
 
     [[nodiscard]] connection_result_t
@@ -248,8 +328,9 @@ public:
         if (_connected == false) {
             return connection_result_t::FAILED;
         }
-        _ioHandler = new_io_handler();
-        _connected = false;
+        _ioHandler    = new_io_handler();
+        _tagIoHandler = new_tag_io_handler();
+        _connected    = false;
         return connection_result_t::SUCCESS;
     }
 
@@ -258,13 +339,11 @@ public:
     connect(Other &&other) {
         static_assert(IS_OUTPUT && std::remove_cvref_t<Other>::IS_INPUT);
         auto src_buffer = writer_handler_internal();
-        return std::forward<Other>(other).update_reader_internal(src_buffer) ? connection_result_t::SUCCESS
-                                                                             : connection_result_t::FAILED;
+        return std::forward<Other>(other).update_reader_internal(src_buffer) ? connection_result_t::SUCCESS : connection_result_t::FAILED;
     }
 
     friend class dynamic_port;
 };
-
 
 namespace detail {
 template<typename T, auto>
@@ -304,6 +383,26 @@ static_assert(OUT_MSG<float, 0, 0, "out_msg">::static_name() == fixed_string("ou
 static_assert(!(OUT_MSG<float, 0, 0, "out_msg">::with_name<"out_message">::static_name() == fixed_string("out_msg")));
 static_assert(OUT_MSG<float, 0, 0, "out_msg">::with_name<"out_message">::static_name() == fixed_string("out_message"));
 
+constexpr void
+publish_tag(Port auto &port, tag_t::map_type &&tag_data, std::size_t tag_offset = 0) noexcept {
+    port.tagWriter().publish(
+            [&port, data = std::move(tag_data), &tag_offset](std::span<fair::graph::tag_t> tag_output) {
+                tag_output[0].index = port.streamWriter().position() + tag_offset;
+                tag_output[0].map   = std::move(data);
+            },
+            1_UZ);
 }
+
+constexpr void
+publish_tag(Port auto &port, const tag_t::map_type &tag_data, std::size_t tag_offset = 0) noexcept {
+    port.tagWriter().publish(
+            [&port, &tag_data, &tag_offset](std::span<fair::graph::tag_t> tag_output) {
+                tag_output[0].index = port.streamWriter().position() + tag_offset;
+                tag_output[0].map = tag_data;
+            },
+            1_UZ);
+}
+
+} // namespace fair::graph
 
 #endif // include guard

--- a/include/port_traits.hpp
+++ b/include/port_traits.hpp
@@ -2,7 +2,6 @@
 #define GNURADIO_NODE_PORT_TRAITS_HPP
 
 #include "port.hpp"
-#include <refl.hpp>
 #include <utils.hpp> // localinclude
 
 namespace fair::graph::traits::port {

--- a/include/reflection.hpp
+++ b/include/reflection.hpp
@@ -1,0 +1,131 @@
+#ifndef GRAPH_PROTOTYPE_REFLECTION_HPP
+#define GRAPH_PROTOTYPE_REFLECTION_HPP
+
+#include <refl.hpp>
+
+/**
+ *
+ *                                |￣￣￣￣￣￣￣￣￣￣￣￣￣￣|
+ *                                |     !!!Horray!!!      |
+ *                                |      you made it!     |
+ *                                |                       |
+ *                                |        Warning!       |
+ *                                |  Beneath are dragons! |
+ *                                |＿＿＿＿＿＿＿＿＿＿＿＿＿＿|
+ *                                    (\__/)  ||
+ *                                    (•ㅅ•)  ||
+ *                                    /  　  づ
+ * ******************************************************************************************************************
+ *
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠸⠄⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⡧⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡱⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠊⠶⣂⣠⢠⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡑⡑⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⣿⣼⡾⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠂⠑⡳⠀⣀⠠⠤⠠⡀⠀⠀⠀⠀⠀⢿⣿⣿⣿⣿⣷⣤⡀⡄⠚⢸⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠁⠁⠀⠀⠀⠙⡕⠀⠀⠀⠀⢻⣿⣿⣿⣿⢿⢧⡭⣶⣿⣿⣿⣷⣶⣶⣤⡀⣀⢄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠪⠤⡠⣙⣿⡿⡫⠉⣿⣭⡞⣿⣿⣿⣿⣿⣿⣿⣷⠂⠨⣌⠚⡴⠂⠤⣀⢀⡂⢢⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠀⠀⠁⠀⠀⠈⢩⣿⢿⣿⣿⡋⣿⣿⣧⣀⠛⠛⠟⢿⢹⣿⣷⣶⣶⣤⡁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣦⣾⠿⣷⣯⣿⣿⣿⢤⣿⣿⣿⣶⣶⣤⣭⣒⣕⡁⠛⠛⠂⠝⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣞⣿⣾⣿⣿⠿⠿⠿⣅⡐⣶⣿⣿⣿⣿⣿⣿⣿⡏⣿⣿⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⣀⠅⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠙⣿⣿⣿⣿⣷⣿⣶⣿⣿⣿⣿⣿⡿⣿⣿⣷⢿⣿⡄⠀⠛⠂⠀⠀⠀⠀⠀⠀⠀⠀⢀⢤⠀⠀⠀⢀⠠⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠜⢠⢁⡁⠒⡈⠐⠒⠒⠛⠊
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⢀⣕⢂⣬⣶⠒⠠⠀⣿⣿⠉⣿⡇⣿⣿⢻⣿⣿⣿⣿⣿⣿⣿⣿⣷⠙⠛⡄⠀⠀⠀⠀⠀⠄⣀⢤⣴⣶⣶⡶⣿⣾⣿⣶⣶⣿⣶⣶⡂⡔⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⣸⢃⣼⠫⢓⠬⠤⠄⠶⠒⠀
+ *    ⠀⠀⠀⠀⠀⠀⠴⠂⣼⣿⡄⣿⠁⣴⣷⠾⠁⠉⠛⠏⣿⠛⠿⣷⡍⣿⣿⢿⣿⣿⣿⣈⠛⡄⠀⠀⠀⠀⠀⣀⡼⣶⣿⣷⣿⣿⣯⣿⢷⣟⣿⡻⣿⣯⣿⣿⣿⣿⣾⣖⠒⠤⠀⠀⠀⠀⠀⠀⣤⠛⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠿⠀⡀⣿⠁⠁⣒⢒⡠⡀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⢻⣿⣿⣿⠛⣀⡤⢱⠀⠀⠀⠉⠃⠀⠈⣳⣿⡿⣿⠿⣿⠟⠀⠀⣀⣤⠀⠀⠁⣬⣿⣿⣿⣿⣿⣟⡿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⣿⣿⣿⡿⠮⡂⠀⣀⠀⢀⣼⠏⡖⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⠀⠀⠀⠢⠂⣞⡿⠰⠠⢀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣿⣿⡿⠛⠛⠛⠃⠀⠀⠀⠀⠀⢀⣴⣿⣿⣿⣿⣿⡫⡱⠀⣾⠁⣀⠀⢴⣾⣿⣿⣷⣿⣿⣿⣿⣿⠟⠛⠉⠉⠁⢀⣉⡙⠛⣿⣿⣿⣿⣿⣯⣿⣿⣶⣧⣶⣟⣁⣾⠁⠀⠀⠀⠀⠀⣰⠃⣶⣷⣶⣶⣶⣶⣈⡄⢀⠒⣤⣶⣿⠁⡉⢒⠁⠑⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⣠⣿⠋⠙⣿⣿⣶⣄⠀⠀⠀⠀⠀⣴⣿⣿⢿⣿⣿⣿⠟⠀⢀⣾⣁⠀⠄⣴⣿⣿⣷⣿⣿⣿⣿⠟⠁⠀⠀⠀⢀⠀⣿⠉⢿⣿⢙⣐⡈⠻⣿⣿⣿⣿⣿⣿⣿⣿⣭⢩⠂⠀⠀⠀⣀⠀⡠⣵⣯⣷⣗⣿⣿⣽⣽⣿⣯⣿⣿⠯⠛⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠃⣒⢿⡏⠀⠀⠈⠛⣽⡽⠿⣿⣿⣿⣿⣿⣿⣿⣯⣿⣿⣤⣷⠿⣯⠟⢠⣢⣿⢿⣿⣿⣿⣽⣿⠟⠀⠀⠀⠀⠀⠀⠋⣦⣍⣻⣮⣿⣿⠋⠀⠀⡴⢿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣦⣶⣥⣬⣿⣿⣿⣿⣿⠿⠉⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⣿⣏⣶⣤⣿⢿⣿⣿⣿⣿⣿⡿⠁⠀⠀⠀⠀⠀⠀⠀⢺⠋⠋⠉⠛⣿⣿⣯⢿⢿⣿⣯⣿⡿⢻⣿⣿⣽⢷⢿⣿⠿⣯⣿⣿⣿⣿⣿⡿⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠻⣿⣿⣍⠙⣿⣿⣿⣿⣿⣿⢿⣿⣽⣿⣿⢿⣿⣿⣿⣷⣿⡿⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣿⣆⡀⠁⠙⣿⣿⣧⡀⠛⣿⣿⣿⢿⣿⣿⣿⣿⣿⡟⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⢻⣄⠙⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠿⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣌⠝⠋⠀⠀⠉⠉⠉⠛⠁⠀⠀⠙⢿⣟⣟⣿⠛⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⢿⣿⣿⣿⣿⣿⣿⠿⣟⣿⣭⠤⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠤⣤⡘⣿⣯⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣀⠤⣤⠴⣒⣀⣄⠀⠀⣿⡿⣿⡻⣿⣧⣿⣿⠛⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣶⣥⣈⢿⣦⣿⣿⠃⠀⢀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣟⠀⠛⣿⣦⣸⣿⠁⢀⣤⣿⣿⢿⣿⢿⣿⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢧⣁⣉⣭⣿⣿⠿⠛⠛⠛⠛⣹⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡞⡻⣿⣷⣶⣿⣿⣿⣾⣿⣿⣽⡿⠟⠋⠁⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡈⢋⣴⣿⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠛⢶⢷⣿⡿⠛⠛⠛⢿⣦⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠁⠈⠊⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⢄⠀⠀⠀⠀⠀⠀⠉⠛⡿⠿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *    ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
+ *
+ * The following macros are helpers to wrap around the existing refl-cpp macros: https://github.com/veselink1/refl-cpp
+ * The are basically needed to do a struct member-field introspections, to support
+ *   a) compile-time serialiser generation between std::map<std::string, pmt::pmtv> <-> user-defined settings structs
+ *   b) allow for block ports being defined a member fields rather than as NTTPs of the node<T, ...> template
+
+ * Their use is limited to the namespace scope where the block is defined (i.e. not across .so boundaries) and will be
+ * supplanted once the compile-time reflection language feature is merged with the C++ standard, e.g.
+ * Matúš Chochlík, Axel Naumann, David Sankel: Static reflection, P0194R3, ISO/IEC JTC1 SC22 WG21
+ *    https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0194r3.html
+ *
+ *  These macros need to be defined in a global scope due to relying on template specialisation that cannot be done in
+ *  any other namespace than the one they were declared -- for illustration see, for example:
+ *  https://github.com/veselink1/refl-cpp/issues/59
+ *  https://compiler-explorer.com/z/MG7fxzK4j
+ *
+ *  For practical purposes, the macro can be defined either at the end of the struct declaring namespace or the specific
+ *  namespace exited/re-enteres such as
+ *  @code
+ *  namespace private::library {
+ *     struct my_struct {
+ *         int field_a;
+ *         std::string field_b;
+ *     };
+ *  }
+ *  ENABLE_REFLECTION(private::library:my_struct, field_a, field_b)
+ *  namespace private::library {
+ *   // ...
+ *  @endcode
+ *
+ *  And please, if you want to accelerator the compile-time reflection process, please give your support and shout-out
+ *  to the above authors, and contact your C++ STD Committee representative that this feature should not be delayed.
+ */
+
+
+/**
+ * This macro can be used for simple non-templated structs and classes, e.g.
+ * @code
+ * struct my_struct {
+ *     int field_a;
+ *      std::string field_b;
+ * };
+ * ENABLE_REFLECTION(private::library:my_struct, field_a, field_b)
+ */
+#define ENABLE_REFLECTION(TypeName, ...) \
+    REFL_TYPE(TypeName __VA_OPT__(, )) \
+    REFL_DETAIL_FOR_EACH(REFL_DETAIL_EX_1_field __VA_OPT__(, ) __VA_ARGS__) \
+    REFL_END
+
+/**
+ * This macro can be used for arbitrary templated structs and classes, that depend
+ * on mixed typename and NTTP parameters
+ * @code
+ * template<typename T, std::size_t size>
+ * struct custom_struct {
+ *     T field_a;
+ *     T field_b;
+ *
+ *     [[nodiscard]] constexpr std::size_t size() const noexcept { return size; }
+ * };
+ * ENABLE_REFLECTION_FOR_TEMPLATE_FULL(typename T, std::size_t size), (custom_struct<T, size>), field_a, field_a);
+ */
+#define ENABLE_REFLECTION_FOR_TEMPLATE_FULL(TemplateDef, TypeName, ...) \
+    REFL_TEMPLATE(TemplateDef, TypeName __VA_OPT__(, )) \
+    REFL_DETAIL_FOR_EACH(REFL_DETAIL_EX_1_field __VA_OPT__(, ) __VA_ARGS__) \
+    REFL_END
+
+/**
+ * This macro can be used for simple templated structs and classes, that depend
+ * only on pure typename-template lists
+ * @code
+ * template<typename T>
+ * struct my_templated_struct {
+ *     T field_a;
+ *     T field_b;
+ * };
+ * ENABLE_REFLECTION_FOR_TEMPLATE(my_templated_struct, field_a, field_b);
+ */
+#define ENABLE_REFLECTION_FOR_TEMPLATE(Type, ...) \
+    ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename ...Ts), (Type<Ts...>), __VA_ARGS__)
+
+
+#endif //GRAPH_PROTOTYPE_REFLECTION_HPP

--- a/include/tag.hpp
+++ b/include/tag.hpp
@@ -1,0 +1,145 @@
+#ifndef GRAPH_PROTOTYPE_TAG_HPP
+#define GRAPH_PROTOTYPE_TAG_HPP
+
+#include <map>
+#include <pmtv/pmt.hpp>
+#include <reflection.hpp>
+#include <utils.hpp>
+
+#ifdef __cpp_lib_hardware_interference_size
+using std::hardware_constructive_interference_size;
+using std::hardware_destructive_interference_size;
+#else
+inline constexpr std::size_t hardware_destructive_interference_size  = 64;
+inline constexpr std::size_t hardware_constructive_interference_size = 64;
+#endif
+
+namespace fair::graph {
+
+enum class tag_propagation_policy_t {
+    TPP_DONT = 0,       /*!< Scheduler doesn't propagate tags from in- to output. The
+                       block itself is free to insert tags. */
+    TPP_ALL_TO_ALL = 1, /*!< Propagate tags from all in- to all outputs. The
+                       scheduler takes care of that. */
+    TPP_ONE_TO_ONE = 2, /*!< Propagate tags from n. input to n. output. Requires
+                       same number of in- and outputs */
+    TPP_CUSTOM = 3      /*!< Like TPP_DONT, but signals the block it should implement
+                       application-specific forwarding behaviour. */
+};
+
+/**
+ * @brief 'tag_t' is a metadata structure that can be attached to a stream of data to carry extra information about that data.
+ * A tag can describe a specific time, parameter or meta-information (e.g. sampling frequency, gains, ...), provide annotations,
+ * or indicate events that blocks may trigger actions in downstream blocks. Tags can be inserted or consumed by blocks at
+ * any point in the signal processing flow, allowing for flexible and customisable data processing.
+ *
+ * Tags contain the index ID of the sending/receiving stream sample <T> they are attached to. Node implementations
+ * may choose to chunk the data based on the MIN_SAMPLES/MAX_SAMPLES criteria only, or in addition break-up the stream
+ * so that there is only one tag per scheduler iteration. Multiple tags on the same sample shall be merged to one.
+ */
+struct alignas(hardware_constructive_interference_size) tag_t {
+    using map_type = std::map<std::string, pmtv::pmt, std::less<>>;
+    int64_t  index = 0;
+    map_type map;
+
+    // TODO: do we need the convenience methods below?
+    pmtv::pmt &
+    at(const std::string &key) {
+        return map.at(key);
+    }
+
+    const pmtv::pmt &
+    at(const std::string &key) const {
+        return map.at(key);
+    }
+
+    [[nodiscard]] std::optional<std::reference_wrapper<const pmtv::pmt>>
+    get(const std::string &key) const noexcept {
+        try {
+            return map.at(key);
+        } catch (std::out_of_range &e) {
+            return std::nullopt;
+        }
+    }
+
+    [[nodiscard]] std::optional<std::reference_wrapper<pmtv::pmt>>
+    get(const std::string &key) noexcept {
+        try {
+            return map.at(key);
+        } catch (std::out_of_range &) {
+            return std::nullopt;
+        }
+    }
+
+    void
+    insert_or_assign(const std::pair<std::string, pmtv::pmt> &value) {
+        map[value.first] = value.second;
+    }
+
+    void
+    insert_or_assign(const std::string &key, const pmtv::pmt &value) {
+        map[key] = value;
+    }
+};
+} // namespace fair::graph
+
+ENABLE_REFLECTION(fair::graph::tag_t, index, map);
+
+namespace fair::graph {
+using meta::fixed_string;
+
+constexpr fixed_string GR_TAG_PREFIX = "gr:";
+
+template<fixed_string Key, typename PMT_TYPE, fixed_string Unit = "", fixed_string Description = "">
+class default_tag {
+    constexpr static fixed_string _key = GR_TAG_PREFIX + Key;
+
+public:
+    using value_type = PMT_TYPE;
+
+    [[nodiscard]] constexpr std::string_view
+    key() const noexcept {
+        return std::string_view{ _key };
+    }
+
+    [[nodiscard]] constexpr std::string_view
+    shortKey() const noexcept {
+        return std::string_view(Key);
+    }
+
+    [[nodiscard]] constexpr std::string_view
+    unit() const noexcept {
+        return std::string_view(Unit);
+    }
+
+    [[nodiscard]] constexpr std::string_view
+    description() const noexcept {
+        return std::string_view(Description);
+    }
+
+    [[nodiscard]] constexpr explicit(false) operator std::string() const noexcept { return std::string(_key); }
+
+    template<typename T>
+        requires std::is_same_v<value_type, T>
+    [[nodiscard]] std::pair<std::string, pmtv::pmt>
+    operator()(const T &newValue) const noexcept {
+        return { std::string(_key), static_cast<pmtv::pmt>(PMT_TYPE(newValue)) };
+    }
+};
+
+namespace tag { // definition of default tags and names
+                // TODO: change 'inline static const' to 'inline constexpr' once pmtv supports constexpr
+inline constexpr default_tag<"sample_rate", float, "Hz", "signal sample rate">                                                       SAMPLE_RATE;
+inline constexpr default_tag<"sample_rate", float, "Hz", "signal sample rate">                                                       SIGNAL_RATE;
+inline constexpr default_tag<"signal_name", std::string, "", "signal name">                                                          SIGNAL_NAME;
+inline constexpr default_tag<"signal_unit", std::string, "", "signal's physical SI unit">                                            SIGNAL_UNIT;
+inline constexpr default_tag<"signal_min", float, "a.u.", "signal physical max. (e.g. DAQ) limit">                                   SIGNAL_MIN;
+inline constexpr default_tag<"signal_max", float, "a.u.", "signal physical max. (e.g. DAQ) limit">                                   SIGNAL_MAX;
+inline constexpr default_tag<"trigger_name", std::string>                                                                            TRIGGER_NAME;
+inline constexpr default_tag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp">                                                 TRIGGER_TIME;
+inline constexpr default_tag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;
+} // namespace tag
+
+} // namespace fair::graph
+
+#endif // GRAPH_PROTOTYPE_TAG_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,3 +9,4 @@ function(add_ut_test TEST_NAME)
 endfunction()
 
 add_ut_test(qa_dynamic_port)
+add_ut_test(qa_tags)

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -1,0 +1,44 @@
+#include <boost/ut.hpp>
+
+#include <tag.hpp>
+
+const boost::ut::suite TagTests = [] {
+    using namespace boost::ut;
+    using namespace fair::graph;
+
+    "TagReflection"_test = [] {
+        static_assert(sizeof(tag_t) % 64 == 0, "needs to meet L1 cache size");
+        static_assert(refl::descriptor::type_descriptor<fair::graph::tag_t>::name == "fair::graph::tag_t");
+        static_assert(refl::member_list<tag_t>::size == 2, "index and map bein declared");
+        static_assert(refl::trait::get_t<0, refl::member_list<tag_t>>::name == "index", "class field index is public API");
+        static_assert(refl::trait::get_t<1, refl::member_list<tag_t>>::name == "map", "class field map is public API");
+    };
+
+    "DefaultTags"_test = [] {
+        tag_t testTag;
+
+        testTag.insert_or_assign(tag::SAMPLE_RATE, pmtv::pmt(3.0f));
+        testTag.insert_or_assign(tag::SAMPLE_RATE(4.0f));
+        // testTag.insert_or_assign(tag::SAMPLE_RATE(5.0)); // type-mismatch -> won't compile
+        expect(testTag.at(tag::SAMPLE_RATE) == 4.0f);
+        expect(tag::SAMPLE_RATE.shortKey() == "sample_rate");
+        expect(tag::SAMPLE_RATE.key() == std::string{ GR_TAG_PREFIX }.append("sample_rate"));
+
+        expect(testTag.get(tag::SAMPLE_RATE).has_value());
+        static_assert(!std::is_const_v<decltype(testTag.get(tag::SAMPLE_RATE).value())>);
+        expect(not testTag.get(tag::SIGNAL_NAME).has_value());
+
+        static_assert(std::is_same_v<decltype(tag::SAMPLE_RATE), decltype(tag::SIGNAL_RATE)>);
+        // test other tag on key definition only
+        static_assert(tag::SIGNAL_UNIT.shortKey() == "signal_unit");
+        static_assert(tag::SIGNAL_MIN.shortKey() == "signal_min");
+        static_assert(tag::SIGNAL_MAX.shortKey() == "signal_max");
+        static_assert(tag::TRIGGER_NAME.shortKey() == "trigger_name");
+        static_assert(tag::TRIGGER_TIME.shortKey() == "trigger_time");
+        static_assert(tag::TRIGGER_OFFSET.shortKey() == "trigger_offset");
+    };
+};
+
+int
+main() { /* tests are statically executed */
+}


### PR DESCRIPTION
Added tag_t definition and basic stream-tag functionality to the port and node definitions.

```
/**
 * @brief 'ports' are interfaces that allows data to flow between blocks in a graph, similar to RF connectors.
 * Each block can have zero or more input/output ports. When connecting ports, either a single-step or a two-step
 * connection method can be used. Ports belong to a computing domain, such as CPU, GPU, or FPGA, and transitions
 * between domains require explicit data conversion.
 * Each port consists of a synchronous performance-optimised streaming and asynchronous tag communication component:
 *                                                                                      ┌───────────────────────
 *         ───────────────────┐                                       ┌─────────────────┤  <node/block definition>
 *             output-port    │                                       │    input-port   │  ...
 *          stream-buffer<T>  │>───────┬─────────────────┬───────────>│                 │
 *          tag-buffer<tag_t> │      tag#0             tag#1          │                 │
 *                            │                                       │                 │
 *         ───────────────────┘                                       └─────────────────┤
 *
 * Tags contain the index ID of the sending/receiving stream sample <T> they are attached to. Node implementations
 * may choose to chunk the data based on the MIN_SAMPLES/MAX_SAMPLES criteria only, or in addition break-up the stream
 * so that there is only one tag per scheduler iteration. Multiple tags on the same sample shall be merged to one.
 * [..]
 */
 ```

* added `tag_t` and some default tag key-value-type definitions (in-line with an earlier approvedd [GR 4.0](https://github.com/gnuradio/gnuradio/pull/6362) PRs)
* renamed the reader/writer to more explicit `streamReader`/`streamWriter` and `tagReader`/`tagWriter` in the public API to more explicitly identify if the buffer is intended to transmit samples of type <T> or tags of type <tag_t> (N.B. functionally these buffers are otherwise identical).

This implementation assumed the same buffer size for streams and tags since -- in theory -- one could attach as many tags as samples per processing iteration. N.B. for large buffers and large numbers of ports/blocks in the application this can be wasteful and one should find a good policy w.r.t. the usually rare occurrence of tags compared to samples. I.e. 10%|1%|0.1% of buffer size being allocated for tags?!?!

Missing corner cases/features:
* handling when the distance of the next tag is less than the port's MIN_SAMPLES (rare corner case implement later)
* convenience function of forwarding tags from input ports to output ports for those implementing their `work()` function from scratch

Tackles '[stream tag](https://wiki.gnuradio.org/index.php?title=Stream_Tags) handling' in https://github.com/fair-acc/opendigitizer/issues/46.
