### PR TITLE
history_buffer<T> and basic FIR and IIR filter

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -10,6 +10,7 @@ endfunction()
 add_benchmark(bm_buffer)
 add_benchmark(bm_case0)
 add_benchmark(bm_case1)
+add_benchmark(bm_filter)
 add_benchmark(bm_history_buffer)
 
 add_executable(bm_case1_nosimd bm_case1.cpp)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -10,6 +10,7 @@ endfunction()
 add_benchmark(bm_buffer)
 add_benchmark(bm_case0)
 add_benchmark(bm_case1)
+add_benchmark(bm_history_buffer)
 
 add_executable(bm_case1_nosimd bm_case1.cpp)
 target_compile_options(bm_case1_nosimd PRIVATE -Wall -march=native -DDISABLE_SIMD=1)

--- a/bench/bm_filter.cpp
+++ b/bench/bm_filter.cpp
@@ -1,0 +1,138 @@
+#include "benchmark.hpp"
+
+#include <algorithm>
+#include <boost/ut.hpp>
+#include <functional>
+
+#include "../test/blocklib/core/filter/time_domain_filter.hpp"
+#include "bm_test_helper.hpp"
+
+#include <graph.hpp>
+#include <node_traits.hpp>
+
+#include <vir/simd.h>
+
+inline constexpr std::size_t N_ITER = 10;
+// inline constexpr std::size_t N_SAMPLES = gr::util::round_up(1'000'000, 1024);
+inline constexpr std::size_t N_SAMPLES = gr::util::round_up(10'000, 1024);
+
+void
+loop_over_work(auto &node) {
+    using namespace boost::ut;
+    using namespace benchmark;
+    test::n_samples_produced = 0LU;
+    test::n_samples_consumed = 0LU;
+    while (test::n_samples_consumed < N_SAMPLES) {
+        node.work();
+    }
+    expect(eq(test::n_samples_produced, N_SAMPLES)) << "produced too many/few samples";
+    expect(eq(test::n_samples_consumed, N_SAMPLES)) << "consumed too many/few samples";
+}
+
+void
+invoke_work(auto &flow_graph) {
+    using namespace boost::ut;
+    using namespace benchmark;
+    test::n_samples_produced = 0LU;
+    test::n_samples_consumed = 0LU;
+    auto token               = flow_graph.init();
+    expect(token);
+    flow_graph.work(token);
+    expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
+    expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
+}
+
+inline const boost::ut::suite _constexpr_bm = [] {
+    using namespace boost::ut;
+    using namespace benchmark;
+    using fair::graph::merge_by_index;
+    using fair::graph::merge;
+    using namespace gr::blocks::filter;
+    namespace fg = fair::graph;
+
+    std::vector<float> fir_coeffs(10.f, 0.1f); // box car filter
+    std::vector<float> iir_coeffs_b{ 0.55f, 0.f };
+    std::vector<float> iir_coeffs_a{ 1.f, -0.45f };
+
+    {
+        auto merged_node = merge<"out", "in">(::test::source<float>(N_SAMPLES), ::test::sink<float>());
+        //
+        "merged src->sink work"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&merged_node]() { loop_over_work(merged_node); };
+    }
+
+    {
+        fir_filter<float> filter;
+        filter.b         = fir_coeffs;
+        auto merged_node = merge<"out", "in">(merge<"out", "in">(::test::source<float>(N_SAMPLES), std::move(filter)), ::test::sink<float>());
+        //
+        "merged src->fir_filter->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&merged_node]() { loop_over_work(merged_node); };
+    }
+
+    {
+        iir_filter<float, IIRForm::DF_I> filter;
+        filter.b         = iir_coeffs_b;
+        filter.a         = iir_coeffs_a;
+        auto merged_node = merge<"out", "in">(merge<"out", "in">(::test::source<float>(N_SAMPLES), std::move(filter)), ::test::sink<float>());
+        //
+        "merged src->iir_filter->sink - direct form I"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&merged_node]() { loop_over_work(merged_node); };
+    }
+
+    {
+        iir_filter<float, IIRForm::DF_II> filter;
+        filter.b         = iir_coeffs_b;
+        filter.a         = iir_coeffs_a;
+        auto merged_node = merge<"out", "in">(merge<"out", "in">(::test::source<float>(N_SAMPLES), std::move(filter)), ::test::sink<float>());
+        //
+        "merged src->iir_filter->sink - direct form II"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&merged_node]() { loop_over_work(merged_node); };
+    }
+
+    {
+        fg::graph flow_graph;
+        auto     &src  = flow_graph.make_node<::test::source<float>>(N_SAMPLES);
+        auto     &sink = flow_graph.make_node<::test::sink<float>>();
+
+        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(sink)));
+
+        "runtime   src->sink overhead"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() { invoke_work(flow_graph); };
+    }
+
+    {
+        fg::graph flow_graph;
+        auto     &src    = flow_graph.make_node<::test::source<float>>(N_SAMPLES);
+        auto     &sink   = flow_graph.make_node<::test::sink<float>>();
+        auto     &filter = flow_graph.make_node<fir_filter<float>>({ { "b", fir_coeffs } });
+
+        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect(src, &::test::source<float>::out).to<"in">(filter)));
+        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
+
+        "runtime   src->fir_filter->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() { invoke_work(flow_graph); };
+    }
+
+    {
+        fg::graph flow_graph;
+        auto     &src    = flow_graph.make_node<::test::source<float>>(N_SAMPLES);
+        auto     &sink   = flow_graph.make_node<::test::sink<float>>();
+        auto     &filter = flow_graph.make_node<iir_filter<float, IIRForm::DF_I>>({ { "b", iir_coeffs_b }, { "a", iir_coeffs_a } });
+
+        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect(src, &::test::source<float>::out).to<"in">(filter)));
+        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
+
+        "runtime   src->iir_filter->sink - direct-form I"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() { invoke_work(flow_graph); };
+    }
+
+    {
+        fg::graph flow_graph;
+        auto     &src    = flow_graph.make_node<::test::source<float>>(N_SAMPLES);
+        auto     &sink   = flow_graph.make_node<::test::sink<float>>();
+        auto     &filter = flow_graph.make_node<iir_filter<float, IIRForm::DF_II>>({ { "b", iir_coeffs_b }, { "a", iir_coeffs_a } });
+
+        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect(src, &::test::source<float>::out).to<"in">(filter)));
+        expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
+
+        "runtime   src->iir_filter->sink - direct-form II"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&flow_graph]() { invoke_work(flow_graph); };
+    }
+};
+
+int
+main() { /* not needed by the UT framework */
+}

--- a/bench/bm_history_buffer.cpp
+++ b/bench/bm_history_buffer.cpp
@@ -1,0 +1,150 @@
+#include "benchmark.hpp"
+
+#include <boost/ut.hpp>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include <fmt/format.h>
+
+#include <circular_buffer.hpp>
+#include <history_buffer.hpp>
+#include <utils.hpp>
+
+inline const boost::ut::suite _buffer_tests = [] {
+    constexpr uint32_t n_repetitions = 10;
+    constexpr uint32_t samples       = 10'000'000; // minimum number of samples
+    using namespace benchmark;
+    using namespace gr;
+
+    {
+        circular_buffer<int, std::dynamic_extent, ProducerType::Multi> buffer(32);
+        auto                                                           writer                   = buffer.new_writer();
+        auto                                                           reader                   = buffer.new_reader();
+
+        "circular_buffer<int>(32) - multiple producer"_benchmark.repeat<n_repetitions>(samples) = [&writer, &reader] {
+            static int counter = 0;
+            for (int i = 0; i < samples; i++) {
+                writer.publish([&](auto &vec) { vec[0] = counter; }, 1LU);
+                if (const auto data = reader.get(1)[0] != counter) {
+                    throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
+                }
+                [[maybe_unused]] const auto ret = reader.consume(1);
+                counter++;
+            }
+        };
+    }
+    {
+        circular_buffer<int> buffer(32);
+        auto                 writer                                                                      = buffer.new_writer();
+        auto                 reader                                                                      = buffer.new_reader();
+
+        "circular_buffer<int>(32) - single producer via lambda"_benchmark.repeat<n_repetitions>(samples) = [&writer, &reader] {
+            static int counter = 0;
+            for (int i = 0; i < samples; i++) {
+                writer.publish([&](auto &vec) { vec[0] = counter; }, 1LU);
+                if (const auto data = reader.get(1)[0] != counter) {
+                    throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
+                }
+                [[maybe_unused]] const auto ret = reader.consume(1);
+                counter++;
+            }
+        };
+    }
+    {
+        circular_buffer<int> buffer(32);
+        auto                 writer                                                                       = buffer.new_writer();
+        auto                 reader                                                                       = buffer.new_reader();
+
+        "circular_buffer<int>(32) - single producer via reserve"_benchmark.repeat<n_repetitions>(samples) = [&writer, &reader] {
+            static int counter = 0;
+            for (int i = 0; i < samples; i++) {
+                auto write_data = writer.reserve_output_range(1LU);
+                write_data[0]   = counter;
+                write_data.publish(1);
+                if (const auto data = reader.get(1)[0] != counter) {
+                    throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
+                }
+                [[maybe_unused]] const auto ret = reader.consume(1);
+                counter++;
+            }
+        };
+    }
+    /*
+     * left intentionally some space to improve the circular_buffer<T> implementation here
+     */
+    {
+        history_buffer<int> buffer(32);
+
+        "history_buffer<int>(32)"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+            static int counter = 0;
+            for (int i = 0; i < samples; i++) {
+                buffer.push_back(counter);
+                if (const auto data = buffer[0] != counter) {
+                    throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
+                }
+                counter++;
+            }
+        };
+    }
+    {
+        history_buffer<int> buffer(32);
+
+        "history_buffer<int, 32>"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+            static int counter = 0;
+            for (int i = 0; i < samples; i++) {
+                buffer.push_back(counter);
+                if (const auto data = buffer[0] != counter) {
+                    throw std::runtime_error(fmt::format("write {} read {} mismatch", counter, data));
+                }
+                counter++;
+            }
+        };
+    }
+
+    {
+        circular_buffer<int> buffer(32);
+        auto                 writer                                                     = buffer.new_writer();
+        auto                 reader                                                     = buffer.new_reader();
+
+        "circular_buffer<int>(32) - no checks"_benchmark.repeat<n_repetitions>(samples) = [&writer, &reader] {
+            static int counter    = 0;
+            auto       write_data = writer.reserve_output_range(1LU);
+            write_data[0]         = counter;
+            for (int i = 0; i < samples; i++) {
+                write_data.publish(1);
+                [[maybe_unused]] const auto data = reader.get(1)[0];
+                [[maybe_unused]] const auto ret  = reader.consume(1);
+                counter++;
+            }
+        };
+    }
+    {
+        history_buffer<int, 32> buffer;
+
+        "history_buffer<int, 32>  - no checks"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+            static int counter = 0;
+            for (int i = 0; i < samples; i++) {
+                buffer.push_back(counter);
+                [[maybe_unused]] const auto data = buffer[0];
+                counter++;
+            }
+        };
+    }
+    {
+        history_buffer<int> buffer(32);
+
+        "history_buffer<int>(32)  - no checks"_benchmark.repeat<n_repetitions>(samples) = [&buffer] {
+            static int counter = 0;
+            for (int i = 0; i < samples; i++) {
+                buffer.push_back(counter);
+                [[maybe_unused]] const auto data = buffer[0];
+                counter++;
+            }
+        };
+    }
+};
+
+int
+main() { /* not needed by the UT framework */
+}

--- a/include/history_buffer.hpp
+++ b/include/history_buffer.hpp
@@ -1,0 +1,224 @@
+#ifndef GRAPH_PROTOTYPE_HISTORY_BUFFER_HPP
+#define GRAPH_PROTOTYPE_HISTORY_BUFFER_HPP
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+#include <fmt/format.h>
+
+namespace gr {
+
+/**
+ * @brief A simple circular history buffer that supports contiguous ranged access across the wrap-around point.
+ *
+ * This buffer is similar to the `circular_buffer<T>` and uses a double-mapped memory approach.
+ * It is optimised for single-threaded use and does not provide thread-safety or multi-writer/multi-reader support.
+ *
+ * Example usage:
+ * gr::history_buffer<int, 5> buffer;
+ * buffer.push_back(1);  // buffer: [1] (size: 1, capacity: 5)
+ * buffer.push_back(2);  // buffer: [1, 2] (size: 2, capacity: 5)
+ * buffer.push_back(3);  // buffer: [1, 2, 3] (size: 3, capacity: 5)
+ * buffer.push_back(4);  // buffer: [1, 2, 3, 4] (size: 4, capacity: 5)
+ * buffer.push_back(5);  // buffer: [1, 2, 3, 4, 5] (size: 5, capacity: 5)
+ * buffer.push_back(6);  // buffer: [2, 3, 4, 5, 6] (size: 5, capacity: 5)
+ *
+ * // :
+ * buffer[0];     // value: 6 - unchecked access of last/actual sample
+ * buffer[-1];    // value: 5 - unchecked access of previous sample
+ * ...
+ * buffer.at(0);  // value: 6 - checked access of last/actual sample
+ * buffer.at(-1); // value: 5 - checked access of last/actual sample
+ * ...
+ * buffer.get_span(0, 3);  // span: [4, 5, 6]
+ * buffer.get_span(1, 3);  // span: [3, 4, 5]
+ * buffer.get_span(0);     // span: [2, 3, 4, 5, 6]
+ * buffer.get_span(1);     // span: [2, 3, 4, 5]
+ */
+template<typename T, std::size_t N = std::dynamic_extent, typename Allocator = std::allocator<T>>
+class history_buffer {
+    using signed_index_type = std::make_signed_t<std::size_t>;
+    using buffer_type       = typename std::conditional_t<N == std::dynamic_extent, std::vector<T, Allocator>, std::array<T, N * 2>>;
+    using size_type   = typename std::conditional_t<N == std::dynamic_extent, std::size_t, std::size_t>;
+
+    buffer_type _buffer;
+    std::size_t _capacity = N;
+    std::size_t _write_position{ 0 };
+    std::size_t _size{ 0 };
+
+    /**
+     * @brief maps the logical index to the physical index in the buffer.
+     */
+    constexpr inline std::size_t
+    map_index(signed_index_type index) const noexcept {
+        if constexpr (N == std::dynamic_extent) {
+            return (_write_position + _capacity - 1 + index) % _capacity;
+        } else {
+            return (_write_position + N - 1 + index) % N;
+        }
+    }
+
+public:
+    constexpr explicit history_buffer() noexcept { static_assert(N != std::dynamic_extent, "need to specify capacity"); }
+
+    constexpr explicit history_buffer(size_t capacity) : _buffer(capacity * 2), _capacity(capacity) {
+        if (capacity == 0) {
+            throw std::out_of_range("capacity is zero");
+        }
+        static_assert(N == std::dynamic_extent, "incompatible fixed capacity and using capacity argument");
+    }
+
+    /**
+     * @brief Adds an element to the end expiring the oldest element beyond the buffer's capacities.
+     */
+    constexpr void
+    push_back(const T &value) noexcept {
+        _buffer[_write_position]             = value;
+        _buffer[_write_position + _capacity] = _buffer[_write_position];
+        ++_write_position;
+        [[unlikely]] if (_write_position == _capacity) { _write_position = 0; }
+        _size = std::min(_size + 1, _capacity);
+    }
+
+    /**
+     * @brief Adds a range of elements the end expiring the oldest elements beyond the buffer's capacities.
+     */
+    template<typename Iter>
+    constexpr void
+    push_back_bulk(Iter cbegin, Iter cend) noexcept {
+        for (auto it = cbegin; it != cend; ++it) {
+            push_back(*it);
+        }
+    }
+
+    /**
+     * @brief Adds a range of elements the end expiring the oldest elements beyond the buffer's capacities.
+     */
+    template<typename Range>
+    constexpr void
+    push_back_bulk(const Range &range) noexcept {
+        for (const auto &item : range) {
+            push_back(item);
+        }
+    }
+
+    /**
+     * @brief unchecked accesses of the element at the specified logical index.
+     */
+    constexpr T &
+    operator[](signed_index_type index) noexcept {
+        return _buffer[map_index(index)];
+    }
+
+    [[nodiscard]] constexpr const T &
+    operator[](signed_index_type index) const noexcept {
+        return _buffer[map_index(index)];
+    }
+
+    [[nodiscard]] constexpr T &
+    at(signed_index_type index) {
+        const auto signed_size = static_cast<signed_index_type>(_size);
+        if (index > 0 || index <= -signed_size) {
+            throw std::out_of_range(fmt::format("index {} out of range ]{}, {}]", index, -signed_size, 0));
+        }
+        return _buffer[map_index(index)];
+    }
+
+    [[nodiscard]] constexpr const T &
+    at(signed_index_type index) const {
+        const auto signed_size = static_cast<signed_index_type>(_size);
+        if (index > 0 || index <= -signed_size) {
+            throw std::out_of_range(fmt::format("index {} out of range ]{}, {}]", index, -signed_size, 0));
+        }
+        return _buffer[map_index(index)];
+    }
+
+    [[nodiscard]] constexpr size_t
+    size() const noexcept {
+        return _size;
+    }
+
+    [[nodiscard]] constexpr size_t
+    capacity() const noexcept {
+        return _capacity;
+    }
+
+    /**
+     * @brief Returns a span of elements with given (optional) length with the last element being the newest
+     */
+    [[nodiscard]] constexpr std::span<const T>
+    get_span(signed_index_type index, std::size_t length = std::dynamic_extent) const /*noexcept*/ {
+        length = std::clamp(length, 0LU, std::max(0UL, static_cast<std::size_t>(size() + index)));
+        return std::span<const T>(cend() + index - length, length);
+    }
+
+    [[nodiscard]] auto
+    begin() noexcept {
+        return _buffer.begin() + _write_position + _capacity - _size;
+    }
+
+    [[nodiscard]] constexpr auto
+    begin() const {
+        return _buffer.begin() + _write_position + _capacity - _size;
+    }
+
+    [[nodiscard]] constexpr auto
+    cbegin() const {
+        return _buffer.cbegin() + _write_position + _capacity - _size;
+    }
+
+    [[nodiscard]] auto
+    end() noexcept {
+        return _buffer.begin() + _write_position + _capacity;
+    }
+
+    [[nodiscard]] constexpr auto
+    end() const noexcept {
+        return _buffer.begin() + _write_position + _capacity;
+    }
+
+    [[nodiscard]] constexpr auto
+    cend() const noexcept {
+        return _buffer.cbegin() + _write_position + _capacity;
+    }
+
+    [[nodiscard]] auto
+    rbegin() noexcept {
+        return std::make_reverse_iterator(_buffer.begin() + static_cast<signed_index_type>(_write_position + _capacity));
+    }
+
+    [[nodiscard]] constexpr auto
+    rbegin() const noexcept {
+        return std::make_reverse_iterator(_buffer.begin() + static_cast<signed_index_type>(_write_position + _capacity));
+    }
+
+    [[nodiscard]] constexpr auto
+    crbegin() const noexcept {
+        return rbegin();
+    }
+
+    [[nodiscard]] auto
+    rend() noexcept {
+        return std::make_reverse_iterator(_buffer.begin() + static_cast<signed_index_type>(_write_position + _capacity - _size));
+    }
+
+    [[nodiscard]] constexpr auto
+    rend() const noexcept {
+        return std::make_reverse_iterator(_buffer.begin() + static_cast<signed_index_type>(_write_position + _capacity - _size));
+    }
+
+    [[nodiscard]] constexpr auto
+    crend() const noexcept {
+        return rend();
+    }
+};
+
+} // namespace gr
+
+#endif // GRAPH_PROTOTYPE_HISTORY_BUFFER_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,12 +17,14 @@ endfunction()
 # mask some tests depending on the target
 if (EMSCRIPTEN)
     add_ut_test(qa_dynamic_port)
+    add_ut_test(qa_filter)
     add_ut_test(qa_settings)
     add_ut_test(qa_tags)
     # fails on emscripten for unclear reasons
     # add_ut_test(qa_buffer)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_ut_test(qa_buffer)
+    add_ut_test_no_asan(qa_filter)
     add_ut_test(qa_tags)
     # these tests trigger address sanitizer errors which have to be resolved
     add_ut_test_no_asan(qa_dynamic_port)
@@ -31,6 +33,7 @@ else()
     # these tests trigger address sanitizer errors which have to be resolved
     # clang asan seems to be even more strict
     add_ut_test_no_asan(qa_buffer)
+    add_ut_test_no_asan(qa_filter)
     add_ut_test_no_asan(qa_tags)
     add_ut_test_no_asan(qa_dynamic_port)
     add_ut_test_no_asan(qa_settings)

--- a/test/blocklib/core/filter/time_domain_filter.hpp
+++ b/test/blocklib/core/filter/time_domain_filter.hpp
@@ -1,0 +1,114 @@
+#ifndef GRAPH_PROTOTYPE_TIME_DOMAIN_FILTER_HPP
+#define GRAPH_PROTOTYPE_TIME_DOMAIN_FILTER_HPP
+
+#include <history_buffer.hpp>
+#include <node.hpp>
+#include <numeric>
+
+namespace gr::blocks::filter {
+
+using namespace fair::graph;
+
+/**
+ * @brief Finite Impulse Response (FIR) filter class
+ *
+ * The transfer function of an FIR filter is given by:
+ * H(z) = b[0] + b[1]*z^-1 + b[2]*z^-2 + ... + b[N]*z^-N
+ *
+ */
+template<typename T>
+    requires std::floating_point<T>
+struct fir_filter : node<fir_filter<T>> {
+    IN<T>             in;
+    OUT<T>            out;
+    std::vector<T>    b{}; // feedforward coefficients
+    history_buffer<T> inputHistory{ 32 };
+
+    void
+    init(const tag_t::map_type & /*old_settings*/, const tag_t::map_type &new_settings) noexcept {
+        if (new_settings.contains("b") && b.size() >= inputHistory.capacity()) {
+            inputHistory = history_buffer<T>(std::bit_ceil(b.size()));
+        }
+    }
+
+    constexpr T
+    process_one(T input) noexcept {
+        inputHistory.push_back(input);
+        return std::inner_product(b.begin(), b.end(), inputHistory.rbegin(), static_cast<T>(0));
+    }
+};
+
+enum class IIRForm {
+    DF_I,  /// direct form I: preferred for fixed-point arithmetics (e.g. no overflow)
+    DF_II, /// direct form II: preferred for floating-point arithmetics (less operations)
+    DF_I_TRANSPOSED,
+    DF_II_TRANSPOSED
+};
+
+/**
+ * @brief Infinite Impulse Response (IIR) filter class
+ *
+ * b are the feed-forward coefficients (N.B. b[0] denoting the newest and n[-1] the previous sample)
+ * a are the feedback coefficients
+ *
+ */
+template<typename T, IIRForm form = std::is_floating_point_v<T> ? IIRForm::DF_II : IIRForm::DF_I>
+    requires std::floating_point<T>
+struct iir_filter : node<iir_filter<T, form>> {
+    IN<T>             in;
+    OUT<T>            out;
+    std::vector<T>    b{ 1 }; // feedforward coefficients
+    std::vector<T>    a{ 1 }; // feedback coefficients
+    history_buffer<T> inputHistory{ 32 };
+    history_buffer<T> outputHistory{ 32 };
+
+    void
+    init(const tag_t::map_type & /*old_settings*/, const tag_t::map_type &new_settings) noexcept {
+        const auto new_size = std::max(a.size(), b.size());
+        if ((new_settings.contains("b") || new_settings.contains("a")) && (new_size >= inputHistory.capacity() || new_size >= inputHistory.capacity())) {
+            inputHistory  = history_buffer<T>(std::bit_ceil(new_size));
+            outputHistory = history_buffer<T>(std::bit_ceil(new_size));
+        }
+    }
+
+    [[nodiscard]] T
+    process_one(T input) noexcept {
+        if constexpr (form == IIRForm::DF_I) {
+            // y[n] = b[0] * x[n]   + b[1] * x[n-1] + ... + b[N] * x[n-N]
+            //      - a[1] * y[n-1] - a[2] * y[n-2] - ... - a[M] * y[n-M]
+            inputHistory.push_back(input);
+            const T output = std::inner_product(b.begin(), b.end(), inputHistory.rbegin(), static_cast<T>(0))       // feed-forward path
+                           - std::inner_product(a.begin() + 1, a.end(), outputHistory.rbegin(), static_cast<T>(0)); // feedback path
+            outputHistory.push_back(output);
+            return output;
+        } else if constexpr (form == IIRForm::DF_II) {
+            // w[n] = x[n] - a[1] * w[n-1] - a[2] * w[n-2] - ... - a[M] * w[n-M]
+            // y[n] =        b[0] * w[n]   + b[1] * w[n-1] + ... + b[N] * w[n-N]
+            const T w = input - std::inner_product(a.begin() + 1, a.end(), inputHistory.rbegin(), T{ 0 });
+            inputHistory.push_back(w);
+            return std::inner_product(b.begin(), b.end(), inputHistory.rbegin(), T{ 0 });
+        } else if constexpr (form == IIRForm::DF_I_TRANSPOSED) {
+            // w_1[n] = x[n] - a[1] * w_2[n-1] - a[2] * w_2[n-2] - ... - a[M] * w_2[n-M]
+            // y[n]   = b[0] * w_2[n] + b[1] * w_2[n-1] + ... + b[N] * w_2[n-N]
+            T v0 = input - std::inner_product(a.begin() + 1, a.end(), outputHistory.rbegin(), static_cast<T>(0));
+            outputHistory.push_back(v0);
+            return std::inner_product(b.begin(), b.end(), outputHistory.rbegin(), static_cast<T>(0));
+        } else if constexpr (form == IIRForm::DF_II_TRANSPOSED) {
+            // y[n] = b_0*f[n] + \sum_(k=1)^N(b_k*f[n−k] − a_k*y[n−k])
+            const T output = b[0] * input                                                                         //
+                           + std::inner_product(b.begin() + 1, b.end(), inputHistory.rbegin(), static_cast<T>(0)) //
+                           - std::inner_product(a.begin() + 1, a.end(), outputHistory.rbegin(), static_cast<T>(0));
+
+            inputHistory.push_back(input);
+            outputHistory.push_back(output);
+            return output;
+        }
+    }
+};
+
+} // namespace gr::blocks::filter
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (gr::blocks::filter::fir_filter<T>), in, out, b);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, gr::blocks::filter::IIRForm form), (gr::blocks::filter::iir_filter<T, form>), in, out, b, a);
+
+#endif // GRAPH_PROTOTYPE_TIME_DOMAIN_FILTER_HPP

--- a/test/qa_buffer.cpp
+++ b/test/qa_buffer.cpp
@@ -1,16 +1,19 @@
-//import boost.ut;
+// import boost.ut;
 #include <boost/ut.hpp>
 
+#include <algorithm>
 #include <complex>
 #include <numeric>
 #include <ranges>
 #include <tuple>
 
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include <buffer.hpp>
 #include <buffer_skeleton.hpp>
 #include <circular_buffer.hpp>
+#include <history_buffer.hpp>
 #include <sequence.hpp>
 #include <wait_strategy.hpp>
 
@@ -22,52 +25,54 @@ auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter
 
 template<gr::WaitStrategy auto wait = gr::NoWaitStrategy()>
 struct TestStruct {
-    [[nodiscard]] constexpr bool test() const noexcept { return true; }
+    [[nodiscard]] constexpr bool
+    test() const noexcept {
+        return true;
+    }
 };
 
 const boost::ut::suite BasicConceptsTests = [] {
     using namespace boost::ut;
 
-    "BasicConcepts"_test = []<typename T> {
-        using namespace gr;
-        Buffer auto buffer = T(1024);
-        auto typeName = reflection::type_name<T>();
-        // N.B. GE because some buffers need to intrinsically
-        // allocate more to meet e.g. page-size requirements
-        expect(ge(buffer.size(), std::size_t{ 1024 })) << "for" << typeName;
+    "BasicConcepts"_test =
+            []<typename T> {
+                using namespace gr;
+                Buffer auto buffer   = T(1024);
+                auto        typeName = reflection::type_name<T>();
+                // N.B. GE because some buffers need to intrinsically
+                // allocate more to meet e.g. page-size requirements
+                expect(ge(buffer.size(), std::size_t{ 1024 })) << "for" << typeName;
 
-        // compile-time interface tests
-        BufferReader auto reader = buffer.new_reader(); // tests matching read concept
-        BufferWriter auto writer = buffer.new_writer(); // tests matching write concept
+                // compile-time interface tests
+                BufferReader auto reader = buffer.new_reader(); // tests matching read concept
+                BufferWriter auto writer = buffer.new_writer(); // tests matching write concept
 
-        static_assert(std::is_same_v<decltype(reader.buffer().new_reader()), decltype(reader)>);
-        static_assert(std::is_same_v<decltype(reader.buffer().new_writer()), decltype(writer)>);
-        static_assert(std::is_same_v<decltype(writer.buffer().new_writer()), decltype(writer)>);
-        static_assert(std::is_same_v<decltype(writer.buffer().new_reader()), decltype(reader)>);
+                static_assert(std::is_same_v<decltype(reader.buffer().new_reader()), decltype(reader)>);
+                static_assert(std::is_same_v<decltype(reader.buffer().new_writer()), decltype(writer)>);
+                static_assert(std::is_same_v<decltype(writer.buffer().new_writer()), decltype(writer)>);
+                static_assert(std::is_same_v<decltype(writer.buffer().new_reader()), decltype(reader)>);
 
-        // runtime interface tests
-        expect(eq(reader.available(), std::size_t{0}));
-        expect(eq(reader.position(), std::int64_t{-1}));
-        expect(nothrow([&reader] { expect(eq(reader.get(std::size_t{0}).size(), std::size_t{0})); })) << typeName << "throws";
-        expect(nothrow([&reader] { expect(reader.consume(std::size_t{0})); }));
+                // runtime interface tests
+                expect(eq(reader.available(), std::size_t{ 0 }));
+                expect(eq(reader.position(), std::int64_t{ -1 }));
+                expect(nothrow([&reader] { expect(eq(reader.get(std::size_t{ 0 }).size(), std::size_t{ 0 })); })) << typeName << "throws";
+                expect(nothrow([&reader] { expect(reader.consume(std::size_t{ 0 })); }));
 
-        expect(writer.available() >= buffer.size());
-        expect(nothrow([&writer] { writer.publish([](const std::span<int32_t> &) { /* noop */ }, 0); }));
-        expect(nothrow([&writer] { writer.publish([](const std::span<int32_t> &, std::int64_t) { /* noop */ }, 0); }));
-        expect(nothrow([&writer] { expect(writer.try_publish([](const std::span<int32_t> &) { /* noop */ }, 0)); }));
-        expect(nothrow([&writer] {
-            expect(writer.try_publish([](const std::span<int32_t> &, std::int64_t) { /* noop */ }, 0));
-        }));
+                expect(writer.available() >= buffer.size());
+                expect(nothrow([&writer] { writer.publish([](const std::span<int32_t> &) { /* noop */ }, 0); }));
+                expect(nothrow([&writer] { writer.publish([](const std::span<int32_t> &, std::int64_t) { /* noop */ }, 0); }));
+                expect(nothrow([&writer] { expect(writer.try_publish([](const std::span<int32_t> &) { /* noop */ }, 0)); }));
+                expect(nothrow([&writer] { expect(writer.try_publish([](const std::span<int32_t> &, std::int64_t) { /* noop */ }, 0)); }));
 
-        // alt expert write interface
-        auto value = writer.reserve_output_range(1);
-        expect(eq(1LU, value.size())) << "for " << typeName;
-        if constexpr (requires { value.publish(1); }) {
-            value.publish(1);
-        }
-    } | std::tuple<gr::test::buffer_skeleton<int32_t>,
-            gr::circular_buffer<int32_t, std::dynamic_extent, gr::ProducerType::Single>,
-            gr::circular_buffer<int32_t, std::dynamic_extent, gr::ProducerType::Multi>>{2, 2, 2};
+                // alt expert write interface
+                auto value = writer.reserve_output_range(1);
+                expect(eq(1LU, value.size())) << "for " << typeName;
+                if constexpr (requires { value.publish(1); }) {
+                    value.publish(1);
+                }
+            }
+            | std::tuple<gr::test::buffer_skeleton<int32_t>, gr::circular_buffer<int32_t, std::dynamic_extent, gr::ProducerType::Single>,
+                         gr::circular_buffer<int32_t, std::dynamic_extent, gr::ProducerType::Multi>>{ 2, 2, 2 };
 };
 
 const boost::ut::suite SequenceTests = [] {
@@ -75,7 +80,7 @@ const boost::ut::suite SequenceTests = [] {
 
     "Sequence"_test = [] {
         using namespace gr;
-        expect(eq(alignof(Sequence), std::size_t{64}));
+        expect(eq(alignof(Sequence), std::size_t{ 64 }));
         expect(eq(-1L, kInitialCursorValue));
         expect(nothrow([] { Sequence(); }));
         expect(nothrow([] { Sequence(2); }));
@@ -84,48 +89,46 @@ const boost::ut::suite SequenceTests = [] {
         expect(eq(s1.value(), kInitialCursorValue));
 
         const auto s2 = Sequence(2);
-        expect(eq(s2.value(), std::int64_t{2}));
+        expect(eq(s2.value(), std::int64_t{ 2 }));
 
         expect(nothrow([&s1] { s1.setValue(3); }));
-        expect(eq(s1.value(), std::int64_t{3}));
+        expect(eq(s1.value(), std::int64_t{ 3 }));
 
         expect(nothrow([&s1] { expect(s1.compareAndSet(3, 4)); }));
-        expect(nothrow([&s1] { expect(eq(s1.value(), std::int64_t{4})); }));
+        expect(nothrow([&s1] { expect(eq(s1.value(), std::int64_t{ 4 })); }));
         expect(nothrow([&s1] { expect(!s1.compareAndSet(3, 5)); }));
-        expect(eq(s1.value(), std::int64_t{4}));
+        expect(eq(s1.value(), std::int64_t{ 4 }));
 
-        expect(eq(s1.incrementAndGet(), std::int64_t{5}));
-        expect(eq(s1.value(), std::int64_t{5}));
-        expect(eq(s1.addAndGet(2), std::int64_t{7}));
-        expect(eq(s1.value(), std::int64_t{7}));
+        expect(eq(s1.incrementAndGet(), std::int64_t{ 5 }));
+        expect(eq(s1.value(), std::int64_t{ 5 }));
+        expect(eq(s1.addAndGet(2), std::int64_t{ 7 }));
+        expect(eq(s1.value(), std::int64_t{ 7 }));
 
-        std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> sequences{
-                std::make_shared<std::vector<std::shared_ptr<Sequence>>>()
-        };
+        std::shared_ptr<std::vector<std::shared_ptr<Sequence>>> sequences{ std::make_shared<std::vector<std::shared_ptr<Sequence>>>() };
         expect(eq(gr::detail::getMinimumSequence(*sequences), std::numeric_limits<std::int64_t>::max()));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), std::int64_t{2}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), std::int64_t{ 2 }));
         sequences->emplace_back(std::make_shared<Sequence>(4));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), std::int64_t{4}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 5), std::int64_t{4}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), std::int64_t{2}));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), std::int64_t{ 4 }));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 5), std::int64_t{ 4 }));
+        expect(eq(gr::detail::getMinimumSequence(*sequences, 2), std::int64_t{ 2 }));
 
         auto cursor = std::make_shared<Sequence>(10);
-        auto s3 = std::make_shared<Sequence>(1);
-        expect(eq(sequences->size(), std::size_t{1}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), std::int64_t{4}));
-        expect(nothrow([&sequences, &cursor, &s3] { gr::detail::addSequences(sequences, *cursor, {s3}); }));
-        expect(eq(sequences->size(), std::size_t{2}));
+        auto s3     = std::make_shared<Sequence>(1);
+        expect(eq(sequences->size(), std::size_t{ 1 }));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), std::int64_t{ 4 }));
+        expect(nothrow([&sequences, &cursor, &s3] { gr::detail::addSequences(sequences, *cursor, { s3 }); }));
+        expect(eq(sequences->size(), std::size_t{ 2 }));
         // newly added sequences are set automatically to the cursor/write position
-        expect(eq(s3->value(), std::int64_t{10}));
-        expect(eq(gr::detail::getMinimumSequence(*sequences), std::int64_t{4}));
+        expect(eq(s3->value(), std::int64_t{ 10 }));
+        expect(eq(gr::detail::getMinimumSequence(*sequences), std::int64_t{ 4 }));
 
         expect(nothrow([&sequences, &cursor] { gr::detail::removeSequence(sequences, cursor); }));
-        expect(eq(sequences->size(), std::size_t{2}));
+        expect(eq(sequences->size(), std::size_t{ 2 }));
         expect(nothrow([&sequences, &s3] { gr::detail::removeSequence(sequences, s3); }));
-        expect(eq(sequences->size(), std::size_t{1}));
+        expect(eq(sequences->size(), std::size_t{ 1 }));
 
         std::stringstream ss;
-        expect(eq(ss.str().size(), std::size_t{0}));
+        expect(eq(ss.str().size(), std::size_t{ 0 }));
         expect(nothrow([&ss, &s3] { ss << fmt::format("{}", *s3); }));
         expect(not ss.str().empty());
     };
@@ -136,9 +139,9 @@ const boost::ut::suite DoubleMappedAllocatorTests = [] {
     using namespace boost::ut;
 
     "DoubleMappedAllocator"_test = [] {
-        using Allocator = std::pmr::polymorphic_allocator<int32_t>;
-        std::size_t size = static_cast<std::size_t>(getpagesize()) / sizeof(int32_t);
-        auto doubleMappedAllocator = gr::double_mapped_memory_resource::allocator<int32_t>();
+        using Allocator                                       = std::pmr::polymorphic_allocator<int32_t>;
+        std::size_t                     size                  = static_cast<std::size_t>(getpagesize()) / sizeof(int32_t);
+        auto                            doubleMappedAllocator = gr::double_mapped_memory_resource::allocator<int32_t>();
         std::vector<int32_t, Allocator> vec(size, doubleMappedAllocator);
         expect(eq(vec.size(), size));
         std::iota(vec.begin(), vec.end(), 1);
@@ -185,12 +188,12 @@ const boost::ut::suite UserApiExamples = [] {
 
     "UserApi"_test = [] {
         using namespace gr;
-        Buffer auto buffer = circular_buffer<int32_t>(1024);
+        Buffer auto       buffer = circular_buffer<int32_t>(1024);
 
         BufferWriter auto writer = buffer.new_writer();
         { // source only write example
             BufferReader auto localReader = buffer.new_reader();
-            expect(eq(localReader.available(), std::size_t{0}));
+            expect(eq(localReader.available(), std::size_t{ 0 }));
 
             auto lambda = [](auto w) { // test writer generating consecutive samples
                 static int offset = 1;
@@ -201,15 +204,15 @@ const boost::ut::suite UserApiExamples = [] {
             expect(ge(writer.available(), buffer.size()));
             writer.publish(lambda, 10);
             expect(eq(writer.available(), buffer.size() - 10));
-            expect(eq(localReader.available(), std::size_t{10}));
-            expect(eq(buffer.n_readers(), std::size_t{1})); // N.B. circular_buffer<..> specific
+            expect(eq(localReader.available(), std::size_t{ 10 }));
+            expect(eq(buffer.n_readers(), std::size_t{ 1 })); // N.B. circular_buffer<..> specific
         }
-        expect(eq(buffer.n_readers(), std::size_t{0})); // reader not in scope release atomic reader index
+        expect(eq(buffer.n_readers(), std::size_t{ 0 }));     // reader not in scope release atomic reader index
 
         BufferReader auto reader = buffer.new_reader();
         // reader does not know about previous submitted data as it joined only after
         // data has been written <-> needed for thread-safe joining of readers while writing
-        expect(eq(reader.available(), std::size_t{0}));
+        expect(eq(reader.available(), std::size_t{ 0 }));
         // populate with some more data
         for (std::size_t i = 0; i < 3; i++) {
             const auto demoWriter = [](auto w) {
@@ -224,9 +227,8 @@ const boost::ut::suite UserApiExamples = [] {
         // N.B. here using a simple read-only (sink) example:
         for (int i = 0; reader.available() != 0; i++) {
             std::span<const int32_t> fixedLength = reader.get(3); // explicitly typed for illustration
-            auto available = reader.get();
-            fmt::print("iteration {} - fixed-size data[{:2}]: [{}]\n", i, fixedLength.size(),
-                       fmt::join(fixedLength, ", "));
+            auto                     available   = reader.get();
+            fmt::print("iteration {} - fixed-size data[{:2}]: [{}]\n", i, fixedLength.size(), fmt::join(fixedLength, ", "));
             fmt::print("iteration {} - full-size  data[{:2}]: [{}]\n", i, available.size(), fmt::join(available, ", "));
 
             // consume data -> allows corresponding buffer to be overwritten by writer
@@ -234,8 +236,7 @@ const boost::ut::suite UserApiExamples = [] {
             if (reader.consume(fixedLength.size())) {
                 // for info-only - since available() can change in parallel
                 // N.B. lock-free buffer and other writer may add while processing
-                fmt::print("iteration {} - consumed {} elements - still available: {}\n", i, fixedLength.size(),
-                           reader.available());
+                fmt::print("iteration {} - consumed {} elements - still available: {}\n", i, fixedLength.size(), reader.available());
             } else {
                 throw std::runtime_error(fmt::format("could not consume data"));
             }
@@ -247,113 +248,114 @@ const boost::ut::suite CircularBufferTests = [] {
     using namespace boost::ut;
     using Allocator = std::pmr::polymorphic_allocator<int32_t>;
 
-    "CircularBuffer"_test = [](const Allocator &allocator) {
-        using namespace gr;
-        Buffer auto buffer = circular_buffer<int32_t>(1024, allocator);
-        expect(ge(buffer.size(), 1024));
+    "CircularBuffer"_test =
+            [](const Allocator &allocator) {
+                using namespace gr;
+                Buffer auto buffer = circular_buffer<int32_t>(1024, allocator);
+                expect(ge(buffer.size(), 1024));
 
-        BufferWriter auto writer = buffer.new_writer();
-        expect(nothrow([&writer] { expect(eq(writer.buffer().n_readers(), std::size_t{0})); })); // no reader, just writer
-        BufferReader auto reader = buffer.new_reader();
-        expect(nothrow([&reader] { expect(eq(reader.buffer().n_readers(), std::size_t{1})); })); // created one reader
+                BufferWriter auto writer = buffer.new_writer();
+                expect(nothrow([&writer] { expect(eq(writer.buffer().n_readers(), std::size_t{ 0 })); })); // no reader, just writer
+                BufferReader auto reader = buffer.new_reader();
+                expect(nothrow([&reader] { expect(eq(reader.buffer().n_readers(), std::size_t{ 1 })); })); // created one reader
 
-        int offset = 1;
-        auto lambda = [&offset](auto w) {
-            std::iota(w.begin(), w.end(), offset);
-            offset += w.size();
-        };
+                int  offset = 1;
+                auto lambda = [&offset](auto w) {
+                    std::iota(w.begin(), w.end(), offset);
+                    offset += w.size();
+                };
 
-        expect(eq(reader.available(), std::size_t{0}));
-        expect(eq(reader.get().size(), std::size_t{0}));
-        expect(eq(reader.get(1).size(), std::size_t{0}));
-        expect(eq(writer.available(), buffer.size()));
-        expect(not reader.consume(1)); // false: no data available yet
-        expect(nothrow([&writer, &lambda, &buffer] { writer.publish(lambda, buffer.size()); })); // fully fill buffer
+                expect(eq(reader.available(), std::size_t{ 0 }));
+                expect(eq(reader.get().size(), std::size_t{ 0 }));
+                expect(eq(reader.get(1).size(), std::size_t{ 0 }));
+                expect(eq(writer.available(), buffer.size()));
+                expect(not reader.consume(1));                                                           // false: no data available yet
+                expect(nothrow([&writer, &lambda, &buffer] { writer.publish(lambda, buffer.size()); })); // fully fill buffer
 
-        expect(eq(writer.available(), std::size_t{0}));
-        expect(eq(reader.available(), buffer.size()));
-        expect(eq(reader.get().size(), buffer.size()));
-        expect(eq(reader.get(1).size(), std::size_t{1}));
+                expect(eq(writer.available(), std::size_t{ 0 }));
+                expect(eq(reader.available(), buffer.size()));
+                expect(eq(reader.get().size(), buffer.size()));
+                expect(eq(reader.get(1).size(), std::size_t{ 1 }));
 
-        // full buffer: fill buffer need to fail/return 'false'
-        expect(not writer.try_publish(lambda, buffer.size()));
+                // full buffer: fill buffer need to fail/return 'false'
+                expect(not writer.try_publish(lambda, buffer.size()));
 
-        expect(reader.consume(buffer.size()));
-        expect(eq(reader.available(), std::size_t{0}));
-        expect(eq(writer.available(), buffer.size()));
+                expect(reader.consume(buffer.size()));
+                expect(eq(reader.available(), std::size_t{ 0 }));
+                expect(eq(writer.available(), buffer.size()));
 
-        // test buffer wrap around twice
-        std::size_t counter = 1;
-        for (const int _blockSize: {1, 2, 3, 5, 7, 42}) {
-            auto blockSize = static_cast<std::size_t>(_blockSize);
-            for (std::size_t i = 0; i < buffer.size(); i++) {
-                expect(writer.try_publish([&counter](auto &writable) {
-                    std::iota(writable.begin(), writable.end(), counter += writable.size());
-                }, blockSize));
-                auto readable = reader.get();
-                expect(eq(readable.size(), blockSize));
-                expect(eq(readable.front(), static_cast<int>(counter)));
-                expect(eq(readable.back(), static_cast<int>(counter + blockSize - 1)));
-                expect(reader.consume(blockSize));
+                // test buffer wrap around twice
+                std::size_t counter = 1;
+                for (const int _blockSize : { 1, 2, 3, 5, 7, 42 }) {
+                    auto blockSize = static_cast<std::size_t>(_blockSize);
+                    for (std::size_t i = 0; i < buffer.size(); i++) {
+                        expect(writer.try_publish([&counter](auto &writable) { std::iota(writable.begin(), writable.end(), counter += writable.size()); }, blockSize));
+                        auto readable = reader.get();
+                        expect(eq(readable.size(), blockSize));
+                        expect(eq(readable.front(), static_cast<int>(counter)));
+                        expect(eq(readable.back(), static_cast<int>(counter + blockSize - 1)));
+                        expect(reader.consume(blockSize));
+                    }
+                }
+
+                // basic expert writer api
+                for (int k = 0; k < 3; k++) {
+                    // case 0: write fully reserved data
+                    auto data = writer.reserve_output_range(4);
+                    for (std::size_t i = 0; i < data.size(); i++) {
+                        data[i] = static_cast<int>(i + 1);
+                    }
+                    data.publish(4);
+                    auto read_data = reader.get();
+                    expect(eq(read_data.size(), std::size_t{ 4 }));
+                    for (std::size_t i = 0; i < data.size(); i++) {
+                        expect(eq(static_cast<int>(i + 1), read_data[i])) << "case 0: read index " << i;
+                    }
+                    expect(reader.consume(4));
+                }
+                for (int k = 0; k < 3; k++) {
+                    // case 1: reserve more than actually written
+                    const auto cursor_initial = buffer.cursor_sequence().value();
+                    auto       data           = writer.reserve_output_range(4);
+                    for (std::size_t i = 0; i < data.size(); i++) {
+                        data[i] = static_cast<int>(i + 1);
+                    }
+                    data.publish(2);
+                    const auto cursor_after = buffer.cursor_sequence().value();
+                    expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
+                    auto read_data = reader.get();
+                    expect(eq(std::size_t{ 2 }, read_data.size())) << fmt::format("received {} samples instead of expected 2", read_data.size());
+                    for (std::size_t i = 0; i < data.size(); i++) {
+                        expect(eq(static_cast<int>(i + 1), read_data[i])) << "read 1: index " << i;
+                    }
+                    expect(reader.consume(2));
+                }
+                for (int k = 0; k < 3; k++) {
+                    // case 2: reserve using RAII token
+                    const auto         cursor_initial = buffer.cursor_sequence().value();
+                    auto               data           = writer.reserve_output_range(4);
+                    std::span<int32_t> span           = data; // tests conversion operator
+                    for (std::size_t i = 0; i < data.size(); i++) {
+                        data[i] = static_cast<int>(i + 1);
+                        expect(eq(data[i], span[i]));
+                    }
+                    data.publish(2);
+                    const auto cursor_after = buffer.cursor_sequence().value();
+                    expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
+                    auto read_data = reader.get();
+                    expect(eq(std::size_t{ 2 }, read_data.size())) << fmt::format("received {} samples instead of expected 2", read_data.size());
+                    for (std::size_t i = 0; i < data.size(); i++) {
+                        expect(eq(static_cast<int>(i + 1), read_data[i])) << "read 1: index " << i;
+                    }
+                    expect(reader.consume(2));
+                }
             }
-        }
-
-        // basic expert writer api
-        for (int k = 0; k < 3; k++) {
-            // case 0: write fully reserved data
-            auto data = writer.reserve_output_range(4);
-            for (std::size_t i = 0; i < data.size(); i++) {
-                data[i] = static_cast<int>(i + 1);
-            }
-            data.publish(4);
-            auto read_data = reader.get();
-            expect(eq(read_data.size(), std::size_t{4}));
-            for (std::size_t i = 0; i < data.size(); i++) {
-                expect(eq(static_cast<int>(i + 1), read_data[i])) << "case 0: read index " << i;
-            }
-            expect(reader.consume(4));
-        }
-        for (int k = 0; k < 3; k++) {
-            // case 1: reserve more than actually written
-            const auto cursor_initial = buffer.cursor_sequence().value();
-            auto data = writer.reserve_output_range(4);
-            for (std::size_t i = 0; i < data.size(); i++) {
-                data[i] = static_cast<int>(i + 1);
-            }
-            data.publish(2);
-            const auto cursor_after = buffer.cursor_sequence().value();
-            expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
-            auto read_data = reader.get();
-            expect(eq(std::size_t{2}, read_data.size())) << fmt::format("received {} samples instead of expected 2", read_data.size());
-            for (std::size_t i = 0; i < data.size(); i++) {
-                expect(eq(static_cast<int>(i + 1), read_data[i])) << "read 1: index " << i;
-            }
-            expect(reader.consume(2));
-        }
-        for (int k = 0; k < 3; k++) {
-            // case 2: reserve using RAII token
-            const auto cursor_initial = buffer.cursor_sequence().value();
-            auto data = writer.reserve_output_range(4);
-            std::span<int32_t> span = data; // tests conversion operator
-            for (std::size_t i = 0; i < data.size(); i++) {
-                data[i] = static_cast<int>(i + 1);
-                expect(eq(data[i], span[i]));
-            }
-            data.publish(2);
-            const auto cursor_after = buffer.cursor_sequence().value();
-            expect(eq(cursor_initial + 2, cursor_after)) << fmt::format("cursor sequence moving by two: {} -> {}", cursor_initial, cursor_after);
-            auto read_data = reader.get();
-            expect(eq(std::size_t{2}, read_data.size())) << fmt::format("received {} samples instead of expected 2", read_data.size());
-            for (std::size_t i = 0; i < data.size(); i++) {
-                expect(eq(static_cast<int>(i + 1), read_data[i])) << "read 1: index " << i;
-            }
-            expect(reader.consume(2));
-        }
-    } | std::vector{
+            | std::vector{
 #ifndef __EMSCRIPTEN__
-        Allocator(gr::double_mapped_memory_resource::allocator<int32_t>()),
+                  Allocator(gr::double_mapped_memory_resource::allocator<int32_t>()),
 #endif
-        Allocator()};
+                  Allocator()
+              };
 };
 
 const boost::ut::suite CircularBufferExceptionTests = [] {
@@ -371,7 +373,7 @@ const boost::ut::suite CircularBufferExceptionTests = [] {
         expect(throws<std::exception>([&writer] { writer.try_publish([](auto &) { throw std::exception(); }); }));
         expect(throws<std::runtime_error>([&writer] { writer.try_publish([](auto &) { throw ""; }); }));
 
-        expect(eq(reader.available(), std::size_t{0})); // needed otherwise buffer write will not be called
+        expect(eq(reader.available(), std::size_t{ 0 })); // needed otherwise buffer write will not be called
     };
 };
 
@@ -385,19 +387,21 @@ const boost::ut::suite UserDefinedTypeCasting = [] {
         BufferWriter auto writer = buffer.new_writer();
         BufferReader auto reader = buffer.new_reader();
 
-        writer.publish([](auto &w) {
-            w[0] = std::complex(1.0f, -1.0f);
-            w[1] = std::complex(2.0f, -2.0f);
-        }, 2);
-        expect(eq(reader.available(), std::size_t{2}));
+        writer.publish(
+                [](auto &w) {
+                    w[0] = std::complex(1.0f, -1.0f);
+                    w[1] = std::complex(2.0f, -2.0f);
+                },
+                2);
+        expect(eq(reader.available(), std::size_t{ 2 }));
         std::span<const std::complex<float>> data = reader.get();
-        expect(eq(data.size(), std::size_t{2}));
+        expect(eq(data.size(), std::size_t{ 2 }));
 
         auto const const_bytes = std::as_bytes(data);
         expect(eq(const_bytes.size(), data.size() * sizeof(std::complex<float>)));
 
         auto convertToFloatSpan = [](std::span<const std::complex<float>> &c) -> std::span<const float> {
-            return {reinterpret_cast<const float *>(c.data()), c.size() * 2}; //NOSONAR(cpp:S3630) //NOPMD needed
+            return { reinterpret_cast<const float *>(c.data()), c.size() * 2 }; // NOSONAR(cpp:S3630) //NOPMD needed
         };
         auto floatArray = convertToFloatSpan(data);
         expect(eq(floatArray[0], +1.0f));
@@ -406,7 +410,7 @@ const boost::ut::suite UserDefinedTypeCasting = [] {
         expect(eq(floatArray[3], -2.0f));
 
         expect(reader.consume(data.size()));
-        expect(eq(reader.available(), std::size_t{0})); // needed otherwise buffer write will not be called
+        expect(eq(reader.available(), std::size_t{ 0 })); // needed otherwise buffer write will not be called
     };
 };
 
@@ -419,19 +423,18 @@ const boost::ut::suite StreamTagConcept = [] {
         struct alignas(gr::hardware_destructive_interference_size) buffer_tag {
             // N.B. type need to be favourably sized e.g. 1 or a power of 2
             // -> otherwise the automatic buffer sizes are getting very large
-            int64_t index;
+            int64_t     index;
             std::string data;
         };
 
-        expect(eq(sizeof(buffer_tag), std::size_t{64})) << "tag size";
-        Buffer auto buffer = circular_buffer<int32_t>(1024);
+        expect(eq(sizeof(buffer_tag), std::size_t{ 64 })) << "tag size";
+        Buffer auto buffer    = circular_buffer<int32_t>(1024);
         Buffer auto tagBuffer = circular_buffer<buffer_tag>(32);
         expect(ge(buffer.size(), 1024));
         expect(ge(tagBuffer.size(), 32));
 
-
-        BufferWriter auto writer = buffer.new_writer();
-        BufferReader auto reader = buffer.new_reader();
+        BufferWriter auto writer    = buffer.new_writer();
+        BufferReader auto reader    = buffer.new_reader();
         BufferWriter auto tagWriter = tagBuffer.new_writer();
         BufferReader auto tagReader = tagBuffer.new_reader();
 
@@ -442,9 +445,7 @@ const boost::ut::suite StreamTagConcept = [] {
                 offset += w.size();
 
                 // read/generated by some method (e.g. reading another buffer)
-                tagWriter.publish([&writePosition](auto &writeTag) {
-                    writeTag[0] = {writePosition, fmt::format("<tag data at index {:3}>", writePosition)};
-                }, 1);
+                tagWriter.publish([&writePosition](auto &writeTag) { writeTag[0] = { writePosition, fmt::format("<tag data at index {:3}>", writePosition) }; }, 1);
             };
 
             writer.publish(lambda, 10); // optional return param.
@@ -453,7 +454,7 @@ const boost::ut::suite StreamTagConcept = [] {
         { // read-only worker (sink) mock-up
             fmt::print("read position: {}\n", reader.position());
             const auto readData = reader.get();
-            const auto tags = tagReader.get();
+            const auto tags     = tagReader.get();
 
             fmt::print("received {} tags\n", tags.size());
             for (auto &readTag : tags) {
@@ -513,6 +514,98 @@ const boost::ut::suite NonPowerTwoTests = [] {
         readSamples();
         genSamples();
         readSamples();
+    };
+};
+
+const boost::ut::suite HistoryBufferTest = [] {
+    using namespace boost::ut;
+    using namespace gr;
+
+    "history_buffer<double>"_test = [](const std::size_t &capacity) {
+        history_buffer<int> hb(capacity);
+        expect(eq(hb.capacity(), capacity));
+        expect(eq(hb.size(), 0));
+
+        for (std::size_t i = 1; i <= capacity + 1; ++i) {
+            hb.push_back(static_cast<int>(i));
+        }
+        expect(eq(hb.capacity(), capacity));
+        expect(eq(hb.size(), capacity));
+
+        expect(eq(hb[0], capacity + 1)) << "access the last/actual sample";
+        expect(eq(hb[-1], capacity)) << "access the previous sample";
+
+        expect(eq(hb.at(0), capacity + 1)) << "checked access the last/actual sample";
+        expect(eq(hb.at(-1), capacity)) << "checked access the previous sample";
+    } | std::vector<std::size_t>{ 5, 3, 10 };
+
+    "history_buffer - range tests"_test = [] {
+        history_buffer<int> hb(5);
+        hb.push_back_bulk(std::array{ 1, 2, 3 });
+        hb.push_back_bulk(std::vector{ 4, 5, 6 });
+        expect(eq(hb.capacity(), 5));
+        expect(eq(hb.size(), 5));
+
+        auto equal = [](const auto &range1, const auto &range2) { // N.B. TODO replacement until libc++ fully supports ranges
+            return std::equal(range1.begin(), range1.end(), range2.begin(), range2.end());
+        };
+
+        expect(equal(hb.get_span(0, 3), std::vector{ 4, 5, 6 })) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(0, 3), ", "));
+        expect(equal(hb.get_span(-1, 3), std::vector{ 3, 4, 5 })) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(1, 3), ", "));
+
+        expect(equal(hb.get_span(0), std::vector{ 2, 3, 4, 5, 6 })) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(0), ", "));
+        expect(equal(hb.get_span(-1), std::vector{ 2, 3, 4, 5 })) << fmt::format("failed - got [{}]", fmt::join(hb.get_span(1), ", "));
+
+        std::vector<int> forward_bracket;
+        for (int64_t i = 1 - static_cast<int64_t>(hb.size()); i <= 0; i++) {
+            forward_bracket.push_back(hb[i]);
+        }
+        expect(equal(forward_bracket, std::vector{ 2, 3, 4, 5, 6 })) << fmt::format("failed - got [{}]", fmt::join(forward_bracket, ", "));
+
+        std::vector<int> forward(hb.begin(), hb.end());
+        expect(equal(forward, std::vector{ 2, 3, 4, 5, 6 })) << fmt::format("failed - got [{}]", fmt::join(forward, ", "));
+
+        std::vector<int> reverse(hb.rbegin(), hb.rend());
+        expect(equal(reverse, std::vector{ 6, 5, 4, 3, 2 })) << fmt::format("failed - got [{}]", fmt::join(reverse, ", "));
+
+        expect(equal(std::vector(hb.cbegin(), hb.cend()), std::vector(hb.begin(), hb.end()))) << "const non-const iterator equivalency";
+        expect(equal(std::vector(hb.crbegin(), hb.crend()), std::vector(hb.rbegin(), hb.rend()))) << "const non-const iterator equivalency";
+    };
+
+    "history_buffer<T> edge cases"_test = [] {
+        fmt::print("\n\ntesting edge cases:\n");
+        expect(throws<std::out_of_range>([] { history_buffer<int>(0); })) << "throws for 0 capacity";
+
+        // Create a history buffer of size 1
+        history_buffer<int> hb_one(1);
+        expect(eq(hb_one.capacity(), 1));
+        expect(eq(hb_one.size(), 0));
+        hb_one.push_back(41);
+        hb_one.push_back(42);
+        expect(eq(hb_one.capacity(), 1));
+        expect(eq(hb_one.size(), 1));
+        expect(eq(hb_one[0], 42));
+
+        expect(throws<std::out_of_range>([&hb_one] { [[maybe_unused]] auto a = hb_one.at(1); })) << "throws for index > 0";
+        expect(throws<std::out_of_range>([&hb_one] { [[maybe_unused]] auto a = hb_one.at(-2); })) << "throws for index > 0";
+
+        // Push more elements than buffer size
+        history_buffer<int> hb_overflow(5);
+        auto                in = std::vector{ 1, 2, 3, 4, 5, 6 };
+        hb_overflow.push_back_bulk(in.begin(), in.end());
+        expect(eq(hb_overflow[0], 6));
+        hb_overflow.push_back_bulk(std::vector{ 7, 8, 9 });
+        expect(eq(hb_overflow[0], 9));
+        hb_overflow.push_back_bulk(std::array{ 10, 11, 12 });
+        expect(eq(hb_overflow[0], 12));
+
+        // Test with different types, e.g., double
+        history_buffer<double> hb_double(5);
+        for (int i = 0; i < 10; ++i) {
+            hb_double.push_back(i * 0.1);
+        }
+        expect(eq(hb_double.capacity(), 5));
+        expect(eq(hb_double.size(), 5));
     };
 };
 

--- a/test/qa_filter.cpp
+++ b/test/qa_filter.cpp
@@ -1,0 +1,135 @@
+#include <boost/ut.hpp>
+
+#if defined(__clang__) && __clang_major__ >= 16
+// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
+template<>
+auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
+#endif
+
+#include "blocklib/core/filter/time_domain_filter.hpp"
+#include <fmt/format.h>
+#include <node.hpp>
+
+namespace fg = fair::graph;
+
+template<typename T, typename Range>
+    requires std::floating_point<T>
+constexpr size_t
+estimate_settling_time(const Range &step_response, std::size_t offset = 0, T step_value = 1.0, T threshold = 0.001) {
+    if (offset >= step_response.size()) {
+        throw std::out_of_range("Offset is greater than the size of the step response.");
+    }
+    const T lower_bound = step_value - threshold;
+    const T upper_bound = step_value + threshold;
+
+    auto    begin       = step_response.begin() + offset;
+    auto    end         = step_response.end();
+
+    auto    it          = std::find_if(begin, end, [lower_bound, upper_bound](T sample) { return sample >= lower_bound && sample <= upper_bound; });
+
+    // If no such sample is found, return an error
+    if (it == end) {
+        throw std::runtime_error("No settling found within the given threshold.");
+    }
+
+    // Check if all subsequent samples stay within the acceptable range
+    auto it_next = it;
+    while (it_next != end) {
+        it_next = std::find_if(it_next, end, [lower_bound, upper_bound](T sample) { return sample < lower_bound || sample > upper_bound; });
+
+        if (it_next != end) {
+            it = it_next++;
+        }
+    }
+
+    // Return the settling time (or index)
+    return std::distance(begin, it);
+}
+
+const boost::ut::suite SequenceTests = [] {
+    using namespace boost::ut;
+    using namespace gr::blocks::filter;
+
+    "FIR and IIR general tests"_test = [] {
+        std::vector<double> fir_coeffs(10, 0.1); // box car filter
+        std::vector<double> iir_coeffs_b{ 0.55, 0 };
+        std::vector<double> iir_coeffs_a{ 1, -0.45 };
+
+        // Create FIR and IIR filter instances
+        fir_filter<double> fir_filter;
+        fir_filter.b = fir_coeffs;
+
+        iir_filter<double, IIRForm::DF_I> iir_filter1;
+        iir_filter1.b = iir_coeffs_b;
+        iir_filter1.a = iir_coeffs_a;
+        iir_filter<double, IIRForm::DF_II> iir_filter2;
+        iir_filter2.b = iir_coeffs_b;
+        iir_filter2.a = iir_coeffs_a;
+
+        std::vector<double> fir_response;
+        std::vector<double> iir_response1;
+        std::vector<double> iir_response2;
+        for (std::size_t i = 0UL; i < 20; ++i) {
+            const double input = (i == 0) ? 0.0 : 1.0; // Step function
+
+            fir_response.push_back(fir_filter.process_one(input));
+            iir_response1.push_back(iir_filter1.process_one(input));
+            iir_response2.push_back(iir_filter1.process_one(input));
+        }
+        expect(eq(fir_response[0], 0.0));
+        expect(eq(iir_response1[0], 0.0));
+        expect(eq(iir_response2[0], 0.0));
+
+        const std::size_t fir_settling_time  = estimate_settling_time<double>(fir_response);
+        const std::size_t iir_settling_time1 = estimate_settling_time<double>(iir_response1);
+        const std::size_t iir_settling_time2 = estimate_settling_time<double>(iir_response2);
+        expect(eq(fir_settling_time, 10)) << "FIR settling time";
+        expect(eq(iir_settling_time1, 5)) << "IIR (I) settling time";
+        expect(eq(iir_settling_time2, 5)) << "IIR (II) settling time";
+
+        //        fmt::print("FIR      filter settling time: {} ms\n", fir_settling_time);
+        //        fmt::print("IIR (I)  filter settling time: {} ms\n", iir_settling_time1);
+        //        fmt::print("IIR (II) filter settling time: {} ms\n", iir_settling_time2);
+    };
+
+    "IIR equality tests"_test = [] {
+        //        std::vector<double>              iir_coeffs_b{ 0.55, 0 };
+        //        std::vector<double>              iir_coeffs_a{ 1, -0.45 };
+        std::vector<double>               iir_coeffs_b{ 0.020083365564211, 0.040166731128423, 0.020083365564211 };
+        std::vector<double>               iir_coeffs_a{ 1.0, -1.561018075800718, 0.641351538057563 };
+
+        iir_filter<double, IIRForm::DF_I> iir_filter_I;
+        iir_filter_I.b = iir_coeffs_b;
+        iir_filter_I.a = iir_coeffs_a;
+        iir_filter<double, IIRForm::DF_II> iir_filter_II;
+        iir_filter_II.b = iir_coeffs_b;
+        iir_filter_II.a = iir_coeffs_a;
+        iir_filter<double, IIRForm::DF_I_TRANSPOSED> iir_filter_IT;
+        iir_filter_IT.b = iir_coeffs_b;
+        iir_filter_IT.a = iir_coeffs_a;
+        iir_filter<double, IIRForm::DF_II_TRANSPOSED> iir_filter_IIT;
+        iir_filter_IIT.b           = iir_coeffs_b;
+        iir_filter_IIT.a           = iir_coeffs_a;
+
+        constexpr double tolerance = 0.00001;
+        for (std::size_t i = 0UL; i < 20; ++i) {
+            const double input     = (i == 0) ? 0.0 : 1.0; // Step function
+            const auto   form_I    = iir_filter_I.process_one(input);
+            const auto   form_II   = iir_filter_II.process_one(input);
+            const auto   form_I_T  = iir_filter_IT.process_one(input);
+            const auto   form_II_T = iir_filter_IIT.process_one(input);
+            expect(approx(form_II, form_I, tolerance)) << "direct form II";
+            expect(approx(form_I_T, form_I, tolerance)) << "direct form I - transposed";
+            expect(approx(form_II_T, form_I, tolerance)) << "direct form II - transposed";
+
+#if defined(__GNUC__) && !defined(__OPTIMIZE__)
+            fmt::print("input[{:2}]={}-> IIR= {:4.2f} (I) {:4.2f} (II) {:4.2f} (I-T) {:4.2f} (II-T)\n", //
+                       i, input, form_I, form_II, form_I_T, form_II_T);
+#endif
+        }
+    };
+};
+
+int
+main() { /* not needed for UT */
+}


### PR DESCRIPTION
History buffer syntax:
```cpp
gr::history_buffer<int, 5> buffer;
buffer.push_back(1);  // buffer: [1] (size: 1, capacity: 5)
buffer.push_back(2);  // buffer: [1, 2] (size: 2, capacity: 5)
buffer.push_back(3);  // buffer: [1, 2, 3] (size: 3, capacity: 5)
buffer.push_back(4);  // buffer: [1, 2, 3, 4] (size: 4, capacity: 5)
buffer.push_back(5);  // buffer: [1, 2, 3, 4, 5] (size: 5, capacity: 5)
buffer.push_back(6);  // buffer: [2, 3, 4, 5, 6] (size: 5, capacity: 5)

 // indexing:
 buffer[0];     // value: 6 - unchecked access of last/actual sample
 buffer[-1];    // value: 5 - unchecked access of previous sample
// ...
buffer.at(0);  // value: 6 - checked access of last/actual sample
buffer.at(-1); // value: 5 - checked access of last/actual sample
// ...
buffer.get_span(0, 3);  // span: [4, 5, 6]
buffer.get_span(1, 3);  // span: [3, 4, 5]
buffer.get_span(0);     // span: [2, 3, 4, 5, 6]
buffer.get_span(1);     // span: [2, 3, 4, 5]
```

example use (here [FIR](https://github.com/fair-acc/graph-prototype/blob/a396bda164c7415da625fd48b073de87fc45a3d1/test/blocklib/core/filter/time_domain_filter.hpp#L12-L39
)):

```cpp
template<typename T> 
     requires std::floating_point<T> 
 struct fir_filter : node<fir_filter<T>> { 
     IN<T>             in; 
     OUT<T>            out; 
     std::vector<T>    b{}; // feedforward coefficients 
     history_buffer<T> inputHistory{ 32 }; 
  
     void 
     init(const tag_t::map_type & /*old_settings*/, const tag_t::map_type &new_settings) noexcept { 
         if (new_settings.contains("b") && b.size() >= inputHistory.capacity()) { 
             inputHistory = history_buffer<T>(std::bit_ceil(b.size())); 
         } 
     } 
  
     constexpr T 
     process_one(T input) noexcept { 
         inputHistory.push_back(input); 
         return std::inner_product(b.begin(), b.end(), inputHistory.rbegin(), static_cast<T>(0)); 
     } 
 }; 
 ```
