### PR TITLE
 Annotated<T, ...> interface to enhance in-code block and parameter field documentation

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -85,9 +85,9 @@ jobs:
         git clone https://github.com/emscripten-core/emsdk.git
         cd emsdk
         # Download and install the latest SDK tools.
-        ./emsdk install latest
+        ./emsdk install releases-03ecb526947f6a3702a0d083083799fe410d3893-64bit
         # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
-        ./emsdk activate latest
+        ./emsdk activate releases-03ecb526947f6a3702a0d083083799fe410d3893-64bit
         # Activate PATH and other environment variables in the current terminal
         source ./emsdk_env.sh
         emcc -v

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -139,4 +139,4 @@ jobs:
       shell: bash
       run: |
         source ~/emsdk/emsdk_env.sh
-        ${EMSDK_NODE} ./src/main.js
+        node ./src/main.js

--- a/include/annotated.hpp
+++ b/include/annotated.hpp
@@ -1,0 +1,167 @@
+#ifndef GRAPH_PROTOTYPE_ANNOTATED_HPP
+#define GRAPH_PROTOTYPE_ANNOTATED_HPP
+
+#include <string_view>
+#include <type_traits>
+#include <utils.hpp>
+
+namespace fair::graph {
+
+/**
+ * @brief a template wrapping structure, which holds a static documentation (e.g. mark down) string as its value.
+ * It's used as a trait class to annotate other template classes (e.g. blocks or fields).
+ */
+template<fair::meta::fixed_string doc_string>
+struct Doc {
+    static constexpr fair::meta::fixed_string value = doc_string;
+};
+
+using EmptyDoc = Doc<"">; // nomen-est-omen
+
+template<typename T>
+struct is_doc : std::false_type {};
+
+template<fair::meta::fixed_string N>
+struct is_doc<Doc<N>> : std::true_type {};
+
+template<typename T>
+concept Documentation = is_doc<T>::value;
+
+/**
+ * @brief Unit is a template structure, which holds a static physical-unit (i.e. SI unit) string as its value.
+ * It's used as a trait class to annotate other template classes (e.g. blocks or fields).
+ */
+template<fair::meta::fixed_string doc_string>
+struct Unit {
+    static constexpr fair::meta::fixed_string value = doc_string;
+};
+
+using EmptyUnit = Unit<"">; // nomen-est-omen
+
+template<typename T>
+struct is_unit : std::false_type {};
+
+template<fair::meta::fixed_string N>
+struct is_unit<Unit<N>> : std::true_type {};
+
+template<typename T>
+concept UnitType = is_unit<T>::value;
+
+static_assert(Documentation<EmptyDoc>);
+static_assert(UnitType<EmptyUnit>);
+static_assert(!UnitType<EmptyDoc>);
+static_assert(!Documentation<EmptyUnit>);
+
+/**
+ * @brief A simple class to annotate field etc. to denotes that the entity is visible.
+ */
+struct Visible {};
+
+/**
+ * @brief Annotated is a template class that acts as a transparent wrapper around another type.
+ * It allows adding additional meta-information to a type, such as documentation, unit, and visibility.
+ * The meta-information is supplied as template parameters.
+ */
+template<typename T, fair::meta::fixed_string description_ = "", typename... Arguments>
+struct Annotated {
+    using value_type = T;
+    T value{};
+
+    Annotated() = default;
+
+    constexpr Annotated(const T &value_) noexcept : value(value_) {}
+
+    constexpr Annotated(T &&value_) noexcept : value(std::move(value_)) {}
+
+    // N.B. intentional implicit assignment and conversion operators to have a transparent wrapper
+    // this does not affect the conversion of the wrapped value type 'T' itself
+    constexpr Annotated &
+    operator=(const T &value_) noexcept {
+        value = value_;
+        return *this;
+    }
+
+    constexpr Annotated &
+    operator=(T &&value_) noexcept {
+        value = std::move(value_);
+        return *this;
+    }
+
+    inline constexpr
+    operator T &() noexcept {
+        return value;
+    }
+
+    inline constexpr operator const T &() const noexcept { return value; }
+
+    constexpr bool
+    operator==(const Annotated &other) const noexcept {
+        return value == other.value;
+    }
+
+    template<typename U>
+    constexpr bool
+    operator==(const U &other) const noexcept {
+        if constexpr (requires { other.value; }) {
+            return value == other.value;
+        } else {
+            return value == other;
+        }
+    }
+
+    // meta-information
+    constexpr std::string_view
+    description() const noexcept {
+        return std::string_view{ description_ };
+    }
+
+    constexpr std::string_view
+    documentation() const noexcept {
+        using Documentation = typename fair::meta::find_type_or_default<is_doc, EmptyDoc, Arguments...>::type;
+        return std::string_view{ Documentation::value };
+    }
+
+    constexpr std::string_view
+    unit() const noexcept {
+        using PhysicalUnit = typename fair::meta::find_type_or_default<is_unit, EmptyUnit, Arguments...>::type;
+        return std::string_view{ PhysicalUnit::value };
+    }
+
+    constexpr bool
+    visible() const noexcept {
+        return std::disjunction_v<std::is_same<Visible, Arguments>...>;
+    }
+};
+
+template<typename T>
+struct is_annotated : std::false_type {};
+
+template<typename T, fair::meta::fixed_string str, typename... Args>
+struct is_annotated<fair::graph::Annotated<T, str, Args...>> : std::true_type {};
+
+template<typename T>
+concept AnnotatedType = is_annotated<T>::value;
+
+template<typename T>
+struct inner_type {
+    using type = T;
+};
+
+template<typename U, fair::meta::fixed_string str, typename... Args>
+struct inner_type<fair::graph::Annotated<U, str, Args...>> {
+    using type = U;
+};
+
+/**
+ * @brief A type trait class that extracts the underlying type `T` from an `Annotated` instance.
+ * If the given type is not an `Annotated`, it returns the type itself.
+ */
+template<typename T>
+using inner_type_t = typename inner_type<T>::type;
+
+template<typename T, fair::meta::fixed_string description = "", typename... Arguments>
+using A = Annotated<T, description, Arguments...>;
+
+} // namespace fair::graph
+
+#endif // GRAPH_PROTOTYPE_ANNOTATED_HPP

--- a/include/annotated.hpp
+++ b/include/annotated.hpp
@@ -98,13 +98,13 @@ struct Annotated {
     // N.B. intentional implicit assignment and conversion operators to have a transparent wrapper
     // this does not affect the conversion of the wrapped value type 'T' itself
     constexpr Annotated &
-    operator=(const T &value_) noexcept {
+    operator=(const T &value_) noexcept(std::is_nothrow_copy_constructible_v<T>) {
         value = value_;
         return *this;
     }
 
     constexpr Annotated &
-    operator=(T &&value_) noexcept {
+    operator=(T &&value_) noexcept(std::is_nothrow_move_constructible_v<T>) {
         value = std::move(value_);
         return *this;
     }
@@ -165,12 +165,12 @@ template<typename T>
 concept AnnotatedType = is_annotated<T>::value;
 
 template<typename T>
-struct inner_type {
+struct unwrap_if_wrapped {
     using type = T;
 };
 
 template<typename U, fair::meta::fixed_string str, typename... Args>
-struct inner_type<fair::graph::Annotated<U, str, Args...>> {
+struct unwrap_if_wrapped<fair::graph::Annotated<U, str, Args...>> {
     using type = U;
 };
 
@@ -179,7 +179,7 @@ struct inner_type<fair::graph::Annotated<U, str, Args...>> {
  * If the given type is not an `Annotated`, it returns the type itself.
  */
 template<typename T>
-using inner_type_t = typename inner_type<T>::type;
+using unwrap_if_wrapped_t = typename unwrap_if_wrapped<T>::type;
 
 } // namespace fair::graph
 

--- a/include/annotated.hpp
+++ b/include/annotated.hpp
@@ -129,25 +129,25 @@ struct Annotated {
     }
 
     // meta-information
-    constexpr std::string_view
-    description() const noexcept {
+    static constexpr std::string_view
+    description() noexcept {
         return std::string_view{ description_ };
     }
 
-    constexpr std::string_view
-    documentation() const noexcept {
+    static constexpr std::string_view
+    documentation() noexcept {
         using Documentation = typename fair::meta::typelist<Arguments...>::template find_or_default<is_doc, EmptyDoc>;
         return std::string_view{ Documentation::value };
     }
 
-    constexpr std::string_view
-    unit() const noexcept {
+    static constexpr std::string_view
+    unit() noexcept {
         using PhysicalUnit = typename fair::meta::typelist<Arguments...>::template find_or_default<is_unit, EmptyUnit>;
         return std::string_view{ PhysicalUnit::value };
     }
 
-    constexpr bool
-    visible() const noexcept {
+    static constexpr bool
+    visible() noexcept {
         return fair::meta::typelist<Arguments...>::template contains<Visible>;
     }
 };

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -3,6 +3,7 @@
 
 #include <map>
 
+#include <annotated.hpp>
 #include <node_traits.hpp>
 #include <port.hpp>
 #include <tag.hpp>
@@ -253,6 +254,12 @@ public:
         _name = std::move(name);
     }
 
+    [[nodiscard]] constexpr std::string_view
+    description() const noexcept {
+        using Description = typename fair::meta::find_type_or_default<is_doc, EmptyDoc, Arguments...>::type;
+        return std::string_view(Description::value);
+    }
+
     [[nodiscard]] constexpr bool
     input_tags_present() const noexcept {
         return _input_tags_present;
@@ -429,7 +436,7 @@ public:
                 if (available_samples == 0) {
                     return work_return_t::OK;
                 }
-                samples_to_process                   = std::max(0UL, std::min(static_cast<std::size_t>(available_samples), max_buffer));
+                samples_to_process = std::max(0UL, std::min(static_cast<std::size_t>(available_samples), max_buffer));
                 if (not enough_samples_for_output_ports(samples_to_process)) {
                     return work_return_t::INSUFFICIENT_INPUT_ITEMS;
                 }

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -657,7 +657,7 @@ node_description() noexcept {
     if constexpr (refl::is_reflectable<DerivedNode>()) {
         for_each(refl::reflect<DerivedNode>().members, [&](auto member) {
             using RawType = std::remove_cvref_t<typename decltype(member)::value_type>;
-            using Type    = inner_type_t<RawType>;
+            using Type    = unwrap_if_wrapped_t<RawType>;
 
             if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string>) ) {
                 if constexpr (is_annotated<RawType>()) {

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -645,7 +645,7 @@ node_description() noexcept {
     using DerivedNode          = typename Node::derived_t;
     using ArgumentList         = typename Node::node_template_parameters;
     using Description          = typename ArgumentList::template find_or_default<is_doc, EmptyDoc>;
-    using SupportedTypes       = typename ArgumentList::template find_or_default<is_supported_type_type, DefaultSupportedTypes>;
+    using SupportedTypes       = typename ArgumentList::template find_or_default<is_supported_types, DefaultSupportedTypes>;
     constexpr bool is_blocking = ArgumentList::template contains<BlockingIO>;
 
     // re-enable once string and constexpr static is supported by all compilers

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -199,7 +199,7 @@ public:
             meta::tuple_for_each(
                     [this](auto &&default_tag) {
                         for_each(refl::reflect(*settings_base<Node>::_node).members, [&](auto member) {
-                            using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
+                            using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
                             if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                                 if (default_tag.shortKey().ends_with(get_display_name(member))) {
                                     _auto_forward.emplace(get_display_name(member));
@@ -258,7 +258,7 @@ public:
                 const auto &value  = localValue;
                 bool        is_set = false;
                 for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
-                    using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
+                    using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
                     if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
                             if (_auto_update.contains(key)) {
@@ -286,7 +286,7 @@ public:
                 const auto &key   = localKey;
                 const auto &value = localValue;
                 for_each(refl::reflect(*settings_base<Node>::_node).members, [&](auto member) {
-                    using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
+                    using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
                     if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
                             _staged.insert_or_assign(key, value);
@@ -359,7 +359,7 @@ public:
                 // take a copy of the field -> map value of the old settings
                 if constexpr (refl::is_reflectable<Node>()) {
                     for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
-                        using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
+                        using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
 
                         if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                             oldSettings.insert_or_assign(get_display_name(member), pmtv::pmt(member(*settings_base<Node>::_node)));
@@ -373,7 +373,7 @@ public:
                 const auto &key          = localKey;
                 const auto &staged_value = localStaged_value;
                 for_each(refl::reflect(*settings_base<Node>::_node).members, [&key, &staged, &forward_parameters, &staged_value, this](auto member) {
-                    using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
+                    using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
                     if constexpr (is_writable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(staged_value)) {
                             member(*settings_base<Node>::_node) = std::get<Type>(staged_value);
@@ -388,7 +388,7 @@ public:
                 });
             }
             for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
-                using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
+                using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
 
                 if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                     _active.insert_or_assign(get_display_name(member), pmtv::pmt(member(*settings_base<Node>::_node)));
@@ -409,7 +409,7 @@ public:
         if constexpr (refl::is_reflectable<Node>()) {
             std::lock_guard lg(_lock);
             for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
-                using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
+                using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
 
                 if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string>) ) {
                     _active.insert_or_assign(get_display_name_const(member).str(), member(*settings_base<Node>::_node));

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -199,7 +199,7 @@ public:
             meta::tuple_for_each(
                     [this](auto &&default_tag) {
                         for_each(refl::reflect(*settings_base<Node>::_node).members, [&](auto member) {
-                            using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                            using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
                             if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                                 if (default_tag.shortKey().ends_with(get_display_name(member))) {
                                     _auto_forward.emplace(get_display_name(member));
@@ -258,7 +258,7 @@ public:
                 const auto &value  = localValue;
                 bool        is_set = false;
                 for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
-                    using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                    using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
                     if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
                             if (_auto_update.contains(key)) {
@@ -286,7 +286,7 @@ public:
                 const auto &key   = localKey;
                 const auto &value = localValue;
                 for_each(refl::reflect(*settings_base<Node>::_node).members, [&](auto member) {
-                    using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                    using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
                     if constexpr (is_writable(member) && (std::is_arithmetic_v<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
                             _staged.insert_or_assign(key, value);
@@ -359,7 +359,7 @@ public:
                 // take a copy of the field -> map value of the old settings
                 if constexpr (refl::is_reflectable<Node>()) {
                     for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
-                        using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                        using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
 
                         if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                             oldSettings.insert_or_assign(get_display_name(member), pmtv::pmt(member(*settings_base<Node>::_node)));
@@ -373,7 +373,7 @@ public:
                 const auto &key          = localKey;
                 const auto &staged_value = localStaged_value;
                 for_each(refl::reflect(*settings_base<Node>::_node).members, [&key, &staged, &forward_parameters, &staged_value, this](auto member) {
-                    using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                    using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
                     if constexpr (is_writable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(staged_value)) {
                             member(*settings_base<Node>::_node) = std::get<Type>(staged_value);
@@ -388,7 +388,7 @@ public:
                 });
             }
             for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
-                using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
 
                 if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string> || fair::meta::vector_type<Type>) ) {
                     _active.insert_or_assign(get_display_name(member), pmtv::pmt(member(*settings_base<Node>::_node)));
@@ -409,7 +409,7 @@ public:
         if constexpr (refl::is_reflectable<Node>()) {
             std::lock_guard lg(_lock);
             for_each(refl::reflect(*settings_base<Node>::_node).members, [&, this](auto member) {
-                using Type = std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>;
+                using Type = inner_type_t<std::remove_cvref_t<decltype(member(*settings_base<Node>::_node))>>;
 
                 if constexpr (is_readable(member) && (std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string>) ) {
                     _active.insert_or_assign(get_display_name_const(member).str(), member(*settings_base<Node>::_node));

--- a/include/typelist.hpp
+++ b/include/typelist.hpp
@@ -303,11 +303,20 @@ struct typelist {
     template<template<typename...> typename Pred>
     constexpr static bool none_of = (!Pred<Ts>::value && ...);
 
-    using safe_head = std::remove_pointer_t<decltype([] {
+    template<typename DefaultType>
+    using safe_head_default = std::remove_pointer_t<decltype([] {
         if constexpr (sizeof...(Ts) > 0) {
-            return static_cast<this_t::at<0>*>(nullptr);
+            return static_cast<this_t::at<0> *>(nullptr);
         } else {
-            return static_cast<void*>(nullptr);
+            return static_cast<DefaultType *>(nullptr);
+        }
+    }())>;
+
+    using safe_head         = std::remove_pointer_t<decltype([] {
+        if constexpr (sizeof...(Ts) > 0) {
+            return static_cast<this_t::at<0> *>(nullptr);
+        } else {
+            return static_cast<void *>(nullptr);
         }
     }())>;
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -291,31 +291,6 @@ indexForName() {
     return helper(std::make_index_sequence<PortList::size>());
 }
 
-template<template<typename> typename Pred, typename... Items>
-struct find_type;
-
-template<template<typename> typename Pred>
-struct find_type<Pred> {
-    using type = typelist<>;
-};
-
-template<template<typename> typename Pred, typename First, typename... Rest>
-struct find_type<Pred, First, Rest...> {
-    using type = typename std::conditional_t<Pred<First>::value, typelist<First, typename find_type<Pred, Rest...>::type>, typename find_type<Pred, Rest...>::type>;
-};
-
-template<template<typename> typename Pred, typename... Items>
-using find_type_t = typename find_type<Pred, Items...>::type;
-
-template<template<typename> typename Predicate, typename DefaultType, typename... Ts>
-struct find_type_or_default {
-    using type = DefaultType;
-};
-
-template<template<typename> typename Predicate, typename DefaultType, typename Head, typename... Ts>
-struct find_type_or_default<Predicate, DefaultType, Head, Ts...>
-    : std::conditional_t<Predicate<Head>::value, find_type_or_default<Predicate, Head, Ts...>, find_type_or_default<Predicate, DefaultType, Ts...>> {};
-
 template<typename... Lambdas>
 struct overloaded : Lambdas... {
     using Lambdas::operator()...;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -291,6 +291,41 @@ indexForName() {
     return helper(std::make_index_sequence<PortList::size>());
 }
 
+// template<template<typename...> typename Type, typename... Items>
+// using find_type = decltype(std::tuple_cat(std::declval<std::conditional_t<is_instantiation_of<Items, Type>, std::tuple<Items>, std::tuple<>>>()...));
+
+template<template<typename> typename Pred, typename... Items>
+struct find_type;
+
+template<template<typename> typename Pred>
+struct find_type<Pred> {
+    using type = std::tuple<>;
+};
+
+template<template<typename> typename Pred, typename First, typename... Rest>
+struct find_type<Pred, First, Rest...> {
+    using type = decltype(std::tuple_cat(std::conditional_t<Pred<First>::value, std::tuple<First>, std::tuple<>>(), typename find_type<Pred, Rest...>::type()));
+};
+
+template<template<typename> typename Pred, typename... Items>
+using find_type_t = typename find_type<Pred, Items...>::type;
+
+template<typename Tuple, typename Default = void>
+struct get_first_or_default;
+
+template<typename First, typename... Rest, typename Default>
+struct get_first_or_default<std::tuple<First, Rest...>, Default> {
+    using type = First;
+};
+
+template<typename Default>
+struct get_first_or_default<std::tuple<>, Default> {
+    using type = Default;
+};
+
+template<typename Tuple, typename Default = void>
+using get_first_or_default_t = typename get_first_or_default<Tuple, Default>::type;
+
 template<typename... Lambdas>
 struct overloaded : Lambdas... {
     using Lambdas::operator()...;

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -7,6 +7,7 @@
 #include <ranges>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <unordered_map>
 
 #include "typelist.hpp"
@@ -295,12 +296,12 @@ struct find_type;
 
 template<template<typename> typename Pred>
 struct find_type<Pred> {
-    using type = std::tuple<>;
+    using type = typelist<>;
 };
 
 template<template<typename> typename Pred, typename First, typename... Rest>
 struct find_type<Pred, First, Rest...> {
-    using type = decltype(std::tuple_cat(std::conditional_t<Pred<First>::value, std::tuple<First>, std::tuple<>>(), typename find_type<Pred, Rest...>::type()));
+    using type = typename std::conditional_t<Pred<First>::value, typelist<First, typename find_type<Pred, Rest...>::type>, typename find_type<Pred, Rest...>::type>;
 };
 
 template<template<typename> typename Pred, typename... Items>

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -102,6 +102,10 @@ struct Source : public node<Source<T>> {
     }
 };
 
+// optional shortening
+template<typename T, fair::meta::fixed_string description = "", typename... Arguments>
+using A            = Annotated<T, description, Arguments...>;
+
 using TestBlockDoc = Doc<R""(
 some test doc documentation
 )"">;


### PR DESCRIPTION
This commit introduces a robust, transparent Annotated<T, ...> type wrapper interface, paving the way for user-friendly, embedded, in-code documentation. Here's how it works and how it benefits our development process:

**Transparent Type Wrapper:**
`Annotated<T, ...>` wraps around any type, preserving its behaviour while augmenting it with added meta information. This information can range from documentation and unit info to UI behaviour controls and beyond. The variable type argument accepts any meta-information type, with built-in support for optional `Doc<"...">` and `Unit<"...">` that allow for more detailed (e.g. using mark-down) documentation of blocks, its parameters, and their physical (e.g. SI) units. This flexibility enables user extendability, creating a flexible interface that adapts to diverse needs.

**Streamlined Documentation:**
Embedding documentation directly in the code removes the need for separate documentation files or automated generation tools. This approach fosters a single source of truth for block definitions, aligning documentation with the actual source code and enhancing the maintainability of the project and OOT modules.

**Enabling UI Behaviour:**
The annotations can drive specific UI behaviours, such as the in-UI detailed block or parameter documentation, highlighting or suppressing specific parameters, and more.

**Example Usage:**
The `TestBlock` class showcases the usage of this interface. It uses `Doc` and `Unit` to annotate the class and the `scaling_factor` field, and `Visible` which may be used to control UI visibility.

```cpp
using TestBlockDoc = Doc<R""(
#TestBlock

some test doc documentation -- may use mark down, references etc. -- and can be read-out programmatically 

// optional future extension: 
// use existing input/output port information and constraints for additional documentation
)"">;

template<typename T>
struct TestBlock : public node<TestBlock<T>, TestBlockDoc> {
    IN<T>  in;
    OUT<T> out;
    A<T, "scaling factor", Visible, Doc<"y = a * x">, Unit<"As">> scaling_factor = static_cast<T>(1); 
    A<std::string, "context information", Visible>                context;
    ...
};
```

and some snippets from the corresponding [unit-test](https://github.com/fair-acc/graph-prototype/blob/92af03690a96c8e228276aef30f63527fde2a28a/test/qa_settings.cpp#L310-L330):
```cpp
graph flow_graph;
TestBlock<float> &block = flow_graph.make_node<TestBlock<float>>();
expect(eq(block.description(), std::string_view(TestBlockDoc::value)));
expect(block.scaling_factor.visible());
expect(eq(block.scaling_factor.description(), std::string_view{ "scaling factor" }));
expect(eq(block.scaling_factor.unit(), std::string_view{ "As" }));
expect(eq(block.context.unit(), std::string_view{ "" }));
expect(block.context.visible());

block.scaling_factor = 42.f; // test wrapper assignment operator
expect(block.scaling_factor == 42) << "the answer to everything failed -- equal operator";
expect(eq(block.scaling_factor.value, 42)) << "the answer to everything failed -- by value";
expect(eq(block.scaling_factor, 42)) << "the answer to everything failed -- direct";
```

In summary, this commit takes a significant leap towards improving the user-friendliness and maintainability of our project by embedding documentation and other metadata directly into the code.

### **Important:** 
This pre-version is open for feedback, comments, and suggestions. 

The hope is to iterate over, for example, naming, additional features, required meta-info types, etc. to improve the GNU Radio 4.0 development user experience.