### PR TITLE
basic node setting handling

### DIFF
--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -601,10 +601,22 @@ public:
 
     template<typename Node, typename... Args>
     auto&
-    make_node(Args&&... args) {
+    make_node(Args&&... args) { // TODO for review: do we still need this factory method or allow only pmt-map-type constructors (see below)
         static_assert(std::is_same_v<Node, std::remove_reference_t<Node>>);
         auto& new_node_ref = _nodes.emplace_back(std::make_unique<node_wrapper<Node>>(std::forward<Args>(args)...));
         return *static_cast<Node*>(new_node_ref->raw());
+    }
+
+    template<typename Node>
+    auto&
+    make_node(const tag_t::map_type& initial_settings) {
+        static_assert(std::is_same_v<Node, std::remove_reference_t<Node>>);
+        auto& new_node_ref = _nodes.emplace_back(std::make_unique<node_wrapper<Node>>());
+        auto raw_ref = static_cast<Node*>(new_node_ref->raw());
+        if (!initial_settings.empty()) {
+            static_cast<node<Node>*>(raw_ref)->settings().init(*raw_ref, initial_settings);
+        }
+        return *raw_ref;
     }
 
     template<std::size_t src_port_index, typename Source>

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -1,0 +1,428 @@
+#ifndef GRAPH_PROTOTYPE_SETTINGS_HPP
+#define GRAPH_PROTOTYPE_SETTINGS_HPP
+
+#include <atomic>
+#include <chrono>
+#include <concepts>
+#include <mutex>
+#include <optional>
+#include <reflection.hpp>
+#include <set>
+#include <tag.hpp>
+#include <variant>
+
+namespace fair::graph {
+
+struct SettingsCtx {
+    // using TimePoint = std::chrono::time_point<std::chrono::utc_clock>; // TODO: change once the C++20 support is ubiquitous
+    using TimePoint               = std::chrono::time_point<std::chrono::system_clock>;
+    std::optional<TimePoint> time = std::nullopt; /// UTC time-stamp from which the setting is valid
+    std::string              context;             /// user-defined multiplexing context for which the setting is valid
+};
+
+template<typename T, typename Node>
+concept Settings = requires(T t, Node& n, std::span<const std::string> parameter_keys, const std::string &parameter_key, const tag_t::map_type &parameters, SettingsCtx ctx) {
+    { init(n, parameters) } -> std::same_as<void>;
+    /**
+     * @brief returns if there are stages settings that haven't been applied yet.
+     */
+    { t.changed() } -> std::same_as<bool>;
+
+    /**
+     * @brief stages new key-value pairs that shall replace the block field-based settings.
+     * N.B. settings become only active after executing 'apply_staged_parameters()' (usually done early on in the 'node::work()' function)
+     * @return key-value pairs that could not be set
+     */
+    { t.set(parameters, ctx) } -> std::same_as<tag_t::map_type>;
+    { t.set(parameters) } -> std::same_as<tag_t::map_type>;
+
+    /**
+     * @brief updates parameters based on node input tags for those with keys stored in `auto_update_parameters()`
+     * Parameter changes to down-stream nodes is controlled via `auto_forward_parameters()`
+     */
+    { t.auto_update(parameters, ctx) } -> std::same_as<void>;
+    { t.auto_update(parameters) } -> std::same_as<void>;
+
+    /**
+     * @brief return all available node settings as key-value pairs
+     */
+    { t.get() } -> std::same_as<tag_t::map_type>;
+
+    /**
+     * @brief return key-pmt values map for multiple keys
+     */
+    { t.get(parameter_keys, ctx) } -> std::same_as<tag_t::map_type>;
+    { t.get(parameter_keys) } -> std::same_as<tag_t::map_type>;
+
+    /**
+     * @brief return pmt value for a single key
+     */
+    { t.get(parameter_key, ctx) } -> std::same_as<std::optional<pmtv::pmt>>;
+    { t.get(parameter_key) } -> std::same_as<std::optional<pmtv::pmt>>;
+
+    /**
+     * @brief returns the staged/not-yet-applied new parameters
+     */
+    { t.staged_parameters() } -> std::same_as<const tag_t::map_type>;
+
+    /**
+     * @brief synchronise map-based with actual node field-based settings
+     */
+    { t.apply_staged_parameters() } -> std::same_as<const tag_t::map_type>;
+
+    /**
+     * @brief synchronises the map-based with the node's field-based parameters
+     * (N.B. usually called after the staged parameters have been synchronised)
+     */
+    { t.update_active_parameters() } -> std::same_as<void>;
+};
+
+template<typename Node>
+struct settings_base {
+    Node             *_node = nullptr;
+    std::atomic<bool> _changed{ false };
+
+    settings_base() = delete;
+
+    explicit settings_base(Node &node) : _node(&node) {}
+
+    settings_base(const settings_base &other) noexcept : _node(other._node), _changed(other._changed.load()) {}
+
+    settings_base(settings_base &&other) noexcept : _node(std::exchange(other._node, nullptr)), _changed(other._changed.load()) {}
+
+    virtual ~settings_base() = default;
+
+    settings_base &
+    operator=(const settings_base &other) noexcept {
+        swap(other);
+        return *this;
+    }
+
+    settings_base &
+    operator=(settings_base &&other) noexcept {
+        settings_base temp(std::move(other));
+        swap(temp);
+        return *this;
+    }
+
+    void
+    swap(settings_base &other) noexcept {
+        if (this == &other) {
+            return;
+        }
+        std::swap(_node, other._node);
+        bool changed = _changed.load();
+        _changed.store(other._changed.load());
+        other._settings_changed.store(changed);
+    }
+
+    virtual void
+    init(Node &node, const tag_t::map_type &initial_settings) noexcept
+            = 0;
+
+    /**
+     * @brief returns if there are stages settings that haven't been applied yet.
+     */
+    [[nodiscard]] constexpr bool
+    changed() const noexcept {
+        return _changed;
+    }
+
+    /**
+     * @brief stages new key-value pairs that shall replace the block field-based settings.
+     * N.B. settings become only active after executing 'apply_staged_parameters()' (usually done early on in the 'node::work()' function)
+     * @return key-value pairs that could not be set
+     */
+    [[nodiscard]] virtual tag_t::map_type
+    set(const tag_t::map_type &parameters, SettingsCtx ctx = {})
+            = 0;
+
+    /**
+     * @brief updates parameters based on node input tags for those with keys stored in `auto_update_parameters()`
+     * Parameter changes to down-stream nodes is controlled via `auto_forward_parameters()`
+     */
+    virtual void
+    auto_update(const tag_t::map_type &parameters, SettingsCtx = {})
+            = 0;
+
+    /**
+     * @brief return all (or for selected multiple keys) available node settings as key-value pairs
+     */
+    [[nodiscard]] virtual tag_t::map_type
+    get(std::span<const std::string> parameter_keys = {}, SettingsCtx = {}) const noexcept
+            = 0;
+
+    [[nodiscard]] virtual std::optional<pmtv::pmt>
+    get(const std::string &parameter_key, SettingsCtx = {}) const noexcept = 0;
+
+    /**
+     * @brief returns the staged/not-yet-applied new parameters
+     */
+    [[nodiscard]] virtual const tag_t::map_type
+    staged_parameters() const
+            = 0;
+
+    [[nodiscard]] virtual std::set<std::string, std::less<>> &
+    auto_update_parameters() noexcept
+            = 0;
+
+    [[nodiscard]] virtual std::set<std::string, std::less<>> &
+    auto_forward_parameters() noexcept
+            = 0;
+
+    /**
+     * @brief synchronise map-based with actual node field-based settings
+     * returns map with key-value tags that should be forwarded
+     * to dependent/child nodes.
+     */
+    [[nodiscard]] virtual tag_t::map_type
+    apply_staged_parameters() noexcept
+            = 0;
+
+    /**
+     * @brief synchronises the map-based with the node's field-based parameters
+     * (N.B. usually called after the staged parameters have been synchronised)
+     */
+    virtual void
+    update_active_parameters() noexcept
+            = 0;
+};
+
+template<typename Node>
+class basic_settings : public settings_base<Node> {
+    mutable std::mutex                 _lock{};
+    tag_t::map_type                    _active{}; // copy of class field settings as pmt-style map
+    tag_t::map_type                    _staged{}; // parameters to become active before the next work() call
+    std::set<std::string, std::less<>> _auto_update{};
+    std::set<std::string, std::less<>> _auto_forward{};
+
+public:
+    basic_settings() = delete;
+
+    explicit constexpr basic_settings(Node &node) noexcept : settings_base<Node>(node) {
+        if constexpr (refl::is_reflectable<Node>()) {
+            meta::tuple_for_each(
+                    [this](auto &&default_tag) {
+                        for_each(refl::reflect(*settings_base<Node>::_node).members, [&](auto member) {
+                            using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                            if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string>) ) {
+                                if (default_tag.shortKey().ends_with(get_display_name(member))) {
+                                    _auto_forward.emplace(get_display_name(member));
+                                }
+                                _auto_update.emplace(get_display_name(member));
+                            }
+                        });
+                    },
+                    fair::graph::tag::DEFAULT_TAGS);
+        }
+    }
+
+    constexpr basic_settings(const basic_settings &other) noexcept : settings_base<Node>(other) {
+        basic_settings temp(other);
+        swap(temp);
+    }
+
+    constexpr basic_settings(basic_settings &&other) noexcept : settings_base<Node>(std::move(other)) {
+        basic_settings temp(std::move(other));
+        swap(temp);
+    }
+
+    basic_settings &
+    operator=(const basic_settings &other) noexcept {
+        swap(other);
+        return *this;
+    }
+
+    basic_settings &
+    operator=(basic_settings &&other) noexcept {
+        basic_settings temp(std::move(other));
+        swap(temp);
+        return *this;
+    }
+
+    void
+    swap(basic_settings &other) noexcept {
+        if (this == &other) {
+            return;
+        }
+        settings_base<Node>::swap(other);
+        std::scoped_lock lock(_lock, other._lock);
+        std::swap(_active, other._active);
+        std::swap(_staged, other._staged);
+        std::swap(_auto_update, other._auto_update);
+        std::swap(_auto_forward, other._auto_forward);
+    }
+
+    void
+    init(Node &node, const tag_t::map_type &initial_settings) noexcept {
+        settings_base<Node>::_node = &node;
+        update_active_parameters();
+        auto invalid_settings = set(initial_settings);
+        [[maybe_unused]] auto ignore = apply_staged_parameters();
+        update_active_parameters();
+        if (!invalid_settings.empty()) {
+            fmt::print(stderr, "{} could not set {} initial parameter - invalid keys/value types\n", meta::type_name<Node>(), invalid_settings.size());
+            for (auto &[key, value] : invalid_settings) {
+                fmt::print(stderr, "key: {} - value-type: {}\n", key, value.index());
+            }
+        }
+    }
+
+    [[nodiscard]] tag_t::map_type
+    set(const tag_t::map_type &parameters, SettingsCtx = {}) {
+        tag_t::map_type ret;
+        if constexpr (refl::is_reflectable<Node>()) {
+            std::lock_guard lg(_lock);
+            for (const auto &[localKey, localValue] : parameters) {
+                const auto &key    = localKey;
+                const auto &value  = localValue;
+                bool        is_set = false;
+                for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
+                    using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                    if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string>) ) {
+                        if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
+                            if (_auto_update.contains(key)) {
+                                _auto_update.erase(key);
+                            }
+                            _staged.insert_or_assign(key, value);
+                            settings_base<Node>::_changed.store(true);
+                            is_set = true;
+                        }
+                    }
+                });
+                if (!is_set) {
+                    ret.insert_or_assign(key, pmtv::pmt(value));
+                }
+            }
+        }
+
+        return ret; // N.B. returns those <key:value> parameters that could not be set
+    }
+
+    void
+    auto_update(const tag_t::map_type &parameters, SettingsCtx = {}) {
+        if constexpr (refl::is_reflectable<Node>()) {
+            for (const auto &[localKey, localValue] : parameters) {
+                const auto &key   = localKey;
+                const auto &value = localValue;
+                for_each(refl::reflect(*settings_base<Node>::_node).members, [&](auto member) {
+                    using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                    if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string>) ) {
+                        if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
+                            _staged.insert_or_assign(key, value);
+                            settings_base<Node>::_changed.store(true);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    [[nodiscard]] const tag_t::map_type
+    staged_parameters() const noexcept {
+        std::lock_guard lg(_lock);
+        return _staged;
+    }
+
+    [[nodiscard]] tag_t::map_type
+    get(std::span<const std::string> parameter_keys = {}, SettingsCtx = {}) const noexcept {
+        std::lock_guard lg(_lock);
+        tag_t::map_type ret;
+        if (parameter_keys.size() == 0) {
+            ret = _active;
+            return ret;
+        }
+        for (const auto &key : parameter_keys) {
+            if (_active.contains(key)) {
+                ret.insert_or_assign(key, _active.at(key));
+            }
+        }
+        return ret;
+    }
+
+    [[nodiscard]] std::optional<pmtv::pmt>
+    get(const std::string &parameter_key, SettingsCtx = {}) const noexcept {
+        if constexpr (refl::is_reflectable<Node>()) {
+            std::lock_guard lg(_lock);
+
+            if (_active.contains(parameter_key)) {
+                return { _active.at(parameter_key) };
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    [[nodiscard]] std::set<std::string, std::less<>> &
+    auto_update_parameters() noexcept {
+        return _auto_update;
+    }
+
+    [[nodiscard]] std::set<std::string, std::less<>> &
+    auto_forward_parameters() noexcept {
+        return _auto_forward;
+    }
+
+    /**
+     * @brief synchronise map-based with actual node field-based settings
+     * returns map with key-value tags that should be forwarded
+     * to dependent/child nodes.
+     */
+    [[nodiscard]] virtual tag_t::map_type
+    apply_staged_parameters() noexcept {
+        tag_t::map_type forward_parameters; // parameters that should be forwarded to dependent child nodes
+        if constexpr (refl::is_reflectable<Node>()) {
+            std::lock_guard lg(_lock);
+            tag_t::map_type staged;
+            for (const auto &[localKey, localStaged_value] : _staged) {
+                const auto &key          = localKey;
+                const auto &staged_value = localStaged_value;
+                for_each(refl::reflect(*settings_base<Node>::_node).members, [&key, &staged, &forward_parameters, &staged_value, this](auto member) {
+                    using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                    if constexpr (is_writable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string>) ) {
+                        if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(staged_value)) {
+                            member(*settings_base<Node>::_node) = std::get<Type>(staged_value);
+                            if constexpr (requires { settings_base<Node>::_node->init(/* old settings */ _active, /* new settings */ staged); }) {
+                                staged.insert_or_assign(key, staged_value);
+                            }
+                            if (_auto_forward.contains(get_display_name(member))) {
+                                forward_parameters.insert_or_assign(key, staged_value);
+                            }
+                        }
+                    }
+                });
+            }
+            for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
+                using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+
+                if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string>) ) {
+                    _active.insert_or_assign(get_display_name(member), pmtv::pmt(member(*settings_base<Node>::_node)));
+                }
+            });
+            if constexpr (requires(Node d, const tag_t::map_type &map) { d.init(map, map); }) {
+                settings_base<Node>::_node->init(/* old settings */ _active, /* new settings */ staged);
+            }
+            _staged.clear();
+        }
+        return forward_parameters;
+    }
+
+    void
+    update_active_parameters() noexcept {
+        if constexpr (refl::is_reflectable<Node>()) {
+            std::lock_guard lg(_lock);
+            for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
+                using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+
+                if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string>) ) {
+                    _active.insert_or_assign(get_display_name_const(member).str(), member(*settings_base<Node>::_node));
+                }
+            });
+        }
+    }
+};
+
+// static_assert(Setting<basic_settings<int>, int>);
+
+} // namespace fair::graph
+#endif // GRAPH_PROTOTYPE_SETTINGS_HPP

--- a/include/tag.hpp
+++ b/include/tag.hpp
@@ -138,6 +138,9 @@ inline constexpr default_tag<"signal_max", float, "a.u.", "signal physical max. 
 inline constexpr default_tag<"trigger_name", std::string>                                                                            TRIGGER_NAME;
 inline constexpr default_tag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp">                                                 TRIGGER_TIME;
 inline constexpr default_tag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;
+inline constexpr default_tag<"context", std::string, "", "multiplexing key to orchestrate node settings/behavioural changes">        CONTEXT;
+
+inline constexpr std::tuple DEFAULT_TAGS = {SAMPLE_RATE, SIGNAL_NAME, SIGNAL_UNIT, SIGNAL_MIN, SIGNAL_MAX, TRIGGER_NAME, TRIGGER_TIME, TRIGGER_OFFSET, CONTEXT};
 } // namespace tag
 
 } // namespace fair::graph

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,4 +9,5 @@ function(add_ut_test TEST_NAME)
 endfunction()
 
 add_ut_test(qa_dynamic_port)
+add_ut_test(qa_settings)
 add_ut_test(qa_tags)

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -1,0 +1,172 @@
+#include <boost/ut.hpp>
+
+#include <node.hpp>
+#include <graph.hpp>
+#include <reflection.hpp>
+
+namespace fair::graph::setting_test {
+
+template<typename T>
+struct Source : public node<Source<T>> {
+    OUT<T>       out;
+    std::int32_t n_samples_produced = 0;
+    std::int32_t n_samples_max      = 1024;
+    std::int32_t n_tag_offset       = 0;
+    float        sample_rate        = 1000.0f;
+
+    void
+    init(const tag_t::map_type &old_settings, const tag_t::map_type &new_settings) {
+        // optional init function that is called after construction and whenever settings change
+        fair::graph::publish_tag(out, { { "n_samples_max", n_samples_max } }, n_tag_offset);
+    }
+
+    constexpr std::int64_t
+    available_samples(const Source &self) noexcept {
+        const auto ret = static_cast<std::int64_t>(n_samples_max - n_samples_produced);
+        return ret >= 0 ? ret : -1; // '-1' -> DONE, produced enough samples
+    }
+
+    [[nodiscard]] constexpr T
+    process_one() noexcept {
+        n_samples_produced++;
+        T x{};
+        return x;
+    }
+};
+
+template<typename T>
+struct TestBlock : public node<TestBlock<T>> {
+    IN<T>       in;
+    OUT<T>      out;
+    T           scaling_factor = static_cast<T>(1);
+    std::string  context;
+    std::int32_t n_samples_max = -1;
+    float        sample_rate        = 1000.0f;
+
+    template<fair::meta::t_or_simd<T> V>
+    [[nodiscard]] constexpr V
+    process_one(const V &a) const noexcept {
+        return a * scaling_factor;
+    }
+};
+
+template<typename T>
+struct Sink : public node<Sink<T>> {
+    IN<T> in;
+    std::int32_t n_samples_consumed = 0;
+    std::int32_t n_samples_max      = -1;
+    int64_t      last_tag_position  = -1;
+    float        sample_rate        = -1.0f;
+
+    template<fair::meta::t_or_simd<T> V>
+    [[nodiscard]] constexpr auto
+    process_one(V) noexcept {
+        // alt: optional user-level tag processing
+        /*
+        if (this->input_tags_present()) {
+            if (this->input_tags_present() && this->input_tags()[0].contains("n_samples_max")) {
+                const auto value = this->input_tags()[0].at("n_samples_max");
+                assert(std::holds_alternative<std::int32_t>(value));
+                n_samples_max = std::get<std::int32_t>(value);
+                last_tag_position        = in.streamReader().position();
+                this->acknowledge_input_tags(); // clears further tag notifications
+            }
+        }
+        */
+
+        if constexpr (fair::meta::any_simd<V>) {
+            n_samples_consumed += V::size();
+        } else {
+            n_samples_consumed++;
+        }
+    }
+};
+} // namespace fair::graph::setting_test
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (fair::graph::setting_test::Source<T>), out, n_samples_produced, n_samples_max, n_tag_offset, sample_rate);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (fair::graph::setting_test::TestBlock<T>), in, out, scaling_factor, context, n_samples_max, sample_rate);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (fair::graph::setting_test::Sink<T>), in, n_samples_consumed, n_samples_max, last_tag_position, sample_rate);
+
+const boost::ut::suite SettingsTests = [] {
+    using namespace boost::ut;
+    using namespace fair::graph;
+    using namespace fair::graph::setting_test;
+
+    "basic node settings tag"_test = [] {
+        graph                  flow_graph;
+        constexpr std::int32_t n_samples = gr::util::round_up(1'000'000, 1024);
+        // define basic Sink->TestBlock->Sink flow graph
+        auto &src = flow_graph.make_node<Source<float>>({ { "n_samples_max", n_samples } });
+        expect(eq(src.n_samples_max, n_samples)) << "check map constructor";
+        expect(eq(src.settings().auto_update_parameters().size(), 3UL));
+        expect(eq(src.settings().auto_forward_parameters().size(), 1UL)); // sample_rate
+        auto &block1 = flow_graph.make_node<TestBlock<float>>();
+        auto &block2 = flow_graph.make_node<TestBlock<float>>();
+        auto &sink  = flow_graph.make_node<Sink<float>>();
+        expect(eq(sink.settings().auto_update_parameters().size(), 4UL));
+        expect(eq(sink.settings().auto_forward_parameters().size(), 1UL)); // sample_rate
+
+        block1.context = "Test Context";
+        block1.settings().update_active_parameters();
+        expect(eq(block1.settings().auto_update_parameters().size(), 4UL));
+        expect(eq(block1.settings().auto_forward_parameters().size(), 2UL));
+
+        expect(block1.settings().get("context").has_value());
+        expect(block1.settings().get({ "context" }).has_value());
+        expect(not block1.settings().get({ "test" }).has_value());
+
+        std::vector<std::string>   keys1{ "key1", "key2", "key3" };
+        std::span<std::string>     keys2{ keys1 };
+        std::array<std::string, 3> keys3{ "key1", "key2", "key3" };
+        expect(block1.settings().get(keys1).empty());
+        expect(block1.settings().get(keys2).empty());
+        expect(block1.settings().get(keys3).empty());
+        expect(eq(block1.settings().get().size(), 4UL));
+
+        // set non-existent setting
+        expect(not block1.settings().changed()) << "settings not changed";
+        auto ret1 = block1.settings().set({ { "unknown", "random value" } });
+        expect(eq(ret1.size(), 1)) << "setting one unknown parameter";
+
+        expect(not block1.settings().changed());
+        auto ret2 = block1.settings().set({ { "context", "alt context" } });
+        expect(not block1.settings().staged_parameters().empty());
+        expect(ret2.empty()) << "setting one known parameter";
+        expect(block1.settings().changed()) << "settings changed";
+        auto forwarding_parameter = block1.settings().apply_staged_parameters();
+        expect(eq(forwarding_parameter.size(), 1)) << "initial forward declarations";
+        block1.settings().update_active_parameters();
+
+        // src -> block1 -> block2 -> sink
+        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(block1)));
+        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block1).to<"in">(block2)));
+        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block2).to<"in">(sink)));
+
+        auto token = flow_graph.init();
+        expect(token);
+        expect(src.settings().auto_update_parameters().contains("sample_rate"));
+        [[maybe_unused]] auto ret = src.settings().set({ { "sample_rate", 49000.0f } });
+        flow_graph.work(token);
+        expect(eq(src.n_samples_produced, n_samples)) << "did not produce enough output samples";
+        expect(eq(sink.n_samples_consumed, n_samples)) << "did not consume enough input samples";
+
+        expect(eq(src.n_samples_max, n_samples)) << "receive tag announcing max samples";
+        expect(eq(block1.n_samples_max, n_samples)) << "receive tag announcing max samples";
+        expect(eq(sink.n_samples_max, n_samples)) << "receive tag announcing max samples";
+
+        // expect(eq(src.sample_rate, 49000.0f)) << "src matching sample_rate";
+        expect(eq(block1.sample_rate, 49000.0f)) << "block1 matching sample_rate";
+        expect(eq(block2.sample_rate, 49000.0f)) << "block2 matching sample_rate";
+        expect(eq(sink.sample_rate, 49000.0f)) << "sink matching src sample_rate";
+
+        // check auto-update flags
+        expect(!src.settings().auto_update_parameters().contains("sample_rate")) << "src should not retain auto-update flag (was manually set)";
+        expect(block1.settings().auto_update_parameters().contains("sample_rate")) << "block1 retained auto-update flag";
+        expect(block2.settings().auto_update_parameters().contains("sample_rate")) << "block1 retained auto-update flag";
+        expect(sink.settings().auto_update_parameters().contains("sample_rate")) << "sink retained auto-update flag";
+    };
+};
+
+int
+main() { /* tests are statically executed */
+}


### PR DESCRIPTION
Implemented node settings as public node member fields (<-> PoCo) that can be interacted with 
  * directly (default from C++ point-of-view), or via 
  * key-value-map (`std::map<std::string, pmtv::pmt, std::less<>>`), that can be interacted via 'setting().set(..)' and 'setting().get(..)'.

Example block implementation:
```cpp
template<typename T>
struct TestBlock : public node<TestBlock<T>> {
    IN<T>       in;
    OUT<T>      out;
    T           scaling_factor = static_cast<T>(1);
    std::string  context;
    std::int32_t n_samples_max = -1;
    float        sample_rate        = 1000.0f;

    template<fair::meta::t_or_simd<T> V>
    [[nodiscard]] constexpr V
    process_one(const V &a) const noexcept {
        return a * scaling_factor;
    }
};
ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (fair::graph::setting_test::TestBlock<T>), in, out, scaling_factor, context, n_samples_max, sample_rate);
```

The settings management is both thread-safe as well as safe w.r.t. real-time/non-real-time usages. Settings are changed either directly during the initial node initialisation, or in the 'work()' function ('staged' -> 'active' settings) prior to calling the user's 'process_[one, bulk](...)' functions.

For example:
```cpp
// during initialisation:
auto &src = flow_graph.make_node<Source<float>>({ { "sample_rate", 49000.0f } });
// or:
src.setting().set({ { "sample_rate", 49000.0f } });

// [..]
auto optCtxValue = block1.settings().get("context")
auto pmtKeyValueMap = block1.settings().get({ "key1", "key2", "key3" })
expect(eq(src.sample_rate, block1.sample_rate)) << "block1 matching src sample_rate";

// [..]
auto forward = block1.settings().apply_staged_parameters(); // explicitly apply/transfer staged pmt settings to struct field
// N.B. forward contains the elements that should be forwarded to dependent children
block1.settings().update_active_parameters(); // synchronises struct fields to pmt 'active' map
```
N.B. the `get(..)` interface returns the values as stored in the 'active' settings map which may differ w.r.t. the real struct field value. To synchronise the function `update_active_parameters()` would need to be called. An automatic synchronised was omitted for performance reasons (requires locking, cannot be done while the node is processing data, etc....)

The fields that are automatically updated/forwarded are controlled via the following two sets:
```cpp
auto auto_update_set  = block1.settings().auto_update_parameters(); // add/remove keys as necessary
auto auto_forward_set = block1.settings().auto_forward_parameters();  // add/remove keys as necessary
```

Setting a parameter explicitly via `set(..)`  (usually by the user) automatically removes the field from the `auto_update_parameters()` set and thus prevents unintential/automatic updates later on.

The `auto_forward_parameters()` set is set during block initialisation for canonical tags, i.e. those that are defined in the `fair::graph::tag::DEFAULT_TAGS` tuple (e.g. 'sample_rate', 'signal_name', 'signal_unit', ..., 'trigger_name', 'trigger_time', ..., 'context').

This implementation is pluggable (i.e. user can provide their own setting handling logic) and has API provisions for optional transaction and timing/ctx-based settings management that is to be completed with a later PR.