### PR TITLE
Remove conversion's warnings.

### DIFF
--- a/include/buffer_skeleton.hpp
+++ b/include/buffer_skeleton.hpp
@@ -17,81 +17,94 @@ namespace gr::test {
  *
  * @tparam T the internally stored type parameter
  */
-template <typename T>
-class buffer_skeleton
-{
+template<typename T>
+class buffer_skeleton {
     struct buffer_impl {
         const std::size_t _size;
-        std::vector<T> _data;
+        std::vector<T>    _data;
 
         buffer_impl() = delete;
         explicit buffer_impl(const std::size_t min_size) : _size(min_size), _data(_size){};
         ~buffer_impl() = default;
     };
 
-
-    template <typename U>
+    template<typename U>
     class buffer_reader {
         std::shared_ptr<buffer_impl> _buffer;
 
         buffer_reader() = delete;
+
         explicit buffer_reader(std::shared_ptr<buffer_impl> buffer) : _buffer(buffer) {}
+
         friend buffer_skeleton<T>;
 
     public:
-        [[nodiscard]] buffer_skeleton buffer() const noexcept { return buffer_skeleton(_buffer); };
+        [[nodiscard]] buffer_skeleton
+        buffer() const noexcept {
+            return buffer_skeleton(_buffer);
+        };
 
-        template <bool strict_check = true>
-        [[nodiscard]] std::span<const U> get(const std::size_t /* n_requested = 0*/) const
-            noexcept(!strict_check)
-        {
+        template<bool strict_check = true>
+        [[nodiscard]] std::span<const U>
+        get(const std::size_t /* n_requested = 0*/) const noexcept(!strict_check) {
             return {};
         }
 
-        template <bool strict_check = true>
-        [[nodiscard]] bool consume(const std::size_t /* n_items = 1 */) const
-            noexcept(!strict_check)
-        {
+        template<bool strict_check = true>
+        [[nodiscard]] bool
+        consume(const std::size_t /* n_items = 1 */) const noexcept(!strict_check) {
             return true;
         }
 
-        [[nodiscard]] constexpr std::int64_t position() const noexcept { return -1; }
+        [[nodiscard]] constexpr std::make_signed_t<std::size_t>
+        position() const noexcept {
+            return -1;
+        }
 
-        [[nodiscard]] constexpr std::size_t available() const noexcept { return 0; }
+        [[nodiscard]] constexpr std::size_t
+        available() const noexcept {
+            return 0;
+        }
     };
 
-    template <typename U>
+    template<typename U>
     class buffer_writer {
         std::shared_ptr<buffer_impl> _buffer;
 
         buffer_writer() = delete;
+
         explicit buffer_writer(std::shared_ptr<buffer_impl> buffer) : _buffer(buffer) {}
+
         friend buffer_skeleton<T>;
 
     public:
-        [[nodiscard]] buffer_skeleton buffer() const noexcept { return buffer_skeleton(_buffer); };
+        [[nodiscard]] buffer_skeleton
+        buffer() const noexcept {
+            return buffer_skeleton(_buffer);
+        };
 
-        [[nodiscard]] constexpr auto reserve_output_range(std::size_t n) noexcept -> std::span<U> {
-                return { &_buffer->_data[0], n };
+        [[nodiscard]] constexpr auto
+        reserve_output_range(std::size_t n) noexcept -> std::span<U> {
+            return { &_buffer->_data[0], n };
         }
 
-        constexpr void publish(std::pair<std::size_t, std::int64_t>, std::size_t) const { /* empty */ }
+        constexpr void
+        publish(std::pair<std::size_t, std::make_signed<std::size_t>>, std::size_t) const { /* empty */
+        }
 
-        template <typename... Args, WriterCallback<U, Args...> Translator>
-        void publish(Translator&& /* translator */,
-                     std::size_t /* n_slots_to_claim = 1 */,
-                     Args&&... /* args */) const noexcept { /* empty */ } // blocks until elements are available
+        template<typename... Args, WriterCallback<U, Args...> Translator>
+        void
+        publish(Translator && /* translator */, std::size_t /* n_slots_to_claim = 1 */, Args &&.../* args */) const noexcept { /* empty */
+        }                                                                                                                      // blocks until elements are available
 
-        template <typename... Args, WriterCallback<U, Args...> Translator>
-        [[nodiscard]] bool try_publish(Translator&& /* translator */,
-                                       std::size_t n_slots_to_claim = 1,
-                                       Args&&... /* args */) const noexcept
-        {
+        template<typename... Args, WriterCallback<U, Args...> Translator>
+        [[nodiscard]] bool
+        try_publish(Translator && /* translator */, std::size_t n_slots_to_claim = 1, Args &&.../* args */) const noexcept {
             return n_slots_to_claim == 0;
         } // returns false if cannot emplace data -> user may need to retry
 
-        [[nodiscard]] constexpr std::size_t available() const noexcept
-        {
+        [[nodiscard]] constexpr std::size_t
+        available() const noexcept {
             return _buffer->_data.size();
         } // #items that can be written -- dynamic since readers can release in parallel
     };
@@ -99,30 +112,34 @@ class buffer_skeleton
     // shared pointer is needed to avoid dangling references to reader/writer
     // or generating buffer itself
     std::shared_ptr<buffer_impl> _shared_buffer_ptr;
+
     explicit buffer_skeleton(std::shared_ptr<buffer_impl> shared_buffer_ptr) : _shared_buffer_ptr(shared_buffer_ptr) {}
 
 public:
     buffer_skeleton() = delete;
-    explicit buffer_skeleton(const std::size_t min_size)
-        : _shared_buffer_ptr(std::make_shared<buffer_impl>(min_size))
-    {
-    }
+
+    explicit buffer_skeleton(const std::size_t min_size) : _shared_buffer_ptr(std::make_shared<buffer_impl>(min_size)) {}
+
     ~buffer_skeleton() = default;
 
-    [[nodiscard]] std::size_t size() const { return _shared_buffer_ptr->_data.size(); }
+    [[nodiscard]] std::size_t
+    size() const {
+        return _shared_buffer_ptr->_data.size();
+    }
 
-    template <typename WriteDataType = T>
-    BufferReader auto new_reader()
-    {
+    template<typename WriteDataType = T>
+    BufferReader auto
+    new_reader() {
         return buffer_reader<WriteDataType>(_shared_buffer_ptr);
     }
 
-    template <typename ReadDataType = T>
-    BufferWriter auto new_writer()
-    {
+    template<typename ReadDataType = T>
+    BufferWriter auto
+    new_writer() {
         return buffer_writer<ReadDataType>(_shared_buffer_ptr);
     }
 };
+
 static_assert(Buffer<buffer_skeleton<int32_t>>);
 
 } // namespace gr::test

--- a/include/circular_buffer.hpp
+++ b/include/circular_buffer.hpp
@@ -47,10 +47,10 @@ static constexpr bool has_posix_mmap_interface = false;
 }
 #endif
 
-#include "claim_strategy.hpp"
-#include "wait_strategy.hpp"
-#include "sequence.hpp"
 #include "buffer.hpp"
+#include "claim_strategy.hpp"
+#include "sequence.hpp"
+#include "wait_strategy.hpp"
 
 namespace gr {
 
@@ -197,14 +197,13 @@ class circular_buffer
     using BufferType        = circular_buffer<T, SIZE, producer_type, WAIT_STRATEGY>;
     using ClaimType         = detail::producer_type_v<SIZE, producer_type, WAIT_STRATEGY>;
     using DependendsType    = std::shared_ptr<std::vector<std::shared_ptr<Sequence>>>;
+    using signed_index_type = Sequence::signed_index_type;
 
     struct buffer_impl {
-        using size_type = std::int32_t;
-
         Sequence                    _cursor;
         Allocator                   _allocator{};
         const bool                  _is_mmap_allocated;
-        const size_type             _size; // pre-condition: std::has_single_bit(_size)
+        const std::size_t             _size; // pre-condition: std::has_single_bit(_size)
         std::vector<T, Allocator>   _data;
         WAIT_STRATEGY               _wait_strategy = WAIT_STRATEGY();
         ClaimType                   _claim_strategy;
@@ -250,18 +249,17 @@ class circular_buffer
     template <typename U = T>
     class buffer_writer {
         using BufferTypeLocal = std::shared_ptr<buffer_impl>;
-        using size_type = typename buffer_impl::size_type;
 
         BufferTypeLocal             _buffer; // controls buffer life-cycle, the rest are cache optimisations
         bool                        _is_mmap_allocated;
-        size_type                   _size;
+        std::size_t                   _size;
         ClaimType*                  _claim_strategy;
 
     class ReservedOutputRange {
         buffer_writer<U>* _parent = nullptr;
         std::size_t       _index = 0;
         std::size_t       _n_slots_to_claim = 0;
-        std::int64_t      _offset = 0;
+        signed_index_type      _offset = 0;
         bool              _published_data = false;
         std::span<T>      _internal_span{};
     public:
@@ -272,8 +270,8 @@ class circular_buffer
     using pointer = typename std::span<T>::reverse_iterator;
 
     explicit ReservedOutputRange(buffer_writer<U>* parent) noexcept : _parent(parent) {};
-    explicit constexpr ReservedOutputRange(buffer_writer<U>* parent, std::size_t index, std::int64_t sequence, std::size_t n_slots_to_claim) noexcept :
-        _parent(parent), _index(index), _n_slots_to_claim(n_slots_to_claim), _offset(sequence - n_slots_to_claim), _internal_span({ &_parent->_buffer->_data[_index], _n_slots_to_claim }) { }
+    explicit constexpr ReservedOutputRange(buffer_writer<U>* parent, std::size_t index, signed_index_type sequence, std::size_t n_slots_to_claim) noexcept :
+        _parent(parent), _index(index), _n_slots_to_claim(n_slots_to_claim), _offset(sequence - static_cast<signed_index_type>(n_slots_to_claim)), _internal_span({ &_parent->_buffer->_data[_index], _n_slots_to_claim }) { }
     ReservedOutputRange(const ReservedOutputRange&) = delete;
     ReservedOutputRange& operator=(const ReservedOutputRange&) = delete;
     explicit ReservedOutputRange(ReservedOutputRange&& other) noexcept
@@ -335,7 +333,7 @@ class circular_buffer
             std::copy(&data[_index], &data[_index + nFirstHalf], &data[_index + size]);
             std::copy(&data[size], &data[size + nSecondHalf], &data[0]);
         }
-        _parent->_claim_strategy->publish(_offset + n_produced);
+        _parent->_claim_strategy->publish(_offset + static_cast<signed_index_type>(n_produced));
         _n_slots_to_claim -= n_produced;
         _published_data = true;
     }
@@ -365,7 +363,7 @@ class circular_buffer
         [[nodiscard]] constexpr auto reserve_output_range(std::size_t n_slots_to_claim) noexcept -> ReservedOutputRange {
             try {
                 const auto sequence = _claim_strategy->next(*_buffer->_read_indices, n_slots_to_claim); // alt: try_next
-                const std::size_t index = (sequence + _size - n_slots_to_claim) % _size;
+                const std::size_t index = (static_cast<std::size_t>(sequence) + _size - n_slots_to_claim) % _size;
                 return ReservedOutputRange(this, index, sequence, n_slots_to_claim);
             } catch (const NoCapacityException &) {
                 return ReservedOutputRange(this);
@@ -395,21 +393,21 @@ class circular_buffer
             }
         }
 
-        [[nodiscard]] constexpr std::int64_t position() const noexcept { return _buffer->_cursor.value(); }
+        [[nodiscard]] constexpr signed_index_type position() const noexcept { return _buffer->_cursor.value(); }
 
         [[nodiscard]] constexpr std::size_t available() const noexcept {
-            return _claim_strategy->getRemainingCapacity(*_buffer->_read_indices);
+            return static_cast<std::size_t>(_claim_strategy->getRemainingCapacity(*_buffer->_read_indices));
         }
 
         private:
         template <typename... Args, WriterCallback<U, Args...> Translator>
-        constexpr void translate_and_publish(Translator&& translator, const std::size_t n_slots_to_claim, const std::int64_t publishSequence, const Args&... args) {
+        constexpr void translate_and_publish(Translator&& translator, const std::size_t n_slots_to_claim, const signed_index_type publishSequence, const Args&... args) {
             try {
                 auto& data = _buffer->_data;
-                const std::size_t index = (publishSequence + _size - n_slots_to_claim) % _size;
+                const std::size_t index = (static_cast<std::size_t>(publishSequence) + _size - n_slots_to_claim) % _size;
                 std::span<U> writable_data(&data[index], n_slots_to_claim);
-                if constexpr (std::is_invocable<Translator, std::span<T>&, std::int64_t, Args...>::value) {
-                    std::invoke(std::forward<Translator>(translator), std::forward<std::span<T>&>(writable_data), publishSequence - n_slots_to_claim, args...);
+                if constexpr (std::is_invocable<Translator, std::span<T>&, signed_index_type, Args...>::value) {
+                    std::invoke(std::forward<Translator>(translator), std::forward<std::span<T>&>(writable_data), publishSequence - static_cast<signed_index_type>(n_slots_to_claim), args...);
                 } else {
                     std::invoke(std::forward<Translator>(translator), std::forward<std::span<T>&>(writable_data), args...);
                 }
@@ -435,17 +433,16 @@ class circular_buffer
     class buffer_reader
     {
         using BufferTypeLocal = std::shared_ptr<buffer_impl>;
-        using size_type = typename buffer_impl::size_type;
 
         std::shared_ptr<Sequence>   _read_index = std::make_shared<Sequence>();
-        std::int64_t                _read_index_cached;
+        signed_index_type                _read_index_cached;
         BufferTypeLocal             _buffer; // controls buffer life-cycle, the rest are cache optimisations
-        size_type                   _size; // pre-condition: std::has_single_bit(_size)
+        std::size_t                   _size; // pre-condition: std::has_single_bit(_size)
 
         std::size_t
         buffer_index() const noexcept {
             const auto bitmask = _size - 1;
-            return static_cast<std::size_t>(_read_index_cached & bitmask);
+            return static_cast<std::size_t>(_read_index_cached) & bitmask;
         }
 
     public:
@@ -493,14 +490,14 @@ class circular_buffer
                     return false;
                 }
             }
-            _read_index_cached = _read_index->addAndGet(static_cast<int64_t>(n_elements));
+            _read_index_cached = _read_index->addAndGet(static_cast<signed_index_type>(n_elements));
             return true;
         }
 
-        [[nodiscard]] constexpr std::int64_t position() const noexcept { return _read_index_cached; }
+        [[nodiscard]] constexpr signed_index_type position() const noexcept { return _read_index_cached; }
 
         [[nodiscard]] constexpr std::size_t available() const noexcept {
-            return _buffer->_cursor.value() - _read_index_cached;
+            return static_cast<std::size_t>(_buffer->_cursor.value() - _read_index_cached);
         }
     };
 

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -429,12 +429,12 @@ public:
         std::size_t    tags_to_process    = 0;
         if constexpr (is_source_node) {
             if constexpr (requires(const Derived &d) {
-                              { self().available_samples(d) } -> std::same_as<std::int64_t>;
+                              { self().available_samples(d) } -> std::same_as<std::make_signed_t<std::size_t>>;
                           }) {
                 // the (source) node wants to determine the number of samples to process
                 std::size_t max_buffer = std::numeric_limits<std::size_t>::max();
                 meta::tuple_for_each([&max_buffer](auto &&out) { max_buffer = std::min(max_buffer, out.streamWriter().available()); }, output_ports(&self()));
-                const std::int64_t available_samples = self().available_samples(self());
+                const std::make_signed_t<std::size_t> available_samples = self().available_samples(self());
                 if (available_samples < 0 && max_buffer > 0) {
                     return work_return_t::DONE;
                 }

--- a/include/port.hpp
+++ b/include/port.hpp
@@ -27,14 +27,14 @@ enum class port_domain_t { CPU, GPU, NET, FPGA, DSP, MLU };
 
 template<class T>
 concept Port = requires(T t, const std::size_t n_items) { // dynamic definitions
-                   typename T::value_type;
-                   { t.pmt_type() } -> std::same_as<supported_type>;
-                   { t.type() } -> std::same_as<port_type_t>;
-                   { t.direction() } -> std::same_as<port_direction_t>;
-                   { t.name() } -> std::same_as<std::string_view>;
-                   { t.resize_buffer(n_items) } -> std::same_as<connection_result_t>;
-                   { t.disconnect() } -> std::same_as<connection_result_t>;
-               };
+    typename T::value_type;
+    { t.pmt_type() } -> std::same_as<supported_type>;
+    { t.type() } -> std::same_as<port_type_t>;
+    { t.direction() } -> std::same_as<port_direction_t>;
+    { t.name() } -> std::same_as<std::string_view>;
+    { t.resize_buffer(n_items) } -> std::same_as<connection_result_t>;
+    { t.disconnect() } -> std::same_as<connection_result_t>;
+};
 
 /**
  * @brief internal port buffer handler
@@ -42,8 +42,8 @@ concept Port = requires(T t, const std::size_t n_items) { // dynamic definitions
  * N.B. void* needed for type-erasure/Python compatibility/wrapping
  */
 struct internal_port_buffers {
-    void* streamHandler;
-    void* tagHandler;
+    void *streamHandler;
+    void *tagHandler;
 };
 
 /**
@@ -257,9 +257,10 @@ public:
     [[nodiscard]] auto
     buffer() {
         struct port_buffers {
-            BufferType streamBuffer;
+            BufferType    streamBuffer;
             TagBufferType tagBufferType;
-        } ;
+        };
+
         return port_buffers{ _ioHandler.buffer(), _tagIoHandler.buffer() };
     }
 
@@ -398,7 +399,7 @@ publish_tag(Port auto &port, const tag_t::map_type &tag_data, std::size_t tag_of
     port.tagWriter().publish(
             [&port, &tag_data, &tag_offset](std::span<fair::graph::tag_t> tag_output) {
                 tag_output[0].index = port.streamWriter().position() + tag_offset;
-                tag_output[0].map = tag_data;
+                tag_output[0].map   = tag_data;
             },
             1_UZ);
 }

--- a/include/tag.hpp
+++ b/include/tag.hpp
@@ -47,9 +47,9 @@ enum class tag_propagation_policy_t {
  * so that there is only one tag per scheduler iteration. Multiple tags on the same sample shall be merged to one.
  */
 struct alignas(hardware_constructive_interference_size) tag_t {
-    using map_type = std::map<std::string, pmtv::pmt, std::less<>>;
-    int64_t  index = 0;
-    map_type map;
+    using map_type                        = std::map<std::string, pmtv::pmt, std::less<>>;
+    std::make_signed_t<std::size_t> index = 0;
+    map_type                        map;
 
     // TODO: do we need the convenience methods below?
     [[nodiscard]] pmtv::pmt &
@@ -137,18 +137,18 @@ public:
 };
 
 namespace tag { // definition of default tags and names
-inline EM_CONSTEXPR_STATIC default_tag<"sample_rate", float, "Hz", "signal sample rate">                                                       SAMPLE_RATE;
-inline EM_CONSTEXPR_STATIC default_tag<"sample_rate", float, "Hz", "signal sample rate">                                                       SIGNAL_RATE;
-inline EM_CONSTEXPR_STATIC default_tag<"signal_name", std::string, "", "signal name">                                                          SIGNAL_NAME;
-inline EM_CONSTEXPR_STATIC default_tag<"signal_unit", std::string, "", "signal's physical SI unit">                                            SIGNAL_UNIT;
-inline EM_CONSTEXPR_STATIC default_tag<"signal_min", float, "a.u.", "signal physical max. (e.g. DAQ) limit">                                   SIGNAL_MIN;
-inline EM_CONSTEXPR_STATIC default_tag<"signal_max", float, "a.u.", "signal physical max. (e.g. DAQ) limit">                                   SIGNAL_MAX;
-inline EM_CONSTEXPR_STATIC default_tag<"trigger_name", std::string>                                                                            TRIGGER_NAME;
-inline EM_CONSTEXPR_STATIC default_tag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp">                                                 TRIGGER_TIME;
+inline EM_CONSTEXPR_STATIC default_tag<"sample_rate", float, "Hz", "signal sample rate"> SAMPLE_RATE;
+inline EM_CONSTEXPR_STATIC default_tag<"sample_rate", float, "Hz", "signal sample rate"> SIGNAL_RATE;
+inline EM_CONSTEXPR_STATIC default_tag<"signal_name", std::string, "", "signal name"> SIGNAL_NAME;
+inline EM_CONSTEXPR_STATIC default_tag<"signal_unit", std::string, "", "signal's physical SI unit"> SIGNAL_UNIT;
+inline EM_CONSTEXPR_STATIC default_tag<"signal_min", float, "a.u.", "signal physical max. (e.g. DAQ) limit"> SIGNAL_MIN;
+inline EM_CONSTEXPR_STATIC default_tag<"signal_max", float, "a.u.", "signal physical max. (e.g. DAQ) limit"> SIGNAL_MAX;
+inline EM_CONSTEXPR_STATIC default_tag<"trigger_name", std::string> TRIGGER_NAME;
+inline EM_CONSTEXPR_STATIC default_tag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp"> TRIGGER_TIME;
 inline EM_CONSTEXPR_STATIC default_tag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;
-inline EM_CONSTEXPR_STATIC default_tag<"context", std::string, "", "multiplexing key to orchestrate node settings/behavioural changes">        CONTEXT;
+inline EM_CONSTEXPR_STATIC default_tag<"context", std::string, "", "multiplexing key to orchestrate node settings/behavioural changes"> CONTEXT;
 
-inline constexpr std::tuple DEFAULT_TAGS = {SAMPLE_RATE, SIGNAL_NAME, SIGNAL_UNIT, SIGNAL_MIN, SIGNAL_MAX, TRIGGER_NAME, TRIGGER_TIME, TRIGGER_OFFSET, CONTEXT};
+inline constexpr std::tuple DEFAULT_TAGS = { SAMPLE_RATE, SIGNAL_NAME, SIGNAL_UNIT, SIGNAL_MIN, SIGNAL_MAX, TRIGGER_NAME, TRIGGER_TIME, TRIGGER_OFFSET, CONTEXT };
 } // namespace tag
 
 } // namespace fair::graph

--- a/test/qa_scheduler.cpp
+++ b/test/qa_scheduler.cpp
@@ -4,14 +4,16 @@
 
 #if defined(__clang__) && __clang_major__ >= 16
 // clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template <>
+template<>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
 #endif
 
-namespace fg = fair::graph;
+namespace fg       = fair::graph;
 
 using trace_vector = std::vector<std::string>;
-static void trace(trace_vector &traceVector, std::string_view id) {
+
+static void
+trace(trace_vector &traceVector, std::string_view id) {
     if (traceVector.empty() || traceVector.back() != id) {
         traceVector.emplace_back(id);
     }
@@ -21,13 +23,14 @@ static void trace(trace_vector &traceVector, std::string_view id) {
 template<typename T, std::int64_t N>
 class count_source : public fg::node<count_source<T, N>, fg::OUT<T, 0, std::numeric_limits<std::size_t>::max(), "out">> {
     trace_vector &tracer;
-    std::int64_t count = 0;
-public:
-    count_source(trace_vector &trace, std::string_view name) : tracer{trace} { this->_name = name;}
+    std::int64_t  count = 0;
 
-    constexpr std::int64_t
-    available_samples(const count_source &/*d*/) noexcept {
-        const auto ret = static_cast<std::int64_t>(N - count);
+public:
+    count_source(trace_vector &trace, std::string_view name) : tracer{ trace } { this->_name = name; }
+
+    constexpr std::make_signed_t<std::size_t>
+    available_samples(const count_source & /*d*/) noexcept {
+        const auto ret = static_cast<std::make_signed_t<std::size_t>>(N - count);
         return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
     }
 
@@ -40,20 +43,23 @@ public:
 
 template<typename T>
 class expect_sink : public fg::node<expect_sink<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "in">> {
-    trace_vector &tracer;
-    std::int64_t count = 0;
+    trace_vector                                   &tracer;
+    std::int64_t                                    count = 0;
     std::function<void(std::int64_t, std::int64_t)> _checker;
+
 public:
-    expect_sink(trace_vector &trace, std::string_view name, std::function<void(std::int64_t, std::int64_t)> &&checker) : tracer{trace}, _checker(std::move(checker)) { this->_name = name;}
+    expect_sink(trace_vector &trace, std::string_view name, std::function<void(std::int64_t, std::int64_t)> &&checker) : tracer{ trace }, _checker(std::move(checker)) { this->_name = name; }
+
     [[nodiscard]] fg::work_return_t
     process_bulk(std::span<const T> input) noexcept {
         trace(tracer, this->name());
-        for (auto data: input) {
+        for (auto data : input) {
             _checker(count, data);
             count++;
         }
         return fg::work_return_t::OK;
     }
+
     constexpr void
     process_one(T /*a*/) const noexcept {
         trace(tracer, this->name());
@@ -63,8 +69,10 @@ public:
 template<typename T, T Scale, typename R = decltype(std::declval<T>() * std::declval<T>())>
 class scale : public fg::node<scale<T, Scale, R>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "original">, fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "scaled">> {
     trace_vector &tracer;
+
 public:
-    scale(trace_vector &trace, std::string_view name) : tracer{trace} {this->_name = name;}
+    scale(trace_vector &trace, std::string_view name) : tracer{ trace } { this->_name = name; }
+
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
     process_one(V a) const noexcept {
@@ -74,10 +82,13 @@ public:
 };
 
 template<typename T, typename R = decltype(std::declval<T>() + std::declval<T>())>
-class adder : public fg::node<adder<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend0">, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend1">, fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "sum">> {
+class adder : public fg::node<adder<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend0">, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend1">,
+                              fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "sum">> {
     trace_vector &tracer;
+
 public:
-    adder(trace_vector &trace, std::string_view name) : tracer{trace} {this->_name = name;}
+    adder(trace_vector &trace, std::string_view name) : tracer{ trace } { this->_name = name; }
+
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
     process_one(V a, V b) const noexcept {
@@ -91,19 +102,17 @@ get_graph_linear(trace_vector &traceVector) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-// Nodes need to be alive for as long as the flow is
+    // Nodes need to be alive for as long as the flow is
     fg::graph flow;
-// Generators
-    auto& source1 = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
-    auto& scale_block1 = flow.make_node<scale<int, 2>>(traceVector, "mult1");
-    auto& scale_block2 = flow.make_node<scale<int, 4>>(traceVector, "mult2");
-    auto& sink = flow.make_node<expect_sink<int>>(traceVector, "out", [](std::uint64_t count, std::uint64_t data) {
-        boost::ut::expect(boost::ut::that % data == 8 * count);
-    } );
+    // Generators
+    auto &source1      = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
+    auto &scale_block1 = flow.make_node<scale<int, 2>>(traceVector, "mult1");
+    auto &scale_block2 = flow.make_node<scale<int, 4>>(traceVector, "mult2");
+    auto &sink         = flow.make_node<expect_sink<int>>(traceVector, "out", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 8 * count); });
 
-    std::ignore = flow.connect<"scaled">(scale_block2).to<"in">(sink);
-    std::ignore = flow.connect<"scaled">(scale_block1).to<"original">(scale_block2);
-    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1);
+    std::ignore        = flow.connect<"scaled">(scale_block2).to<"in">(sink);
+    std::ignore        = flow.connect<"scaled">(scale_block1).to<"original">(scale_block2);
+    std::ignore        = flow.connect<"out">(source1).to<"original">(scale_block1);
 
     return flow;
 }
@@ -113,31 +122,26 @@ get_graph_parallel(trace_vector &traceVector) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-// Nodes need to be alive for as long as the flow is
+    // Nodes need to be alive for as long as the flow is
     fg::graph flow;
-// Generators
-    auto& source1 = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
-    auto& scale_block1a = flow.make_node<scale<int, 2>>(traceVector, "mult1a");
-    auto& scale_block2a = flow.make_node<scale<int, 3>>(traceVector, "mult2a");
-    auto& sink_a = flow.make_node<expect_sink<int>>(traceVector, "outa", [](std::uint64_t count, std::uint64_t data) {
-        boost::ut::expect(boost::ut::that % data == 6 * count);
-    } );
-    auto& scale_block1b = flow.make_node<scale<int, 3>>(traceVector, "mult1b");
-    auto& scale_block2b = flow.make_node<scale<int, 5>>(traceVector, "mult2b");
-    auto& sink_b = flow.make_node<expect_sink<int>>(traceVector, "outb", [](std::uint64_t count, std::uint64_t data) {
-        boost::ut::expect(boost::ut::that % data == 15 * count);
-    } );
+    // Generators
+    auto &source1       = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
+    auto &scale_block1a = flow.make_node<scale<int, 2>>(traceVector, "mult1a");
+    auto &scale_block2a = flow.make_node<scale<int, 3>>(traceVector, "mult2a");
+    auto &sink_a        = flow.make_node<expect_sink<int>>(traceVector, "outa", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 6 * count); });
+    auto &scale_block1b = flow.make_node<scale<int, 3>>(traceVector, "mult1b");
+    auto &scale_block2b = flow.make_node<scale<int, 5>>(traceVector, "mult2b");
+    auto &sink_b        = flow.make_node<expect_sink<int>>(traceVector, "outb", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 15 * count); });
 
-    std::ignore = flow.connect<"scaled">(scale_block1a).to<"original">(scale_block2a);
-    std::ignore = flow.connect<"scaled">(scale_block1b).to<"original">(scale_block2b);
-    std::ignore = flow.connect<"scaled">(scale_block2b).to<"in">(sink_b);
-    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1a);
-    std::ignore = flow.connect<"scaled">(scale_block2a).to<"in">(sink_a);
-    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1b);
+    std::ignore         = flow.connect<"scaled">(scale_block1a).to<"original">(scale_block2a);
+    std::ignore         = flow.connect<"scaled">(scale_block1b).to<"original">(scale_block2b);
+    std::ignore         = flow.connect<"scaled">(scale_block2b).to<"in">(sink_b);
+    std::ignore         = flow.connect<"out">(source1).to<"original">(scale_block1a);
+    std::ignore         = flow.connect<"scaled">(scale_block2a).to<"in">(sink_a);
+    std::ignore         = flow.connect<"out">(source1).to<"original">(scale_block1b);
 
     return flow;
 }
-
 
 /**
  * sets up an example graph
@@ -160,22 +164,20 @@ get_graph_scaled_sum(trace_vector &traceVector) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-// Nodes need to be alive for as long as the flow is
+    // Nodes need to be alive for as long as the flow is
     fg::graph flow;
 
-// Generators
-    auto& source1 = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
-    auto& source2 = flow.make_node<count_source<int, 100000>>(traceVector, "s2");
-    auto& scale_block = flow.make_node<scale<int, 2>>(traceVector, "mult");
-    auto& add_block = flow.make_node<adder<int>>(traceVector, "add");
-    auto& sink = flow.make_node<expect_sink<int>>(traceVector, "out", [](std::uint64_t count, std::uint64_t data) {
-        boost::ut::expect(boost::ut::that % data == (2 * count) + count);
-    } );
+    // Generators
+    auto &source1     = flow.make_node<count_source<int, 100000>>(traceVector, "s1");
+    auto &source2     = flow.make_node<count_source<int, 100000>>(traceVector, "s2");
+    auto &scale_block = flow.make_node<scale<int, 2>>(traceVector, "mult");
+    auto &add_block   = flow.make_node<adder<int>>(traceVector, "add");
+    auto &sink        = flow.make_node<expect_sink<int>>(traceVector, "out", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == (2 * count) + count); });
 
-    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block);
-    std::ignore = flow.connect<"scaled">(scale_block).to<"addend0">(add_block);
-    std::ignore = flow.connect<"out">(source2).to<"addend1">(add_block);
-    std::ignore = flow.connect<"sum">(add_block).to<"in">(sink);
+    std::ignore       = flow.connect<"out">(source1).to<"original">(scale_block);
+    std::ignore       = flow.connect<"scaled">(scale_block).to<"addend0">(add_block);
+    std::ignore       = flow.connect<"out">(source2).to<"addend1">(add_block);
+    std::ignore       = flow.connect<"sum">(add_block).to<"in">(sink);
 
     return flow;
 }
@@ -187,7 +189,7 @@ const boost::ut::suite SchedulerTests = [] {
     "SimpleScheduler_linear"_test = [] {
         using scheduler = fair::graph::scheduler::simple;
         trace_vector t{};
-        auto sched = scheduler{get_graph_linear(t)};
+        auto         sched = scheduler{ get_graph_linear(t) };
         sched.work();
         expect(boost::ut::that % t.size() == 8u);
         expect(boost::ut::that % t == trace_vector{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
@@ -196,47 +198,63 @@ const boost::ut::suite SchedulerTests = [] {
     "BreadthFirstScheduler_linear"_test = [] {
         using scheduler = fair::graph::scheduler::breadth_first;
         trace_vector t{};
-        auto sched = scheduler{get_graph_linear(t)};
+        auto         sched = scheduler{ get_graph_linear(t) };
         sched.work();
         expect(boost::ut::that % t.size() == 8u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out"});
+        expect(boost::ut::that % t == trace_vector{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
     };
 
     "SimpleScheduler_parallel"_test = [] {
         using scheduler = fair::graph::scheduler::simple;
         trace_vector t{};
-        auto sched = scheduler{get_graph_parallel(t)};
+        auto         sched = scheduler{ get_graph_parallel(t) };
         sched.work();
         expect(boost::ut::that % t.size() == 14u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb", "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb"});
+        expect(boost::ut::that % t == trace_vector{ "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb", "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb" });
     };
 
     "BreadthFirstScheduler_parallel"_test = [] {
         using scheduler = fair::graph::scheduler::breadth_first;
         trace_vector t{};
-        auto sched = scheduler{get_graph_parallel(t)};
+        auto         sched = scheduler{ get_graph_parallel(t) };
         sched.work();
         expect(boost::ut::that % t.size() == 14u);
-        expect(boost::ut::that % t == trace_vector{"s1", "mult1a", "mult1b", "mult2a", "mult2b", "outa", "outb", "s1", "mult1a", "mult1b", "mult2a", "mult2b", "outa", "outb", });
+        expect(boost::ut::that % t
+               == trace_vector{
+                       "s1",
+                       "mult1a",
+                       "mult1b",
+                       "mult2a",
+                       "mult2b",
+                       "outa",
+                       "outb",
+                       "s1",
+                       "mult1a",
+                       "mult1b",
+                       "mult2a",
+                       "mult2b",
+                       "outa",
+                       "outb",
+               });
     };
 
     "SimpleScheduler_scaled_sum"_test = [] {
         using scheduler = fair::graph::scheduler::simple;
         // construct an example graph and get an adjacency list for it
         trace_vector t{};
-        auto sched = scheduler{get_graph_scaled_sum(t)};
+        auto         sched = scheduler{ get_graph_scaled_sum(t) };
         sched.work();
         expect(boost::ut::that % t.size() == 10u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out"});
+        expect(boost::ut::that % t == trace_vector{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out" });
     };
 
     "BreadthFirstScheduler_scaled_sum"_test = [] {
         using scheduler = fair::graph::scheduler::breadth_first;
         trace_vector t{};
-        auto sched = scheduler{get_graph_scaled_sum(t)};
+        auto         sched = scheduler{ get_graph_scaled_sum(t) };
         sched.work();
         expect(boost::ut::that % t.size() == 10u);
-        expect(boost::ut::that % t == trace_vector{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out"});
+        expect(boost::ut::that % t == trace_vector{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out" });
     };
 };
 

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -3,8 +3,8 @@
 #include <buffer.hpp>
 #include <graph.hpp>
 #include <node.hpp>
-#include <scheduler.hpp>
 #include <reflection.hpp>
+#include <scheduler.hpp>
 
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -88,9 +88,9 @@ struct Source : public node<Source<T>> {
         fair::graph::publish_tag(out, { { "n_samples_max", n_samples_max } }, n_tag_offset);
     }
 
-    constexpr std::int64_t
+    constexpr std::make_signed_t<std::size_t>
     available_samples(const Source &self) noexcept {
-        const auto ret = static_cast<std::int64_t>(n_samples_max - n_samples_produced);
+        const auto ret = static_cast<std::make_signed_t<std::size_t>>(n_samples_max - n_samples_produced);
         return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
     }
 
@@ -233,7 +233,7 @@ const boost::ut::suite SettingsTests = [] {
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block1).to<"in">(block2)));
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(block2).to<"in">(sink)));
 
-        fair::graph::scheduler::simple sched{std::move(flow_graph)};
+        fair::graph::scheduler::simple sched{ std::move(flow_graph) };
         expect(src.settings().auto_update_parameters().contains("sample_rate"));
         std::ignore = src.settings().set({ { "sample_rate", 49000.0f } });
         sched.work();


### PR DESCRIPTION
Remove conversion's warnings and make explicit cast where appropriate.
`std::make_signed_t<std::size>` is used for most of the "index" types and `std::size_t` is used for "size" types.
Initially is was planned to remove warnings only for `circular_buffer` class, but since it has many dependencies, other classes were also changed if needed.

**Benchmark bm_buffer results**
The results slightly differ fromm run to run. Here are the 2 randomly selected example outputs.

**Before updates**
```text
┌─────────────────────────benchmark:─────────────────────────┬──────┬─#N─┬─CTX-SW─┬───CPU cache misses────┬───CPU branch misses───┬─<CPU-I>─┬──min───┬──mean──┬─stddev─┬─median─┬───max───┬─total time─┬─ops/s─┐
│                                                            │ SKIP │    │        │                       │                       │         │        │        │        │        │         │            │       │
│ portable: 1 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 17.2k / 32.2k = 53.4% │ 3.14k / 29.9k = 10.5% │    2.1m │ 154 ms │ 167 ms │  10 ms │ 171 ms │  185 ms │       1  s │ 59.9M │
│ portable: 1 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 15.8k / 29.9k = 52.9% │ 2.99k / 29.3k = 10.2% │    2.1m │ 205 ms │ 222 ms │  14 ms │ 230 ms │  243 ms │       2  s │ 45.0M │
│ portable: 1 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 17.0k / 32.5k = 52.4% │ 3.24k / 31.6k = 10.2% │    2.3m │ 302 ms │ 372 ms │  38 ms │ 385 ms │  422 ms │       3  s │ 26.9M │
│ portable: 2 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 16.3k / 30.8k = 52.9% │ 3.02k / 29.2k = 10.3% │    2.1m │ 580 ms │ 588 ms │   4 ms │ 591 ms │  593 ms │       5  s │ 17.0M │
│ portable: 2 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 17.8k / 33.4k = 53.4% │ 3.29k / 30.2k = 10.9% │    2.2m │ 712 ms │ 718 ms │   4 ms │ 718 ms │  726 ms │       6  s │ 13.9M │
│ portable: 2 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 17.5k / 32.8k = 53.2% │ 3.15k / 32.1k =  9.8% │    2.3m │   1  s │   1  s │   3 ms │   1  s │    1  s │       8  s │  9.9M │
│ portable: 4 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 13.8k / 27.7k = 49.9% │ 2.60k / 31.2k =  8.3% │    2.3m │ 769 ms │ 781 ms │   7 ms │ 783 ms │  790 ms │       6  s │ 12.8M │
│ portable: 4 producers -< 1  >-> 2 consumers                │ PASS │ 8  │    11  │ 16.2k / 32.0k = 50.7% │ 3.14k / 37.1k =  8.5% │    2.7m │ 946 ms │ 962 ms │  13 ms │ 964 ms │  989 ms │       8  s │ 10.4M │
│ portable: 4 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 16.9k / 32.7k = 51.7% │ 3.35k / 34.8k =  9.6% │    2.5m │   2  s │   2  s │  10 ms │   2  s │    2  s │      16  s │  5.0M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼─────────┼────────────┼───────┤
│ portable: 1 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.28k / 11.3k = 20.2% │  773  / 28.3k =  2.7% │    2.1m │ 832 us │ 922 us │ 213 us │ 844 us │    1 ms │       7 ms │ 10.8G │
│ portable: 1 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.43k / 11.8k = 20.7% │  720  / 29.4k =  2.5% │    2.1m │ 974 us │   1 ms │ 281 us │ 982 us │    2 ms │       9 ms │  9.0G │
│ portable: 1 producers -<1024>-> 4 consumers                │ PASS │ 8  │     8  │ 2.88k / 12.2k = 23.6% │  734  / 31.0k =  2.4% │    2.3m │   1 ms │   1 ms │ 136 us │   1 ms │    1 ms │       9 ms │  8.8G │
│ portable: 2 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.57k / 11.6k = 22.2% │  702  / 29.2k =  2.4% │    2.1m │ 933 us │   1 ms │ 219 us │ 968 us │    2 ms │       8 ms │  9.6G │
│ portable: 2 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.49k / 11.6k = 21.4% │  703  / 30.5k =  2.3% │    2.2m │   1 ms │   1 ms │ 301 us │   1 ms │    2 ms │      10 ms │  8.4G │
│ portable: 2 producers -<1024>-> 4 consumers                │ PASS │ 8  │     8  │ 2.39k / 12.8k = 18.7% │  739  / 31.9k =  2.3% │    2.3m │   1 ms │   1 ms │ 210 us │   1 ms │    2 ms │      11 ms │  7.3G │
│ portable: 4 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.62k / 11.7k = 22.4% │  689  / 30.9k =  2.2% │    2.2m │ 795 us │ 882 us │ 181 us │ 818 us │    1 ms │       7 ms │ 11.3G │
│ portable: 4 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.80k / 13.0k = 21.5% │  751  / 32.7k =  2.3% │    2.4m │ 875 us │ 962 us │ 210 us │ 884 us │    2 ms │       8 ms │ 10.4G │
│ portable: 4 producers -<1024>-> 4 consumers                │ PASS │ 8  │     9  │ 3.17k / 13.6k = 23.4% │  863  / 35.2k =  2.5% │    2.5m │   2 ms │   2 ms │ 160 us │   2 ms │    2 ms │      14 ms │  5.6G │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼─────────┼────────────┼───────┤
│ portable - RAII writer: 1 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 16.4k / 30.8k = 53.4% │ 3.03k / 28.3k = 10.7% │    2.1m │ 151 ms │ 189 ms │  28 ms │ 210 ms │  212 ms │       2  s │ 53.1M │
│ portable - RAII writer: 1 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 16.2k / 31.5k = 51.6% │ 3.06k / 29.5k = 10.4% │    2.2m │ 178 ms │ 237 ms │  39 ms │ 263 ms │  280 ms │       2  s │ 42.1M │
│ portable - RAII writer: 1 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 15.9k / 31.2k = 50.9% │ 3.01k / 31.4k =  9.6% │    2.3m │ 312 ms │ 349 ms │  18 ms │ 348 ms │  376 ms │       3  s │ 28.7M │
│ portable - RAII writer: 2 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 17.1k / 32.6k = 52.4% │ 3.27k / 31.8k = 10.3% │    2.3m │ 441 ms │ 464 ms │  21 ms │ 460 ms │  495 ms │       4  s │ 21.5M │
│ portable - RAII writer: 2 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 15.4k / 30.4k = 50.5% │ 3.01k / 30.6k =  9.8% │    2.2m │ 612 ms │ 618 ms │   9 ms │ 615 ms │  642 ms │       5  s │ 16.2M │
│ portable - RAII writer: 2 producers -< 1  >-> 4 consumers  │ PASS │ 8  │    10  │ 16.8k / 32.7k = 51.3% │ 3.30k / 35.5k =  9.3% │    2.6m │ 994 ms │ 997 ms │   2 ms │ 998 ms │ 1000 ms │       8  s │ 10.0M │
│ portable - RAII writer: 4 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 16.7k / 31.6k = 52.7% │ 3.15k / 31.3k = 10.1% │    2.3m │ 740 ms │ 754 ms │   7 ms │ 756 ms │  763 ms │       6  s │ 13.3M │
│ portable - RAII writer: 4 producers -< 1  >-> 2 consumers  │ PASS │ 8  │    10  │ 17.0k / 35.7k = 47.6% │ 3.42k / 39.8k =  8.6% │    2.9m │ 934 ms │ 951 ms │  10 ms │ 951 ms │  969 ms │       8  s │ 10.5M │
│ portable - RAII writer: 4 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 19.6k / 37.3k = 52.6% │ 3.57k / 39.7k =  9.0% │    2.9m │   2  s │   2  s │  32 ms │   2  s │    2  s │      15  s │  5.4M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼─────────┼────────────┼───────┤
│ portable - RAII writer: 1 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 3.30k / 13.3k = 24.8% │ 1.08k / 28.3k =  3.8% │    2.1m │   1 ms │   1 ms │  55 us │   1 ms │    1 ms │       9 ms │  9.3G │
│ portable - RAII writer: 1 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.34k / 11.5k = 20.3% │  712  / 29.2k =  2.4% │    2.1m │   1 ms │   1 ms │ 151 us │   1 ms │    2 ms │      10 ms │  7.8G │
│ portable - RAII writer: 1 producers -<1024>-> 4 consumers  │ PASS │ 8  │     8  │ 3.73k / 14.0k = 26.6% │  827  / 33.8k =  2.4% │    2.5m │   1 ms │   1 ms │ 259 us │   1 ms │    2 ms │      11 ms │  7.6G │
│ portable - RAII writer: 2 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 2.27k / 11.4k = 20.0% │  636  / 29.0k =  2.2% │    2.1m │   1 ms │   1 ms │ 104 us │   1 ms │    1 ms │       9 ms │  9.3G │
│ portable - RAII writer: 2 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.18k / 11.2k = 19.5% │  628  / 30.1k =  2.1% │    2.2m │   1 ms │   1 ms │ 117 us │   1 ms │    1 ms │       9 ms │  8.8G │
│ portable - RAII writer: 2 producers -<1024>-> 4 consumers  │ PASS │ 8  │     8  │ 2.68k / 12.6k = 21.3% │  677  / 32.0k =  2.1% │    2.3m │   1 ms │   1 ms │ 240 us │   1 ms │    2 ms │      11 ms │  7.4G │
│ portable - RAII writer: 4 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 2.73k / 12.2k = 22.3% │  703  / 31.6k =  2.2% │    2.3m │ 779 us │ 881 us │ 156 us │ 793 us │    1 ms │       7 ms │ 11.4G │
│ portable - RAII writer: 4 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.52k / 12.3k = 20.6% │  687  / 32.0k =  2.1% │    2.3m │ 856 us │ 926 us │ 158 us │ 867 us │    1 ms │       7 ms │ 10.8G │
│ portable - RAII writer: 4 producers -<1024>-> 4 consumers  │ PASS │ 8  │    10  │ 3.32k / 14.4k = 23.0% │  934  / 37.1k =  2.5% │    2.7m │   2 ms │   2 ms │  95 us │   2 ms │    2 ms │      13 ms │  6.0G │
└────────────────────────────────────────────────────────────┴──────┴────┴────────┴───────────────────────┴───────────────────────┴─────────┴────────┴────────┴────────┴────────┴─────────┴────────────┴───────┘
```



**After updates**
```text
┌─────────────────────────benchmark:─────────────────────────┬──────┬─#N─┬─CTX-SW─┬───CPU cache misses────┬───CPU branch misses───┬─<CPU-I>─┬──min───┬──mean──┬─stddev─┬─median─┬───max───┬─total time─┬─ops/s─┐
│                                                            │ SKIP │    │        │                       │                       │         │        │        │        │        │         │            │       │
│ portable: 1 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 17.7k / 32.9k = 53.8% │ 3.32k / 29.7k = 11.2% │    2.1m │ 154 ms │ 167 ms │  11 ms │ 169 ms │  188 ms │       1  s │ 59.9M │
│ portable: 1 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 18.1k / 32.6k = 55.3% │ 3.28k / 29.3k = 11.2% │    2.1m │ 214 ms │ 242 ms │  26 ms │ 267 ms │  270 ms │       2  s │ 41.2M │
│ portable: 1 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 18.4k / 33.4k = 55.2% │ 3.38k / 31.3k = 10.8% │    2.3m │ 294 ms │ 356 ms │  31 ms │ 362 ms │  400 ms │       3  s │ 28.1M │
│ portable: 2 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 17.3k / 32.2k = 53.8% │ 3.22k / 29.4k = 11.0% │    2.1m │ 577 ms │ 580 ms │   3 ms │ 581 ms │  584 ms │       5  s │ 17.2M │
│ portable: 2 producers -< 1  >-> 2 consumers                │ PASS │ 8  │    10  │ 16.4k / 32.6k = 50.4% │ 3.15k / 34.0k =  9.3% │    2.5m │ 668 ms │ 671 ms │   5 ms │ 669 ms │  684 ms │       5  s │ 14.9M │
│ portable: 2 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 18.7k / 34.5k = 54.3% │ 3.37k / 32.3k = 10.4% │    2.3m │   1  s │   1  s │   8 ms │   1  s │    1  s │       8  s │  9.6M │
│ portable: 4 producers -< 1  >-> 1 consumers                │ PASS │ 8  │    10  │ 18.7k / 35.9k = 52.2% │ 3.64k / 35.0k = 10.4% │    2.5m │ 715 ms │ 725 ms │   9 ms │ 724 ms │  741 ms │       6  s │ 13.8M │
│ portable: 4 producers -< 1  >-> 2 consumers                │ PASS │ 8  │    14  │ 14.9k / 32.4k = 46.0% │ 3.10k / 42.4k =  7.3% │    3.1m │ 937 ms │ 958 ms │  10 ms │ 959 ms │  974 ms │       8  s │ 10.4M │
│ portable: 4 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 15.9k / 31.8k = 50.2% │ 3.04k / 34.9k =  8.7% │    2.5m │   2  s │   2  s │   7 ms │   2  s │    2  s │      16  s │  5.0M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼─────────┼────────────┼───────┤
│ portable: 1 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.61k / 12.2k = 21.4% │  805  / 28.6k =  2.8% │    2.1m │ 793 us │ 875 us │ 211 us │ 795 us │    1 ms │       7 ms │ 11.4G │
│ portable: 1 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 3.58k / 13.6k = 26.4% │  859  / 31.6k =  2.7% │    2.3m │ 966 us │   1 ms │ 180 us │ 985 us │    2 ms │       9 ms │  9.4G │
│ portable: 1 producers -<1024>-> 4 consumers                │ PASS │ 8  │     8  │ 3.95k / 14.8k = 26.8% │  917  / 33.5k =  2.7% │    2.4m │   1 ms │   1 ms │ 141 us │   1 ms │    1 ms │       9 ms │  8.9G │
│ portable: 2 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.48k / 11.7k = 21.2% │  629  / 29.2k =  2.2% │    2.1m │ 895 us │ 924 us │  33 us │ 915 us │    1 ms │       7 ms │ 10.8G │
│ portable: 2 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.41k / 11.4k = 21.1% │  638  / 30.0k =  2.1% │    2.2m │   1 ms │   1 ms │ 150 us │   1 ms │    2 ms │       9 ms │  8.7G │
│ portable: 2 producers -<1024>-> 4 consumers                │ PASS │ 8  │     9  │ 2.75k / 13.0k = 21.3% │  719  / 33.8k =  2.1% │    2.4m │   1 ms │   1 ms │ 168 us │   1 ms │    2 ms │      11 ms │  7.5G │
│ portable: 4 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 3.35k / 12.9k = 26.0% │  724  / 31.3k =  2.3% │    2.3m │ 791 us │ 888 us │ 216 us │ 801 us │    1 ms │       7 ms │ 11.3G │
│ portable: 4 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.59k / 12.2k = 21.2% │  652  / 32.1k =  2.0% │    2.3m │ 869 us │   1 ms │ 289 us │ 890 us │    2 ms │       8 ms │ 10.0G │
│ portable: 4 producers -<1024>-> 4 consumers                │ PASS │ 8  │     9  │ 2.90k / 13.6k = 21.4% │  845  / 35.1k =  2.4% │    2.5m │   2 ms │   2 ms │ 143 us │   2 ms │    2 ms │      14 ms │  5.8G │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼─────────┼────────────┼───────┤
│ portable - RAII writer: 1 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 17.2k / 31.9k = 53.8% │ 3.08k / 28.5k = 10.8% │    2.1m │ 144 ms │ 173 ms │  21 ms │ 183 ms │  193 ms │       1  s │ 57.9M │
│ portable - RAII writer: 1 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 17.9k / 33.6k = 53.2% │ 3.32k / 29.4k = 11.3% │    2.1m │ 205 ms │ 214 ms │  10 ms │ 214 ms │  230 ms │       2  s │ 46.7M │
│ portable - RAII writer: 1 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 18.6k / 34.4k = 54.1% │ 3.38k / 31.2k = 10.8% │    2.3m │ 277 ms │ 333 ms │  35 ms │ 346 ms │  400 ms │       3  s │ 30.0M │
│ portable - RAII writer: 2 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 17.0k / 32.6k = 52.3% │ 3.20k / 29.3k = 10.9% │    2.1m │ 431 ms │ 433 ms │   1 ms │ 433 ms │  434 ms │       3  s │ 23.1M │
│ portable - RAII writer: 2 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 15.7k / 31.2k = 50.4% │ 3.03k / 30.2k = 10.0% │    2.2m │ 604 ms │ 607 ms │   2 ms │ 607 ms │  609 ms │       5  s │ 16.5M │
│ portable - RAII writer: 2 producers -< 1  >-> 4 consumers  │ PASS │ 8  │    11  │ 19.4k / 37.5k = 51.6% │ 3.77k / 37.5k = 10.1% │    2.7m │   1  s │   1  s │   9 ms │   1  s │    1  s │       8  s │  9.9M │
│ portable - RAII writer: 4 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     9  │ 17.2k / 33.6k = 51.3% │ 3.31k / 33.4k =  9.9% │    2.4m │ 693 ms │ 738 ms │  30 ms │ 763 ms │  769 ms │       6  s │ 13.6M │
│ portable - RAII writer: 4 producers -< 1  >-> 2 consumers  │ PASS │ 8  │    10  │ 14.5k / 31.6k = 46.0% │ 2.92k / 37.3k =  7.8% │    2.7m │ 891 ms │ 908 ms │  15 ms │ 905 ms │  942 ms │       7  s │ 11.0M │
│ portable - RAII writer: 4 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 17.0k / 32.8k = 51.9% │ 3.13k / 34.2k =  9.1% │    2.5m │   2  s │   2  s │   8 ms │   2  s │    2  s │      15  s │  5.4M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼─────────┼────────────┼───────┤
│ portable - RAII writer: 1 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 2.69k / 12.4k = 21.7% │  867  / 28.2k =  3.1% │    2.1m │ 764 us │ 805 us │  71 us │ 778 us │  985 us │       6 ms │ 12.4G │
│ portable - RAII writer: 1 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.22k / 11.6k = 19.1% │  671  / 29.2k =  2.3% │    2.1m │ 872 us │ 935 us │ 142 us │ 882 us │    1 ms │       7 ms │ 10.7G │
│ portable - RAII writer: 1 producers -<1024>-> 4 consumers  │ PASS │ 8  │     8  │ 2.51k / 12.0k = 20.8% │  682  / 31.1k =  2.2% │    2.3m │ 992 us │   1 ms │ 279 us │ 998 us │    2 ms │       9 ms │  9.1G │
│ portable - RAII writer: 2 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 2.21k / 11.2k = 19.7% │  632  / 29.0k =  2.2% │    2.1m │ 909 us │ 932 us │  27 us │ 927 us │ 1000 us │       7 ms │ 10.7G │
│ portable - RAII writer: 2 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.60k / 12.0k = 21.6% │  638  / 29.9k =  2.1% │    2.2m │   1 ms │   1 ms │ 253 us │   1 ms │    2 ms │       9 ms │  8.8G │
│ portable - RAII writer: 2 producers -<1024>-> 4 consumers  │ PASS │ 8  │     8  │ 2.64k / 12.3k = 21.4% │  681  / 32.0k =  2.1% │    2.3m │   1 ms │   1 ms │ 159 us │   1 ms │    2 ms │      11 ms │  7.6G │
│ portable - RAII writer: 4 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 3.54k / 13.8k = 25.6% │  770  / 33.4k =  2.3% │    2.4m │ 786 us │ 845 us │  66 us │ 813 us │  992 us │       7 ms │ 11.8G │
│ portable - RAII writer: 4 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.62k / 12.2k = 21.4% │  681  / 32.0k =  2.1% │    2.3m │ 863 us │ 941 us │ 134 us │ 876 us │    1 ms │       8 ms │ 10.6G │
│ portable - RAII writer: 4 producers -<1024>-> 4 consumers  │ PASS │ 8  │     8  │ 4.25k / 14.3k = 29.7% │  772  / 33.7k =  2.3% │    2.4m │   2 ms │   2 ms │ 169 us │   2 ms │    2 ms │      13 ms │  6.3G │
└────────────────────────────────────────────────────────────┴──────┴────┴────────┴───────────────────────┴───────────────────────┴─────────┴────────┴────────┴────────┴────────┴─────────┴────────────┴───────┘

```

