### PR TITLE
scheduler: add thread pool backed parallel implementation to "simple" and "breadth_first" schedulers

### DIFF
--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -471,7 +471,7 @@ invoke_work(auto &sched) {
     using namespace benchmark;
     test::n_samples_produced = 0LU;
     test::n_samples_consumed = 0LU;
-    sched.work();
+    sched.run_and_wait();
     expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
     expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
 }
@@ -598,7 +598,7 @@ inline const boost::ut::suite _runtime_tests = [] {
         ::benchmark::benchmark<1LU>{ test_name }.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
-            sched.work();
+            sched.run_and_wait();
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };
@@ -629,7 +629,7 @@ inline const boost::ut::suite _simd_tests = [] {
         "runtime   src->mult(2.0)->mult(0.5)->add(-1)->sink (SIMD)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
-            sched.work();
+            sched.run_and_wait();
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };
@@ -665,7 +665,8 @@ inline const boost::ut::suite _simd_tests = [] {
         "runtime   src->(mult(2.0)->mult(0.5)->add(-1))^10->sink (SIMD)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
-            sched.work();
+            sched.run_and_wait();
+            sched.reset();
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };
@@ -693,7 +694,7 @@ inline const boost::ut::suite _sample_by_sample_vs_bulk_access_tests = [] {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
             fg::scheduler::simple sched{ std::move(flow_graph) };
-            sched.work();
+            sched.run_and_wait();
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };
@@ -719,7 +720,7 @@ inline const boost::ut::suite _sample_by_sample_vs_bulk_access_tests = [] {
         ::benchmark::benchmark<1LU>{ test_name }.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
-            sched.work();
+            sched.run_and_wait();
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };

--- a/bench/bm_filter.cpp
+++ b/bench/bm_filter.cpp
@@ -36,7 +36,7 @@ invoke_work(auto &sched) {
     using namespace benchmark;
     test::n_samples_produced = 0LU;
     test::n_samples_consumed = 0LU;
-    sched.work();
+    sched.run_and_wait();
     expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
     expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
 }

--- a/bench/bm_scheduler.cpp
+++ b/bench/bm_scheduler.cpp
@@ -99,7 +99,7 @@ void exec_bm(auto& scheduler, const std::string& test_case) {
     using namespace benchmark;
     test::n_samples_produced = 0LU;
     test::n_samples_consumed = 0LU;
-    scheduler.work();
+    scheduler.run_and_wait();
     expect(eq(test::n_samples_produced, N_SAMPLES)) << fmt::format("did not produce enough output samples for {}", test_case);
     expect(ge(test::n_samples_consumed, N_SAMPLES)) << fmt::format("did not consume enough input samples for {}", test_case);
     scheduler.reset();
@@ -152,29 +152,6 @@ void exec_bm(auto& scheduler, const std::string& test_case) {
     "bifurcated graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt]() {
         exec_bm(sched4_mt, "bifurcated-graph BFS-sched (multi-threaded)");
     };
-
-    //auto pinned_pool = std::make_shared<thread_pool>("pinned-pool", 2, 2);
-    //pinned_pool->setAffinityMask({true, true, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false, false});
-
-    //fg::scheduler::simple<multi_threaded> sched1_mt2(test_graph_linear<float>(2 * NODES), pinned_pool);
-    //"linear graph - simple scheduler (multi-threaded(pinned))"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1_mt2]() {
-    //    exec_bm(sched1_mt2, "linear-graph simple-sched (multi-threaded(pinned))");
-    //};
-
-    //fg::scheduler::breadth_first<multi_threaded> sched2_mt2(test_graph_linear<float>(2 * NODES), pinned_pool);
-    //"linear graph - BFS scheduler (multi-threaded(pinned))"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2_mt2]() {
-    //    exec_bm(sched2_mt2, "linear-graph BFS-sched (multi-threaded(pinned))");
-    //};
-
-    //fg::scheduler::simple<multi_threaded> sched3_mt2(test_graph_bifurcated<float>(NODES), pinned_pool);
-    //"bifurcated graph - simple scheduler (multi-threaded(pinned))"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3_mt2]() {
-    //    exec_bm(sched3_mt2, "bifurcated-graph simple-sched (multi-threaded(pinned))");
-    //};
-
-    //fg::scheduler::breadth_first<multi_threaded> sched4_mt2(test_graph_bifurcated<float>(NODES), pinned_pool);
-    //"bifurcated graph - BFS scheduler (multi-threaded(pinned))"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt2]() {
-    //    exec_bm(sched4_mt2, "bifurcated-graph BFS-sched (multi-threaded(pinned))");
-    //};
 };
 
 int

--- a/bench/bm_scheduler.cpp
+++ b/bench/bm_scheduler.cpp
@@ -102,6 +102,7 @@ void exec_bm(auto& scheduler, const std::string& test_case) {
     scheduler.work();
     expect(eq(test::n_samples_produced, N_SAMPLES)) << fmt::format("did not produce enough output samples for {}", test_case);
     expect(ge(test::n_samples_consumed, N_SAMPLES)) << fmt::format("did not consume enough input samples for {}", test_case);
+    scheduler.reset();
 }
 
 [[maybe_unused]] inline const boost::ut::suite scheduler_tests = [] {

--- a/bench/bm_scheduler.cpp
+++ b/bench/bm_scheduler.cpp
@@ -107,10 +107,10 @@ void exec_bm(auto& scheduler, const std::string& test_case) {
 [[maybe_unused]] inline const boost::ut::suite scheduler_tests = [] {
     using namespace boost::ut;
     using namespace benchmark;
-    using thread_pool = fair::thread_pool::BasicThreadPool<fair::thread_pool::CPU_BOUND>;
+    using thread_pool = fair::thread_pool::BasicThreadPool;
     using fg::scheduler::execution_policy::multi_threaded;
 
-    auto pool = std::make_shared<thread_pool>("custom-pool", 2, 2);
+    auto pool = std::make_shared<thread_pool>("custom-pool", fair::thread_pool::CPU_BOUND, 2, 2);
 
     fg::scheduler::simple sched1(test_graph_linear<float>(2 * N_NODES), pool);
     "linear graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1]() {

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -629,9 +629,9 @@ public:
 
 class graph {
 private:
-    std::vector<std::function<connection_result_t()>> _connection_definitions;
-    std::vector<std::unique_ptr<node_model>>          _nodes;
-    std::vector<edge>                                 _edges;
+    std::vector<std::function<connection_result_t(graph&)>> _connection_definitions;
+    std::vector<std::unique_ptr<node_model>>                _nodes;
+    std::vector<edge>                                       _edges;
 
     template<typename Node>
     std::unique_ptr<node_model> &
@@ -705,8 +705,8 @@ private:
             if (!is_node_known(source) || !is_node_known(destination)) {
                 throw fmt::format("Source {} and/or destination {} do not belong to this graph\n", source.name(), destination.name());
             }
-            self._connection_definitions.push_back([self = &self, source = &source, source_port = &port, destination = &destination, destination_port = &destination_port]() {
-                return self->connect_impl<src_port_index, dst_port_index>(*source, *source_port, *destination, *destination_port);
+            self._connection_definitions.push_back([source = &source, source_port = &port, destination = &destination, destination_port = &destination_port](graph &graph) {
+                return graph.connect_impl<src_port_index, dst_port_index>(*source, *source_port, *destination, *destination_port);
             });
             return connection_result_t::SUCCESS;
         }
@@ -761,6 +761,11 @@ private:
     connect(Source &source, Port Source::*member_ptr);
 
 public:
+    graph(graph&) = delete;
+    graph(graph&&) = default;
+    graph() = default;
+    graph &operator=(graph&) = delete;
+    graph &operator=(graph&&) = default;
     /**
      * @return a list of all blocks contained in this graph
      * N.B. some 'blocks' may be (sub-)graphs themselves
@@ -846,7 +851,7 @@ public:
         return result;
     }
 
-    const std::vector<std::function<connection_result_t()>> &
+    const std::vector<std::function<connection_result_t(graph&)>> &
     connection_definitions() {
         return _connection_definitions;
     }

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -5,124 +5,129 @@
 #include <queue>
 #include <thread_pool.hpp>
 #include <latch>
+#include <utility>
 
 namespace fair::graph::scheduler {
 
-struct init_proof {
-    explicit init_proof(bool _success) : success(_success) {}
-
-    init_proof(init_proof &&init)  noexcept : init_proof(init.success) {}
-
-    bool success = true;
-
-    init_proof &
-    operator=(init_proof &&init) noexcept {
-        this->success = init;
-        return *this;
-    }
-
-    operator bool() const { return success; }
-};
-
-init_proof
-init(fair::graph::graph &graph) {
-    auto result = init_proof(std::all_of(graph.connection_definitions().begin(), graph.connection_definitions().end(),
-                                         [](auto &connection_definition) { return connection_definition() == connection_result_t::SUCCESS; }));
-    graph.clear_connection_definitions();
-    return result;
-}
-
 enum execution_policy { single_threaded, multi_threaded };
+enum SchedulerState { IDLE, INITIALISED, RUNNING, REQUESTED_STOP, REQUESTED_PAUSE, STOPPED, PAUSE, SHUTTING_DOWN };
 
-namespace detail {
-template<typename node_t>
-work_return_t traverse_nodes(std::span<node_t> nodes) {
-    bool something_happened = false;
-    for (auto &node: nodes) {
-        auto result = node->work();
-        if (result == work_return_t::ERROR) {
-            return work_return_t::ERROR;
-        } else if (result == work_return_t::INSUFFICIENT_INPUT_ITEMS || result == work_return_t::DONE) {
-            // nothing
-        } else if (result == work_return_t::OK || result == work_return_t::INSUFFICIENT_OUTPUT_ITEMS) {
-            something_happened = true;
-        }
+template<typename scheduler_type, execution_policy = single_threaded>
+class scheduler_base : public node<scheduler_type> {
+protected:
+    using node_t                             = node_model *;
+    using thread_pool_type                   = thread_pool::BasicThreadPool;
+    SchedulerState                    _state = IDLE;
+    fair::graph::graph                _graph;
+    std::shared_ptr<thread_pool_type> _pool;
+    std::vector<std::vector<node_t>>  _job_lists{};
+
+public:
+    explicit scheduler_base(fair::graph::graph              &&graph,
+                            std::shared_ptr<thread_pool_type> thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("simple-scheduler-pool", thread_pool::CPU_BOUND))
+        : _graph(std::move(graph)), _pool(std::move(thread_pool)){};
+
+    void
+    init(fair::graph::graph &graph) {
+        auto result = init_proof(std::all_of(graph.connection_definitions().begin(), graph.connection_definitions().end(),
+                                             [](auto &connection_definition) { return connection_definition() == connection_result_t::SUCCESS; }));
+        graph.clear_connection_definitions();
+        return result;
     }
-    return something_happened ? work_return_t::OK : work_return_t::DONE;
-}
 
-void run_on_pool(std::span<node_model*> job, std::size_t n_batches, std::atomic_uint64_t &progress, std::latch &running_threads, std::atomic_bool &stop_requested) {
-    uint32_t done = 0;
-    uint32_t progress_count = 0;
-    while (done < n_batches && !stop_requested) {
-        bool something_happened = traverse_nodes(job) == work_return_t::OK;
-        uint64_t progress_local, progress_new;
-        if (something_happened) { // something happened in this thread => increase progress and reset done count
-            do {
-                progress_local = progress.load();
-                progress_count = static_cast<std::uint32_t>((progress_local >> 32) & ((1ULL << 32) - 1));
-                done           = static_cast<std::uint32_t>(progress_local         & ((1ULL << 32) - 1));
-                progress_new   = (progress_count + 1ULL) << 32;
-            } while (!progress.compare_exchange_strong(progress_local, progress_new));
-            progress.notify_all();
-        } else { // nothing happened on this thread
-            uint32_t progress_count_old = progress_count;
-            do {
-                progress_local = progress.load();
-                progress_count = static_cast<std::uint32_t>((progress_local >> 32) & ((1ULL << 32) - 1));
-                done           = static_cast<std::uint32_t>(progress_local         & ((1ULL << 32) - 1));
-                if (progress_count == progress_count_old) { // nothing happened => increase done count
-                    progress_new = ((progress_count + 0ULL) << 32) + done + 1;
-                } else { // something happened in another thread => keep progress and done count and rerun this task without waiting
-                    progress_new = ((progress_count + 0ULL) << 32) + done;
-                }
-            } while (!progress.compare_exchange_strong(progress_local, progress_new));
-            progress.notify_all();
-            if (progress_count == progress_count_old && done < n_batches) {
-                progress.wait(progress_new);
+    template<typename node_t>
+    work_return_t
+    traverse_nodes(std::span<node_t> nodes) {
+        bool something_happened = false;
+        for (auto &currentNode : nodes) {
+            auto result = currentNode->work();
+            if (result == work_return_t::ERROR) {
+                return work_return_t::ERROR;
+            } else if (result == work_return_t::INSUFFICIENT_INPUT_ITEMS || result == work_return_t::DONE) {
+                // nothing
+            } else if (result == work_return_t::OK || result == work_return_t::INSUFFICIENT_OUTPUT_ITEMS) {
+                something_happened = true;
             }
         }
-    } // while (done < n_batches) {
-    running_threads.count_down();
-}
-}
+        return something_happened ? work_return_t::OK : work_return_t::DONE;
+    }
+
+    void
+    run_on_pool(std::span<node_model *> job, std::size_t n_batches, std::atomic_uint64_t &progress, std::latch &running_threads, std::atomic_bool &stop_requested) {
+        uint32_t done           = 0;
+        uint32_t progress_count = 0;
+        while (done < n_batches && !stop_requested) {
+            bool     something_happened = traverse_nodes(job) == work_return_t::OK;
+            uint64_t progress_local, progress_new;
+            if (something_happened) { // something happened in this thread => increase progress and reset done count
+                do {
+                    progress_local = progress.load();
+                    progress_count = static_cast<std::uint32_t>((progress_local >> 32) & ((1ULL << 32) - 1));
+                    done           = static_cast<std::uint32_t>(progress_local & ((1ULL << 32) - 1));
+                    progress_new   = (progress_count + 1ULL) << 32;
+                } while (!progress.compare_exchange_strong(progress_local, progress_new));
+                progress.notify_all();
+            } else { // nothing happened on this thread
+                uint32_t progress_count_old = progress_count;
+                do {
+                    progress_local = progress.load();
+                    progress_count = static_cast<std::uint32_t>((progress_local >> 32) & ((1ULL << 32) - 1));
+                    done           = static_cast<std::uint32_t>(progress_local & ((1ULL << 32) - 1));
+                    if (progress_count == progress_count_old) { // nothing happened => increase done count
+                        progress_new = ((progress_count + 0ULL) << 32) + done + 1;
+                    } else {                                    // something happened in another thread => keep progress and done count and rerun this task without waiting
+                        progress_new = ((progress_count + 0ULL) << 32) + done;
+                    }
+                } while (!progress.compare_exchange_strong(progress_local, progress_new));
+                progress.notify_all();
+                if (progress_count == progress_count_old && done < n_batches) {
+                    progress.wait(progress_new);
+                }
+            }
+        } // while (done < n_batches)
+        running_threads.count_down();
+    }
+
+    [[nodiscard]] const std::vector<std::vector<node_t>> &getJobLists() const {
+        return _job_lists;
+    }
+};
 
 /**
  * Trivial loop based scheduler, which iterates over all nodes in definition order in the graph until no node did any processing
  */
 template<execution_policy executionPolicy = single_threaded>
-class simple : public node<simple<executionPolicy>>{
-    using node_t = node_model*;
-    using thread_pool_type = thread_pool::BasicThreadPool;
-    init_proof                        _init;
-    fair::graph::graph                _graph;
-    std::shared_ptr<thread_pool_type> _pool;
-    std::vector<std::vector<node_t>>  _job_lists{};
+class simple : public scheduler_base<simple<executionPolicy>>{
+    using S = scheduler_base<simple<executionPolicy>>;
+    using node_t = S::node_t; //node_model*;
+    using thread_pool_type = S::thread_pool_type; //thread_pool::BasicThreadPool;
 public:
-    explicit simple(fair::graph::graph &&graph, std::shared_ptr<thread_pool_type> thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("simple-scheduler-pool", thread_pool::CPU_BOUND))
-            : _init{fair::graph::scheduler::init(graph)}, _graph(std::move(graph)), _pool(std::move(thread_pool)) {
+    explicit simple(fair::graph::graph &&graph, std::shared_ptr<thread_pool_type> thread_pool = std::make_shared<thread_pool_type>("simple-scheduler-pool", thread_pool::CPU_BOUND))
+            : S(std::move(graph), thread_pool) {
         // generate job list
-        const auto n_batches = std::min(static_cast<std::size_t>(_pool->maxThreads()), _graph.blocks().size());
-        _job_lists.reserve(n_batches);
-        for (std::size_t i = 0; i < n_batches; i++) {
-            // create job-set for thread
-            auto &job = _job_lists.emplace_back();
-            job.reserve(_graph.blocks().size() / n_batches + 1);
-            for (std::size_t j = i; j < _graph.blocks().size(); j += n_batches) {
-                job.push_back(_graph.blocks()[j].get());
+        if constexpr (executionPolicy == multi_threaded) {
+            const auto n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), this->_graph.blocks().size());
+            this->_job_lists.reserve(n_batches);
+            for (std::size_t i = 0; i < n_batches; i++) {
+                // create job-set for thread
+                auto &job = this->_job_lists.emplace_back();
+                job.reserve(this->_graph.blocks().size() / n_batches + 1);
+                for (std::size_t j = i; j < this->_graph.blocks().size(); j += n_batches) {
+                    job.push_back(this->_graph.blocks()[j].get());
+                }
             }
         }
     }
 
     work_return_t
     work() {
-        if (!_init) {
-            return work_return_t::ERROR;
-    }
+        // if (!_init) {
+        //     return work_return_t::ERROR;
+        // }
         if constexpr (executionPolicy == single_threaded) {
             bool run = true;
             while (run) {
-                if (auto result = detail::traverse_nodes(std::span{_graph.blocks()}); result == work_return_t::ERROR) {
+                if (auto result = this->traverse_nodes(std::span{this->_graph.blocks()}); result == work_return_t::ERROR) {
                     return result;
                 } else {
                     run = result == work_return_t::OK;
@@ -131,11 +136,10 @@ public:
         } else if (executionPolicy == multi_threaded) {
             std::atomic_bool stop_requested(false);
             std::atomic_uint64_t progress{0}; // upper uint32t: progress counter, lower uint32t: number of workers that finished all their work
-            std::latch running_threads{static_cast<std::ptrdiff_t>(_job_lists.size())}; // latch to wait for completion of the flowgraph
-            for (auto &job: _job_lists) {
-                //_pool->execute(detail::run_on_pool, std::span{job}, _job_lists.size(), progress, running_threads, stoken);
-                _pool->execute([this, &job, &progress, &running_threads, &stop_requested]() {
-                    detail::run_on_pool(std::span{job}, _job_lists.size(), progress, running_threads, stop_requested);
+            std::latch running_threads{static_cast<std::ptrdiff_t>(this->_job_lists.size())}; // latch to wait for completion of the flowgraph
+            for (auto &job: this->_job_lists) {
+                this->_pool->execute([this, &job, &progress, &running_threads, &stop_requested]() {
+                    this->run_on_pool(std::span{job}, this->_job_lists.size(), progress, running_threads, stop_requested);
                 });
             }
             running_threads.wait();
@@ -152,22 +156,19 @@ public:
  * detecting cycles and nodes which can be reached from several source nodes.
  */
 template<execution_policy executionPolicy = single_threaded>
-class breadth_first : public node<breadth_first<executionPolicy>> {
+class breadth_first : public scheduler_base<breadth_first<executionPolicy>> {
+    using S = scheduler_base<breadth_first<executionPolicy>>;
     using node_t = node_model*;
     using thread_pool_type = thread_pool::BasicThreadPool;
-    init_proof _init;
-    fair::graph::graph _graph;
     std::vector<node_t> _nodelist;
-    std::vector<std::vector<node_t>> _job_lists;
-    std::shared_ptr<thread_pool_type> _pool;
 public:
     explicit breadth_first(fair::graph::graph &&graph, std::shared_ptr<thread_pool_type> thread_pool = std::make_shared<thread_pool_type>("breadth-first-pool", thread_pool::CPU_BOUND))
-            : _init{fair::graph::scheduler::init(graph)}, _graph(std::move(graph)), _pool(std::move(thread_pool)) {
+                : S(std::move(graph), thread_pool) {
         std::map<node_t, std::vector<node_t>> _adjacency_list{};
         std::vector<node_t>                   _source_nodes{};
         // compute the adjacency list
         std::set<node_t> node_reached;
-        for (auto &e : _graph.edges()) {
+        for (auto &e : this->_graph.edges()) {
             _adjacency_list[e._src_node].push_back(e._dst_node);
             _source_nodes.push_back(e._src_node);
             node_reached.insert(e._dst_node);
@@ -198,11 +199,11 @@ public:
             }
         }
         // generate job list
-        const auto n_batches = std::min(static_cast<std::size_t>(_pool->maxThreads()), _nodelist.size());
-        _job_lists.reserve(n_batches);
+        const auto n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), _nodelist.size());
+        this->_job_lists.reserve(n_batches);
         for (std::size_t i = 0; i < n_batches; i++) {
             // create job-set for thread
-            auto &job = _job_lists.emplace_back();
+            auto &job = this->_job_lists.emplace_back();
             job.reserve(_nodelist.size() / n_batches + 1);
             for (std::size_t j = i; j < _nodelist.size(); j += n_batches) {
                 job.push_back(_nodelist[j]);
@@ -212,13 +213,13 @@ public:
 
     work_return_t
     work() {
-        if (!_init) {
-            return work_return_t::ERROR;
-        }
+        // if (!_init) {
+        //     return work_return_t::ERROR;
+        // }
         if constexpr (executionPolicy == single_threaded) {
             bool run = true;
             while (run) {
-                if (auto result = detail::traverse_nodes(std::span{_nodelist}); result == work_return_t::ERROR) {
+                if (auto result = this->traverse_nodes(std::span{_nodelist}); result == work_return_t::ERROR) {
                     return work_return_t::ERROR;
                 } else {
                     run = (result == work_return_t::OK);
@@ -227,11 +228,10 @@ public:
         } else if (executionPolicy == multi_threaded) {
             std::atomic_bool stop_requested;
             std::atomic_uint64_t progress{0}; // upper uint32t: progress counter, lower uint32t: number of workers that finished all their work
-            std::latch running_threads{static_cast<std::ptrdiff_t>(_job_lists.size())}; // latch to wait for completion of the flowgraph
-            for (auto &job: _job_lists) {
-                //_pool->execute(detail::run_on_pool, std::span{job}, _job_lists.size(), progress, running_threads, stoken);
-                _pool->execute([this, &job, &progress, &running_threads, &stop_requested]() {
-                    detail::run_on_pool(std::span{job}, _job_lists.size(), progress, running_threads, stop_requested);
+            std::latch running_threads{static_cast<std::ptrdiff_t>(this->_job_lists.size())}; // latch to wait for completion of the flowgraph
+            for (auto &job: this->_job_lists) {
+                this->_pool->execute([this, &job, &progress, &running_threads, &stop_requested]() {
+                    this->run_on_pool(std::span{job}, this->_job_lists.size(), progress, running_threads, stop_requested);
                 });
             }
             running_threads.wait();
@@ -240,10 +240,6 @@ public:
             throw std::invalid_argument("Unknown execution Policy");
         }
         return work_return_t::DONE;
-    }
-
-    const std::vector<std::vector<node_t>> &getJobLists() const {
-        return _job_lists;
     }
 
 };

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -3,13 +3,15 @@
 #include <graph.hpp>
 #include <set>
 #include <queue>
+#include <thread_pool.hpp>
+#include <latch>
 
 namespace fair::graph::scheduler {
 
 struct init_proof {
-    init_proof(bool _success) : success(_success) {}
+    explicit init_proof(bool _success) : success(_success) {}
 
-    init_proof(init_proof &&init) : init_proof(init.success) {}
+    init_proof(init_proof &&init)  noexcept : init_proof(init.success) {}
 
     bool success = true;
 
@@ -30,41 +32,116 @@ init(fair::graph::graph &graph) {
     return result;
 }
 
+enum execution_policy { single_threaded, multi_threaded };
+
+namespace detail {
+template<typename node_t>
+work_return_t traverse_nodes(std::span<node_t> nodes) {
+    bool something_happened = false;
+    for (auto &node: nodes) {
+        auto result = node->work();
+        if (result == work_return_t::ERROR) {
+            return work_return_t::ERROR;
+        } else if (result == work_return_t::INSUFFICIENT_INPUT_ITEMS || result == work_return_t::DONE) {
+            // nothing
+        } else if (result == work_return_t::OK || result == work_return_t::INSUFFICIENT_OUTPUT_ITEMS) {
+            something_happened = true;
+        }
+    }
+    return something_happened ? work_return_t::OK : work_return_t::DONE;
+}
+
+void run_on_pool(std::span<node_model*> job, std::size_t n_batches, std::atomic_uint64_t &progress, std::latch &running_threads, std::atomic_bool &stop_requested) {
+    uint32_t done = 0;
+    uint32_t progress_count = 0;
+    while (done < n_batches && !stop_requested) {
+        bool something_happened = traverse_nodes(job) == work_return_t::OK;
+        uint64_t progress_local, progress_new;
+        if (something_happened) { // something happened in this thread => increase progress and reset done count
+            do {
+                progress_local = progress.load();
+                progress_count = static_cast<std::uint32_t>((progress_local >> 32) & ((1ULL << 32) - 1));
+                done           = static_cast<std::uint32_t>(progress_local         & ((1ULL << 32) - 1));
+                progress_new   = (progress_count + 1ULL) << 32;
+            } while (!progress.compare_exchange_strong(progress_local, progress_new));
+            progress.notify_all();
+        } else { // nothing happened on this thread
+            uint32_t progress_count_old = progress_count;
+            do {
+                progress_local = progress.load();
+                progress_count = static_cast<std::uint32_t>((progress_local >> 32) & ((1ULL << 32) - 1));
+                done           = static_cast<std::uint32_t>(progress_local         & ((1ULL << 32) - 1));
+                if (progress_count == progress_count_old) { // nothing happened => increase done count
+                    progress_new = ((progress_count + 0ULL) << 32) + done + 1;
+                } else { // something happened in another thread => keep progress and done count and rerun this task without waiting
+                    progress_new = ((progress_count + 0ULL) << 32) + done;
+                }
+            } while (!progress.compare_exchange_strong(progress_local, progress_new));
+            progress.notify_all();
+            if (progress_count == progress_count_old && done < n_batches) {
+                progress.wait(progress_new);
+            }
+        }
+    } // while (done < n_batches) {
+    running_threads.count_down();
+}
+}
+
 /**
  * Trivial loop based scheduler, which iterates over all nodes in definition order in the graph until no node did any processing
  */
-class simple : public node<simple> {
-    init_proof         _init;
-    fair::graph::graph _graph;
-
+template<execution_policy executionPolicy = single_threaded, typename thread_pool_type = thread_pool::BasicThreadPool<thread_pool::CPU_BOUND>>
+class simple : public node<simple<executionPolicy, thread_pool_type>>{
+    using node_t = node_model*;
+    init_proof                        _init;
+    fair::graph::graph                _graph;
+    std::shared_ptr<thread_pool_type> _pool;
+    std::vector<std::vector<node_t>>  _job_lists{};
 public:
-    explicit simple(fair::graph::graph &&graph) : _init{ fair::graph::scheduler::init(graph) }, _graph(std::move(graph)) {}
+    explicit simple(fair::graph::graph &&graph, std::shared_ptr<thread_pool_type> thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool<thread_pool::CPU_BOUND>>("simple-scheduler-pool"))
+            : _init{fair::graph::scheduler::init(graph)}, _graph(std::move(graph)), _pool(thread_pool) {
+        // generate job list
+        const auto n_batches = std::min(static_cast<std::size_t>(_pool->maxThreads()), _graph.blocks().size());
+        _job_lists.reserve(n_batches);
+        for (std::size_t i = 0; i < n_batches; i++) {
+            // create job-set for thread
+            auto &job = _job_lists.emplace_back();
+            job.reserve(_graph.blocks().size() / n_batches + 1);
+            for (std::size_t j = i; j < _graph.blocks().size(); j += n_batches) {
+                job.push_back(_graph.blocks()[j].get());
+            }
+        }
+    }
 
     work_return_t
     work() {
         if (!_init) {
             return work_return_t::ERROR;
-        }
-        bool run = true;
-        while (run) {
-            bool something_happened = false;
-            for (const auto &current_node : _graph.blocks()) {
-                auto result = current_node->work();
-                if (result == work_return_t::ERROR) {
-                    return work_return_t::ERROR;
-                } else if (result == work_return_t::INSUFFICIENT_INPUT_ITEMS) {
-                    // nothing
-                } else if (result == work_return_t::DONE) {
-                    // nothing
-                } else if (result == work_return_t::OK) {
-                    something_happened = true;
-                } else if (result == work_return_t::INSUFFICIENT_OUTPUT_ITEMS) {
-                    something_happened = true;
+    }
+        if constexpr (executionPolicy == single_threaded) {
+            bool run = true;
+            while (run) {
+                if (auto result = detail::traverse_nodes(std::span{_graph.blocks()}); result == work_return_t::ERROR) {
+                    return result;
+                } else {
+                    run = result == work_return_t::OK;
                 }
             }
-            run = something_happened;
+        } else if (executionPolicy == multi_threaded) {
+            std::atomic_bool stop_requested(false);
+            std::atomic_uint64_t progress{0}; // upper uint32t: progress counter, lower uint32t: number of workers that finished all their work
+            std::latch running_threads{static_cast<std::ptrdiff_t>(_job_lists.size())}; // latch to wait for completion of the flowgraph
+            for (auto &job: _job_lists) {
+                //_pool->execute(detail::run_on_pool, std::span{job}, _job_lists.size(), progress, running_threads, stoken);
+                _pool->execute([this, &job, &progress, &running_threads, &stop_requested]() {
+                    detail::run_on_pool(std::span{job}, _job_lists.size(), progress, running_threads, stop_requested);
+                });
+            }
+            running_threads.wait();
+            return work_return_t::DONE;
+        } else {
+            throw std::invalid_argument("Unknown execution Policy");
         }
-
         return work_return_t::DONE;
     }
 };
@@ -73,14 +150,17 @@ public:
  * Breadth first traversal scheduler which traverses the graph starting from the source nodes in a breath first fashion
  * detecting cycles and nodes which can be reached from several source nodes.
  */
-class breadth_first : public node<breadth_first> {
-    using node_t = fair::graph::node_model *;
-    init_proof          _init;
-    fair::graph::graph  _graph;
+template<execution_policy executionPolicy = single_threaded, typename thread_pool_type = thread_pool::BasicThreadPool<thread_pool::CPU_BOUND>>
+class breadth_first : public node<breadth_first<executionPolicy, thread_pool_type>> {
+    using node_t = node_model*;
+    init_proof _init;
+    fair::graph::graph _graph;
     std::vector<node_t> _nodelist;
-
+    std::vector<std::vector<node_t>> _job_lists;
+    std::shared_ptr<thread_pool_type> _pool;
 public:
-    explicit breadth_first(fair::graph::graph &&graph) : _init{ fair::graph::scheduler::init(graph) }, _graph(std::move(graph)) {
+    explicit breadth_first(fair::graph::graph &&graph, std::shared_ptr<thread_pool_type> thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool<thread_pool::CPU_BOUND>>("breadth-first-pool"))
+            : _init{fair::graph::scheduler::init(graph)}, _graph(std::move(graph)), _pool(thread_pool) {
         std::map<node_t, std::vector<node_t>> _adjacency_list{};
         std::vector<node_t>                   _source_nodes{};
         // compute the adjacency list
@@ -96,7 +176,9 @@ public:
         std::set<node_t>   reached;
         // add all source nodes to queue
         for (node_t source_node : _source_nodes) {
-            queue.push(source_node);
+            if (!reached.contains(source_node)) {
+                queue.push(source_node);
+            }
             reached.insert(source_node);
         }
         // process all nodes, adding all unvisited child nodes to the queue
@@ -104,13 +186,24 @@ public:
             node_t current_node = queue.front();
             queue.pop();
             _nodelist.push_back(current_node);
-            if (_adjacency_list.contains(current_node)) { // current_node has outgoing edges
+            if (_adjacency_list.contains(current_node)) { // node has outgoing edges
                 for (auto &dst : _adjacency_list.at(current_node)) {
                     if (!reached.contains(dst)) { // detect cycles. this could be removed if we guarantee cycle free graphs earlier
                         queue.push(dst);
                         reached.insert(dst);
                     }
                 }
+            }
+        }
+        // generate job list
+        const auto n_batches = std::min(static_cast<std::size_t>(_pool->maxThreads()), _nodelist.size());
+        _job_lists.reserve(n_batches);
+        for (std::size_t i = 0; i < n_batches; i++) {
+            // create job-set for thread
+            auto &job = _job_lists.emplace_back();
+            job.reserve(_nodelist.size() / n_batches + 1);
+            for (std::size_t j = i; j < _nodelist.size(); j += n_batches) {
+                job.push_back(_nodelist[j]);
             }
         }
     }
@@ -120,17 +213,37 @@ public:
         if (!_init) {
             return work_return_t::ERROR;
         }
-        while (true) {
-            bool anything_happened = false;
-            for (auto current_node : _nodelist) {
-                auto res = current_node->work();
-                anything_happened |= (res == work_return_t::OK || res == work_return_t::INSUFFICIENT_OUTPUT_ITEMS);
+        if constexpr (executionPolicy == single_threaded) {
+            bool run = true;
+            while (run) {
+                if (auto result = detail::traverse_nodes(std::span{_nodelist}); result == work_return_t::ERROR) {
+                    return work_return_t::ERROR;
+                } else {
+                    run = (result == work_return_t::OK);
+                }
             }
-            if (!anything_happened) {
-                return work_return_t::DONE;
+        } else if (executionPolicy == multi_threaded) {
+            std::atomic_bool stop_requested;
+            std::atomic_uint64_t progress{0}; // upper uint32t: progress counter, lower uint32t: number of workers that finished all their work
+            std::latch running_threads{static_cast<std::ptrdiff_t>(_job_lists.size())}; // latch to wait for completion of the flowgraph
+            for (auto &job: _job_lists) {
+                //_pool->execute(detail::run_on_pool, std::span{job}, _job_lists.size(), progress, running_threads, stoken);
+                _pool->execute([this, &job, &progress, &running_threads, &stop_requested]() {
+                    detail::run_on_pool(std::span{job}, _job_lists.size(), progress, running_threads, stop_requested);
+                });
             }
+            running_threads.wait();
+            return work_return_t::DONE;
+        } else {
+            throw std::invalid_argument("Unknown execution Policy");
         }
+        return work_return_t::DONE;
     }
+
+    const std::vector<std::vector<node_t>> &getJobLists() const {
+        return _job_lists;
+    }
+
 };
 } // namespace fair::graph::scheduler
 

--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -321,7 +321,6 @@ concept ThreadPool = requires(T t, std::function<void()> &&func) {
  * }
  * @endcode
  */
-template<TaskType taskType>
 class BasicThreadPool {
     using Task      = thread_pool::detail::Task;
     using TaskQueue = thread_pool::detail::TaskQueue;
@@ -351,6 +350,7 @@ class BasicThreadPool {
     int                          _schedulingPriority = 0;
 
     const std::string            _poolName;
+    const TaskType               _taskType;
     const uint32_t               _minThreads;
     const uint32_t               _maxThreads;
 
@@ -358,8 +358,8 @@ public:
     std::chrono::microseconds    sleepDuration       = std::chrono::milliseconds(1);
     std::chrono::milliseconds    keepAliveDuration = std::chrono::seconds(10);
 
-    BasicThreadPool(const std::string_view &name = generateName(), uint32_t min = std::thread::hardware_concurrency(), uint32_t max = std::thread::hardware_concurrency())
-        : _poolName(name), _minThreads(min), _maxThreads(max) {
+    BasicThreadPool(const std::string_view &name = generateName(), const TaskType taskType = TaskType::CPU_BOUND, uint32_t min = std::thread::hardware_concurrency(), uint32_t max = std::thread::hardware_concurrency())
+        : _poolName(name), _taskType(taskType), _minThreads(min), _maxThreads(max) {
         assert(min > 0 && "minimum number of threads must be > 0");
         assert(min <= max && "minimum number of threads must be <= maximum number of threads");
         for (uint32_t i = 0; i < _minThreads; ++i) {
@@ -376,9 +376,9 @@ public:
     }
 
     BasicThreadPool(const BasicThreadPool &) = delete;
-    BasicThreadPool(BasicThreadPool &&)      = default;
+    BasicThreadPool(BasicThreadPool &&)      = delete;
     BasicThreadPool           &operator=(const BasicThreadPool &) = delete;
-    BasicThreadPool           &operator=(BasicThreadPool &&) = default;
+    BasicThreadPool           &operator=(BasicThreadPool &&) = delete;
 
     [[nodiscard]] std::string  poolName() const noexcept { return _poolName; }
     [[nodiscard]] uint32_t     minThreads() const noexcept { return _minThreads; };
@@ -435,7 +435,7 @@ public:
 
         _taskQueue.push(createTask<taskName, priority, cpuID>(std::forward<decltype(func)>(func), std::forward<decltype(func)>(args)...));
         _condition.notify_one();
-        if constexpr (taskType == TaskType::IO_BOUND) {
+        if (_taskType == TaskType::IO_BOUND) {
             spinWait.spinOnce();
             spinWait.spinOnce();
             while (_taskQueue.size() > 0) {
@@ -493,7 +493,7 @@ private:
         thread::setThreadName(fmt::format("{}#{}", _poolName, threadID), thread);
         thread::setThreadSchedulingParameter(_schedulingPolicy, _schedulingPriority, thread);
         if (!_affinityMask.empty()) {
-            if (taskType == TaskType::IO_BOUND) {
+            if (_taskType == TaskType::IO_BOUND) {
                 thread::setThreadAffinity(_affinityMask);
                 return;
             }
@@ -636,12 +636,9 @@ private:
         } while (running);
     }
 };
-template<TaskType T>
-inline std::atomic<uint64_t> BasicThreadPool<T>::_globalPoolId = 0U;
-template<TaskType T>
-inline std::atomic<uint64_t> BasicThreadPool<T>::_taskID = 0U;
-static_assert(ThreadPool<BasicThreadPool<IO_BOUND>>);
-static_assert(ThreadPool<BasicThreadPool<CPU_BOUND>>);
+inline std::atomic<uint64_t> BasicThreadPool::_globalPoolId = 0U;
+inline std::atomic<uint64_t> BasicThreadPool::_taskID = 0U;
+static_assert(ThreadPool<BasicThreadPool>);
 
 }
 

--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -376,9 +376,9 @@ public:
     }
 
     BasicThreadPool(const BasicThreadPool &) = delete;
-    BasicThreadPool(BasicThreadPool &&)      = delete;
+    BasicThreadPool(BasicThreadPool &&)      = default;
     BasicThreadPool           &operator=(const BasicThreadPool &) = delete;
-    BasicThreadPool           &operator=(BasicThreadPool &&) = delete;
+    BasicThreadPool           &operator=(BasicThreadPool &&) = default;
 
     [[nodiscard]] std::string  poolName() const noexcept { return _poolName; }
     [[nodiscard]] uint32_t     minThreads() const noexcept { return _minThreads; };

--- a/test/app_grc.cpp
+++ b/test/app_grc.cpp
@@ -54,7 +54,7 @@ main(int argc, char *argv[]) {
         assert(graph_saved_source + "\n" == graph_expected_source);
 
         fair::graph::scheduler::simple scheduler(std::move(graph));
-        scheduler.work();
+        scheduler.run_and_wait();
     }
 
     // Test if we get the same graph when saving it and loading the saved

--- a/test/qa_dynamic_port.cpp
+++ b/test/qa_dynamic_port.cpp
@@ -169,7 +169,7 @@ const boost::ut::suite PortApiTests = [] {
         expect(eq(connection_result_t::SUCCESS, flow.connect<"sum">(added).to<"sink">(out)));
 
         fair::graph::scheduler::simple sched{ std::move(flow) };
-        sched.work();
+        sched.run_and_wait();
     };
 
 #ifdef ENABLE_DYNAMIC_PORTS

--- a/test/qa_hier_node.cpp
+++ b/test/qa_hier_node.cpp
@@ -194,7 +194,7 @@ make_graph(std::size_t events_count) {
 
 int
 main() {
-    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool<fair::thread_pool::CPU_BOUND>>("custom pool", 2,2);
+    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2,2);
 
     fg::scheduler::simple scheduler(make_graph(10), thread_pool);
 

--- a/test/qa_hier_node.cpp
+++ b/test/qa_hier_node.cpp
@@ -87,7 +87,8 @@ public:
 
     fg::work_return_t
     work() override {
-        return _scheduler.work();
+        _scheduler.run_and_wait();
+        return fair::graph::work_return_t::DONE;
     }
 
     void *
@@ -194,9 +195,9 @@ make_graph(std::size_t events_count) {
 
 int
 main() {
-    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2,2);
+    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2,2); // use custom pool to limit number of threads for emscripten
 
     fg::scheduler::simple scheduler(make_graph(10), thread_pool);
 
-    scheduler.work();
+    scheduler.run_and_wait();
 }

--- a/test/qa_hier_node.cpp
+++ b/test/qa_hier_node.cpp
@@ -50,7 +50,7 @@ protected:
 
     using in_port_t                              = fg::IN<T>;
 
-    fg::scheduler::simple _scheduler;
+    fg::scheduler::simple<> _scheduler;
 
     fg::graph
     make_graph() {
@@ -194,7 +194,9 @@ make_graph(std::size_t events_count) {
 
 int
 main() {
-    fg::scheduler::simple scheduler(make_graph(10));
+    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool<fair::thread_pool::CPU_BOUND>>("custom pool", 2,2);
+
+    fg::scheduler::simple scheduler(make_graph(10), thread_pool);
 
     scheduler.work();
 }

--- a/test/qa_scheduler.cpp
+++ b/test/qa_scheduler.cpp
@@ -4,144 +4,156 @@
 
 #if defined(__clang__) && __clang_major__ >= 16
 // clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
+template <>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
 #endif
 
-namespace fg       = fair::graph;
+namespace fg = fair::graph;
 
-using trace_vector = std::vector<std::string>;
-
-static void
-trace(trace_vector &traceVector, std::string_view id) {
-    if (traceVector.empty() || traceVector.back() != id) {
-        traceVector.emplace_back(id);
+using trace_vector_type = std::vector<std::string>;
+class tracer{
+    std::mutex        _trace_mutex;
+    trace_vector_type _trace_vector;
+public:
+    void trace(std::string_view id) {
+        std::scoped_lock lock{ _trace_mutex };
+        if (_trace_vector.empty() || _trace_vector.back() != id) {
+            _trace_vector.emplace_back(id);
+        }
     }
-}
+
+    trace_vector_type get_vec() {
+        std::scoped_lock lock{_trace_mutex};
+        return {_trace_vector};
+    }
+};
 
 // define some example graph nodes
 template<typename T, std::size_t N>
 class count_source : public fg::node<count_source<T, N>, fg::OUT<T, 0, std::numeric_limits<std::size_t>::max(), "out">> {
-    trace_vector &tracer;
-    std::size_t   count = 0;
-
+    tracer     &_tracer;
+    std::size_t _count = 0;
 public:
-    count_source(trace_vector &trace, std::string_view name) : tracer{ trace } { this->_name = name; }
+    count_source(tracer &trace, std::string_view name) : _tracer{trace} { this->_name = name;}
 
     constexpr std::make_signed_t<std::size_t>
-    available_samples(const count_source & /*d*/) noexcept {
-        const auto ret = static_cast<std::make_signed_t<std::size_t>>(N - count);
+    available_samples(const count_source &/*d*/) noexcept {
+        const auto ret = static_cast<std::make_signed_t<std::size_t>>(N - _count);
         return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
     }
 
     constexpr T
     process_one() {
-        trace(tracer, this->name());
-        return static_cast<int>(count++);
+        _tracer.trace(this->name());
+        return static_cast<int>(_count++);
     }
 };
 
-template<typename T>
-class expect_sink : public fg::node<expect_sink<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "in">> {
-    trace_vector                                   &tracer;
-    std::int64_t                                    count = 0;
+template<typename T, std::int64_t N>
+class expect_sink : public fg::node<expect_sink<T, N>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "in">> {
+    tracer       &_tracer;
+    std::int64_t _count = 0;
     std::function<void(std::int64_t, std::int64_t)> _checker;
-
 public:
-    expect_sink(trace_vector &trace, std::string_view name, std::function<void(std::int64_t, std::int64_t)> &&checker) : tracer{ trace }, _checker(std::move(checker)) { this->_name = name; }
+    expect_sink(tracer &trace, std::string_view name, std::function<void(std::int64_t, std::int64_t)> &&checker) : _tracer{trace}, _checker(std::move(checker)) { this->_name = name;}
+
+    ~expect_sink() {
+        boost::ut::expect(boost::ut::that % _count == N);
+    }
 
     [[nodiscard]] fg::work_return_t
     process_bulk(std::span<const T> input) noexcept {
-        trace(tracer, this->name());
-        for (auto data : input) {
-            _checker(count, data);
-            count++;
+        _tracer.trace(this->name());
+        for (auto data: input) {
+            _checker(_count, data);
+            _count++;
         }
         return fg::work_return_t::OK;
     }
-
     constexpr void
-    process_one(T /*a*/) const noexcept {
-        trace(tracer, this->name());
+    process_one(T /*a*/) noexcept {
+        _tracer.trace(this->name());
     }
 };
 
 template<typename T, T Scale, typename R = decltype(std::declval<T>() * std::declval<T>())>
 class scale : public fg::node<scale<T, Scale, R>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "original">, fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "scaled">> {
-    trace_vector &tracer;
-
+    tracer &_tracer;
 public:
-    scale(trace_vector &trace, std::string_view name) : tracer{ trace } { this->_name = name; }
-
+    scale(tracer &trace, std::string_view name) : _tracer{trace} {this->_name = name;}
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
-    process_one(V a) const noexcept {
-        trace(tracer, this->name());
+    process_one(V a) noexcept {
+        _tracer.trace(this->name());
         return a * Scale;
     }
 };
 
 template<typename T, typename R = decltype(std::declval<T>() + std::declval<T>())>
-class adder : public fg::node<adder<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend0">, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend1">,
-                              fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "sum">> {
-    trace_vector &tracer;
-
+class adder : public fg::node<adder<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend0">, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend1">, fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "sum">> {
+    tracer &_tracer;
 public:
-    adder(trace_vector &trace, std::string_view name) : tracer{ trace } { this->_name = name; }
-
+    adder(tracer &trace, std::string_view name) : _tracer(trace) {this->_name = name;}
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
-    process_one(V a, V b) const noexcept {
-        trace(tracer, this->name());
+    process_one(V a, V b) noexcept {
+        _tracer.trace(this->name());
         return a + b;
     }
 };
 
 fair::graph::graph
-get_graph_linear(trace_vector &traceVector) {
+get_graph_linear(tracer &trace) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-    // Nodes need to be alive for as long as the flow is
+// Nodes need to be alive for as long as the flow is
     fg::graph flow;
-    // Generators
-    auto &source1      = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
-    auto &scale_block1 = flow.make_node<scale<int, 2>>(traceVector, "mult1");
-    auto &scale_block2 = flow.make_node<scale<int, 4>>(traceVector, "mult2");
-    auto &sink         = flow.make_node<expect_sink<int>>(traceVector, "out", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 8 * count); });
+// Generators
+    auto& source1 = flow.make_node<count_source<int, 100000>>(trace, "s1");
+    auto& scale_block1 = flow.make_node<scale<int, 2>>(trace, "mult1");
+    auto& scale_block2 = flow.make_node<scale<int, 4>>(trace, "mult2");
+    auto& sink = flow.make_node<expect_sink<int, 100000>>(trace, "out", [](std::uint64_t count, std::uint64_t data) {
+        boost::ut::expect(boost::ut::that % data == 8 * count);
+    } );
 
-    std::ignore        = flow.connect<"scaled">(scale_block2).to<"in">(sink);
-    std::ignore        = flow.connect<"scaled">(scale_block1).to<"original">(scale_block2);
-    std::ignore        = flow.connect<"out">(source1).to<"original">(scale_block1);
+    std::ignore = flow.connect<"scaled">(scale_block2).to<"in">(sink);
+    std::ignore = flow.connect<"scaled">(scale_block1).to<"original">(scale_block2);
+    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1);
 
     return flow;
 }
 
 fair::graph::graph
-get_graph_parallel(trace_vector &traceVector) {
+get_graph_parallel(tracer &trace) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-    // Nodes need to be alive for as long as the flow is
+// Nodes need to be alive for as long as the flow is
     fg::graph flow;
-    // Generators
-    auto &source1       = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
-    auto &scale_block1a = flow.make_node<scale<int, 2>>(traceVector, "mult1a");
-    auto &scale_block2a = flow.make_node<scale<int, 3>>(traceVector, "mult2a");
-    auto &sink_a        = flow.make_node<expect_sink<int>>(traceVector, "outa", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 6 * count); });
-    auto &scale_block1b = flow.make_node<scale<int, 3>>(traceVector, "mult1b");
-    auto &scale_block2b = flow.make_node<scale<int, 5>>(traceVector, "mult2b");
-    auto &sink_b        = flow.make_node<expect_sink<int>>(traceVector, "outb", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 15 * count); });
+// Generators
+    auto& source1 = flow.make_node<count_source<int, 100000>>(trace, "s1");
+    auto& scale_block1a = flow.make_node<scale<int, 2>>(trace, "mult1a");
+    auto& scale_block2a = flow.make_node<scale<int, 3>>(trace, "mult2a");
+    auto& sink_a = flow.make_node<expect_sink<int, 100000>>(trace, "outa", [](std::uint64_t count, std::uint64_t data) {
+        boost::ut::expect(boost::ut::that % data == 6 * count);
+    } );
+    auto& scale_block1b = flow.make_node<scale<int, 3>>(trace, "mult1b");
+    auto& scale_block2b = flow.make_node<scale<int, 5>>(trace, "mult2b");
+    auto& sink_b = flow.make_node<expect_sink<int, 100000>>(trace, "outb", [](std::uint64_t count, std::uint64_t data) {
+        boost::ut::expect(boost::ut::that % data == 15 * count);
+    } );
 
-    std::ignore         = flow.connect<"scaled">(scale_block1a).to<"original">(scale_block2a);
-    std::ignore         = flow.connect<"scaled">(scale_block1b).to<"original">(scale_block2b);
-    std::ignore         = flow.connect<"scaled">(scale_block2b).to<"in">(sink_b);
-    std::ignore         = flow.connect<"out">(source1).to<"original">(scale_block1a);
-    std::ignore         = flow.connect<"scaled">(scale_block2a).to<"in">(sink_a);
-    std::ignore         = flow.connect<"out">(source1).to<"original">(scale_block1b);
+    std::ignore = flow.connect<"scaled">(scale_block1a).to<"original">(scale_block2a);
+    std::ignore = flow.connect<"scaled">(scale_block1b).to<"original">(scale_block2b);
+    std::ignore = flow.connect<"scaled">(scale_block2b).to<"in">(sink_b);
+    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1a);
+    std::ignore = flow.connect<"scaled">(scale_block2a).to<"in">(sink_a);
+    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1b);
 
     return flow;
 }
+
 
 /**
  * sets up an example graph
@@ -160,101 +172,163 @@ get_graph_parallel(trace_vector &traceVector) {
  * └───────────┘
  */
 fair::graph::graph
-get_graph_scaled_sum(trace_vector &traceVector) {
+get_graph_scaled_sum(tracer &trace) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-    // Nodes need to be alive for as long as the flow is
+// Nodes need to be alive for as long as the flow is
     fg::graph flow;
 
-    // Generators
-    auto &source1     = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
-    auto &source2     = flow.make_node<count_source<int, 100000>>(traceVector, "s2");
-    auto &scale_block = flow.make_node<scale<int, 2>>(traceVector, "mult");
-    auto &add_block   = flow.make_node<adder<int>>(traceVector, "add");
-    auto &sink        = flow.make_node<expect_sink<int>>(traceVector, "out", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == (2 * count) + count); });
+// Generators
+    auto& source1 = flow.make_node<count_source<int, 100000>>(trace, "s1");
+    auto& source2 = flow.make_node<count_source<int, 100000>>(trace, "s2");
+    auto& scale_block = flow.make_node<scale<int, 2>>(trace, "mult");
+    auto& add_block = flow.make_node<adder<int>>(trace, "add");
+    auto& sink = flow.make_node<expect_sink<int, 100000>>(trace, "out", [](std::uint64_t count, std::uint64_t data) {
+        boost::ut::expect(boost::ut::that % data == (2 * count) + count);
+    } );
 
-    std::ignore       = flow.connect<"out">(source1).to<"original">(scale_block);
-    std::ignore       = flow.connect<"scaled">(scale_block).to<"addend0">(add_block);
-    std::ignore       = flow.connect<"out">(source2).to<"addend1">(add_block);
-    std::ignore       = flow.connect<"sum">(add_block).to<"in">(sink);
+    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block);
+    std::ignore = flow.connect<"scaled">(scale_block).to<"addend0">(add_block);
+    std::ignore = flow.connect<"out">(source2).to<"addend1">(add_block);
+    std::ignore = flow.connect<"sum">(add_block).to<"in">(sink);
 
     return flow;
+}
+
+template<typename node_type>
+void check_node_names(std::vector<node_type> joblist, std::set<std::string> set) {
+    boost::ut::expect(boost::ut::that % joblist.size() == set.size());
+    for (auto &node: joblist) {
+        boost::ut::expect(boost::ut::that % set.contains(std::string(node->name()))) << fmt::format("{} not in {}\n", node->name(), set);
+    }
 }
 
 const boost::ut::suite SchedulerTests = [] {
     using namespace boost::ut;
     using namespace fair::graph;
+    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool<fair::thread_pool::CPU_BOUND>>("custom pool", 2,2);
 
-    "SimpleScheduler_linear"_test = [] {
-        using scheduler = fair::graph::scheduler::simple;
-        trace_vector t{};
-        auto         sched = scheduler{ get_graph_linear(t) };
+    "SimpleScheduler_linear"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::simple<>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_linear(trace), thread_pool};
         sched.work();
+        auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 8u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
     };
 
-    "BreadthFirstScheduler_linear"_test = [] {
-        using scheduler = fair::graph::scheduler::breadth_first;
-        trace_vector t{};
-        auto         sched = scheduler{ get_graph_linear(t) };
+    "BreadthFirstScheduler_linear"_test = [&] {
+        using scheduler = fair::graph::scheduler::breadth_first<>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_linear(trace), thread_pool};
         sched.work();
+        auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 8u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out"});
     };
 
-    "SimpleScheduler_parallel"_test = [] {
-        using scheduler = fair::graph::scheduler::simple;
-        trace_vector t{};
-        auto         sched = scheduler{ get_graph_parallel(t) };
+    "SimpleScheduler_parallel"_test = [&] {
+        using scheduler = fair::graph::scheduler::simple<>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_parallel(trace), thread_pool};
         sched.work();
+        auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 14u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb", "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb" });
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb", "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb"});
     };
 
-    "BreadthFirstScheduler_parallel"_test = [] {
-        using scheduler = fair::graph::scheduler::breadth_first;
-        trace_vector t{};
-        auto         sched = scheduler{ get_graph_parallel(t) };
+    "BreadthFirstScheduler_parallel"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::breadth_first<>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_parallel(trace), thread_pool};
         sched.work();
+        auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 14u);
-        expect(boost::ut::that % t
-               == trace_vector{
-                       "s1",
-                       "mult1a",
-                       "mult1b",
-                       "mult2a",
-                       "mult2b",
-                       "outa",
-                       "outb",
-                       "s1",
-                       "mult1a",
-                       "mult1b",
-                       "mult2a",
-                       "mult2b",
-                       "outa",
-                       "outb",
-               });
+        expect(boost::ut::that % t == trace_vector_type{"s1", "mult1a", "mult1b", "mult2a", "mult2b", "outa", "outb", "s1", "mult1a", "mult1b", "mult2a", "mult2b", "outa", "outb", });
     };
 
-    "SimpleScheduler_scaled_sum"_test = [] {
-        using scheduler = fair::graph::scheduler::simple;
+    "SimpleScheduler_scaled_sum"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::simple<>;
         // construct an example graph and get an adjacency list for it
-        trace_vector t{};
-        auto         sched = scheduler{ get_graph_scaled_sum(t) };
+        tracer trace{};
+        auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
         sched.work();
+        auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 10u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out" });
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out"});
     };
 
-    "BreadthFirstScheduler_scaled_sum"_test = [] {
-        using scheduler = fair::graph::scheduler::breadth_first;
-        trace_vector t{};
-        auto         sched = scheduler{ get_graph_scaled_sum(t) };
+    "BreadthFirstScheduler_scaled_sum"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::breadth_first<>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
         sched.work();
+        auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 10u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out" });
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out"});
+    };
+
+    "SimpleScheduler_linear_multi_threaded"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::simple<fg::scheduler::execution_policy::multi_threaded>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_linear(trace), thread_pool};
+        expect(sched.work() == work_return_t::DONE);
+        auto t = trace.get_vec();
+        expect(that % t.size() >= 8u);
+    };
+
+    "BreadthFirstScheduler_linear_multi_threaded"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_linear(trace), thread_pool};
+        check_node_names(sched.getJobLists()[0], {"s1", "mult2"});
+        check_node_names(sched.getJobLists()[1], {"mult1", "out"});
+        sched.work();
+        auto t = trace.get_vec();
+        expect(boost::ut::that % t.size() >= 8u);
+    };
+
+    "SimpleScheduler_parallel_multi_threaded"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::simple<fg::scheduler::execution_policy::multi_threaded>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_parallel(trace), thread_pool};
+        sched.work();
+        auto t = trace.get_vec();
+        expect(boost::ut::that % t.size() >= 14u);
+    };
+
+    "BreadthFirstScheduler_parallel_multi_threaded"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_parallel(trace), thread_pool};
+        check_node_names(sched.getJobLists()[0], {"s1", "mult1b", "mult2b",  "outb"});
+        check_node_names(sched.getJobLists()[1], {"mult1a", "mult2a",  "outa"});
+        sched.work();
+        auto t = trace.get_vec();
+        expect(boost::ut::that % t.size() >= 14u);
+    };
+
+    "SimpleScheduler_scaled_sum_multi_threaded"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::simple<fg::scheduler::execution_policy::multi_threaded>;
+        // construct an example graph and get an adjacency list for it
+        tracer trace{};
+        auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
+        sched.work();
+        auto t = trace.get_vec();
+        expect(boost::ut::that % t.size() >= 10u);
+    };
+
+    "BreadthFirstScheduler_scaled_sum_multi_threaded"_test = [&thread_pool] {
+        using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
+        tracer trace{};
+        auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
+        check_node_names(sched.getJobLists()[0], {"s1", "mult",  "out"});
+        check_node_names(sched.getJobLists()[1], {"s2", "add"});
+        sched.work();
+        auto t = trace.get_vec();
+        expect(boost::ut::that % t.size() >= 10u);
     };
 };
 

--- a/test/qa_scheduler.cpp
+++ b/test/qa_scheduler.cpp
@@ -207,7 +207,7 @@ void check_node_names(std::vector<node_type> joblist, std::set<std::string> set)
 const boost::ut::suite SchedulerTests = [] {
     using namespace boost::ut;
     using namespace fair::graph;
-    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool<fair::thread_pool::CPU_BOUND>>("custom pool", 2,2);
+    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
 
     "SimpleScheduler_linear"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::simple<>;

--- a/test/qa_scheduler.cpp
+++ b/test/qa_scheduler.cpp
@@ -197,7 +197,7 @@ get_graph_scaled_sum(tracer &trace) {
 }
 
 template<typename node_type>
-void check_node_names(std::vector<node_type> joblist, std::set<std::string> set) {
+void check_node_names(const std::vector<node_type> &joblist, std::set<std::string> set) {
     boost::ut::expect(boost::ut::that % joblist.size() == set.size());
     for (auto &node: joblist) {
         boost::ut::expect(boost::ut::that % set.contains(std::string(node->name()))) << fmt::format("{} not in {}\n", node->name(), set);
@@ -283,6 +283,8 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
         auto sched = scheduler{get_graph_linear(trace), thread_pool};
+        sched.init();
+        expect(sched.getJobLists().size() == 2u);
         check_node_names(sched.getJobLists()[0], {"s1", "mult2"});
         check_node_names(sched.getJobLists()[1], {"mult1", "out"});
         sched.work();
@@ -303,6 +305,8 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
         auto sched = scheduler{get_graph_parallel(trace), thread_pool};
+        sched.init();
+        expect(sched.getJobLists().size() == 2u);
         check_node_names(sched.getJobLists()[0], {"s1", "mult1b", "mult2b",  "outb"});
         check_node_names(sched.getJobLists()[1], {"mult1a", "mult2a",  "outa"});
         sched.work();
@@ -324,6 +328,8 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
         auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
+        sched.init();
+        expect(sched.getJobLists().size() == 2u);
         check_node_names(sched.getJobLists()[0], {"s1", "mult",  "out"});
         check_node_names(sched.getJobLists()[1], {"s2", "add"});
         sched.work();

--- a/test/qa_scheduler.cpp
+++ b/test/qa_scheduler.cpp
@@ -213,7 +213,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::simple<>;
         tracer trace{};
         auto sched = scheduler{get_graph_linear(trace), thread_pool};
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 8u);
         expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
@@ -223,7 +223,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::breadth_first<>;
         tracer trace{};
         auto sched = scheduler{get_graph_linear(trace), thread_pool};
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 8u);
         expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out"});
@@ -233,7 +233,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::simple<>;
         tracer trace{};
         auto sched = scheduler{get_graph_parallel(trace), thread_pool};
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 14u);
         expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb", "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb"});
@@ -243,7 +243,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::breadth_first<>;
         tracer trace{};
         auto sched = scheduler{get_graph_parallel(trace), thread_pool};
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 14u);
         expect(boost::ut::that % t == trace_vector_type{"s1", "mult1a", "mult1b", "mult2a", "mult2b", "outa", "outb", "s1", "mult1a", "mult1b", "mult2a", "mult2b", "outa", "outb", });
@@ -254,7 +254,7 @@ const boost::ut::suite SchedulerTests = [] {
         // construct an example graph and get an adjacency list for it
         tracer trace{};
         auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 10u);
         expect(boost::ut::that % t == trace_vector_type{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out"});
@@ -264,7 +264,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::breadth_first<>;
         tracer trace{};
         auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 10u);
         expect(boost::ut::that % t == trace_vector_type{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out"});
@@ -274,7 +274,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::simple<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
         auto sched = scheduler{get_graph_linear(trace), thread_pool};
-        expect(sched.work() == work_return_t::DONE);
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(that % t.size() >= 8u);
     };
@@ -287,7 +287,7 @@ const boost::ut::suite SchedulerTests = [] {
         expect(sched.getJobLists().size() == 2u);
         check_node_names(sched.getJobLists()[0], {"s1", "mult2"});
         check_node_names(sched.getJobLists()[1], {"mult1", "out"});
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 8u);
     };
@@ -296,7 +296,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::simple<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
         auto sched = scheduler{get_graph_parallel(trace), thread_pool};
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 14u);
     };
@@ -309,7 +309,7 @@ const boost::ut::suite SchedulerTests = [] {
         expect(sched.getJobLists().size() == 2u);
         check_node_names(sched.getJobLists()[0], {"s1", "mult1b", "mult2b",  "outb"});
         check_node_names(sched.getJobLists()[1], {"mult1a", "mult2a",  "outa"});
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 14u);
     };
@@ -319,7 +319,7 @@ const boost::ut::suite SchedulerTests = [] {
         // construct an example graph and get an adjacency list for it
         tracer trace{};
         auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 10u);
     };
@@ -332,7 +332,7 @@ const boost::ut::suite SchedulerTests = [] {
         expect(sched.getJobLists().size() == 2u);
         check_node_names(sched.getJobLists()[0], {"s1", "mult",  "out"});
         check_node_names(sched.getJobLists()[1], {"s2", "add"});
-        sched.work();
+        sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 10u);
     };

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -238,11 +238,11 @@ const boost::ut::suite SettingsTests = [] {
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block1).to<"in">(block2)));
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block2).to<"in">(sink)));
 
-        auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
+        auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2); // use custom pool to limit number of threads for emscripten
         fair::graph::scheduler::simple sched{ std::move(flow_graph), thread_pool };
         expect(src.settings().auto_update_parameters().contains("sample_rate"));
         std::ignore = src.settings().set({ { "sample_rate", 49000.0f } });
-        sched.work();
+        sched.run_and_wait();
         expect(eq(src.n_samples_produced, n_samples)) << "did not produce enough output samples";
         expect(eq(sink.n_samples_consumed, n_samples)) << "did not consume enough input samples";
 

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -238,7 +238,8 @@ const boost::ut::suite SettingsTests = [] {
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block1).to<"in">(block2)));
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block2).to<"in">(sink)));
 
-        fair::graph::scheduler::simple sched{ std::move(flow_graph) };
+        auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool<fair::thread_pool::CPU_BOUND>>("custom pool", 2,2);
+        fair::graph::scheduler::simple sched{ std::move(flow_graph), thread_pool };
         expect(src.settings().auto_update_parameters().contains("sample_rate"));
         std::ignore = src.settings().set({ { "sample_rate", 49000.0f } });
         sched.work();

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -238,7 +238,7 @@ const boost::ut::suite SettingsTests = [] {
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block1).to<"in">(block2)));
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block2).to<"in">(sink)));
 
-        auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool<fair::thread_pool::CPU_BOUND>>("custom pool", 2,2);
+        auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
         fair::graph::scheduler::simple sched{ std::move(flow_graph), thread_pool };
         expect(src.settings().auto_update_parameters().contains("sample_rate"));
         std::ignore = src.settings().set({ { "sample_rate", 49000.0f } });

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -90,7 +90,7 @@ const boost::ut::suite TagPropagation = [] {
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor2).to<"in">(sink2)));
 
         scheduler::simple sched{ std::move(flow_graph) };
-        sched.work();
+        sched.run_and_wait();
 
         expect(eq(src.n_samples_produced, n_samples)) << "src did not produce enough output samples";
         expect(eq(monitor1.n_samples_produced, n_samples)) << "monitor1 did not consume enough input samples";

--- a/test/qa_thread_pool.cpp
+++ b/test/qa_thread_pool.cpp
@@ -11,12 +11,12 @@ const boost::ut::suite ThreadPoolTests = [] {
     using namespace boost::ut;
 
     "Basic ThreadPool tests"_test = [] {
-        expect(nothrow([] { fair::thread_pool::BasicThreadPool<fair::thread_pool::IO_BOUND>(); }));
-        expect(nothrow([] { fair::thread_pool::BasicThreadPool<fair::thread_pool::CPU_BOUND>(); }));
+        expect(nothrow([] { fair::thread_pool::BasicThreadPool("test", fair::thread_pool::IO_BOUND); }));
+        expect(nothrow([] { fair::thread_pool::BasicThreadPool("test2", fair::thread_pool::CPU_BOUND); }));
 
         std::atomic<int> enqueueCount{0};
         std::atomic<int> executeCount{0};
-        fair::thread_pool::BasicThreadPool<fair::thread_pool::IO_BOUND> pool("TestPool", 1, 2);
+        fair::thread_pool::BasicThreadPool pool("TestPool", fair::thread_pool::IO_BOUND, 1, 2);
         expect(nothrow([&] { pool.sleepDuration = std::chrono::milliseconds(1); }));
         expect(nothrow([&] { pool.keepAliveDuration = std::chrono::seconds(10); }));
         pool.waitUntilInitialised();
@@ -60,7 +60,7 @@ const boost::ut::suite ThreadPoolTests = [] {
     };
     "contention tests"_test = [] {
         std::atomic<int> counter{0};
-        fair::thread_pool::BasicThreadPool<fair::thread_pool::IO_BOUND> pool("contention", 1, 4);
+        fair::thread_pool::BasicThreadPool pool("contention", fair::thread_pool::IO_BOUND, 1, 4);
         pool.waitUntilInitialised();
         expect(that % pool.isInitialised());
         expect(pool.numThreads() == 1_u);
@@ -99,7 +99,7 @@ const boost::ut::suite ThreadPoolTests = [] {
                 std::atomic<int> counter{0};
 
                 // Pool with min and max thread count
-                fair::thread_pool::BasicThreadPool<fair::thread_pool::IO_BOUND> pool("count_test", minThreads, maxThreads);
+                fair::thread_pool::BasicThreadPool pool("count_test", fair::thread_pool::IO_BOUND, minThreads, maxThreads);
                 pool.keepAliveDuration = std::chrono::milliseconds(10); // default is 10 seconds, reducing for testing
                 pool.waitUntilInitialised();
 


### PR DESCRIPTION
Adds basic multi-threaded implementations for the simple scheduling algorithms (simple & breadth-first).

fixes #76 