### PR TITLE
unique node 'id' and 'name'

### DIFF
--- a/include/node.hpp
+++ b/include/node.hpp
@@ -193,11 +193,15 @@ output_ports(Self *self) noexcept {
  */
 template<typename Derived, typename... Arguments>
 class node : protected std::tuple<Arguments...> {
+    static std::atomic<std::size_t> _unique_id_counter;
+
 public:
-    using derived_t                                      = Derived;
-    using node_template_parameters                       = meta::typelist<Arguments...>;
-    using Description                                    = typename node_template_parameters::template find_or_default<is_doc, EmptyDoc>;
-    constexpr static tag_propagation_policy_t tag_policy = tag_propagation_policy_t::TPP_ALL_TO_ALL;
+    using derived_t                                       = Derived;
+    using node_template_parameters                        = meta::typelist<Arguments...>;
+    using Description                                     = typename node_template_parameters::template find_or_default<is_doc, EmptyDoc>;
+    constexpr static tag_propagation_policy_t tag_policy  = tag_propagation_policy_t::TPP_ALL_TO_ALL;
+    const std::size_t                         unique_id   = _unique_id_counter++;
+    const std::string                         unique_name = fmt::format("{}#{}", fair::meta::type_name<Derived>(), unique_id);
 
 protected:
     using setting_map = std::map<std::string, int, std::less<>>;
@@ -636,6 +640,9 @@ public:
     } // end: work_return_t work() noexcept { ..}
 };
 
+template<typename Derived, typename... Arguments>
+inline std::atomic<std::size_t> node<Derived, Arguments...>::_unique_id_counter{ 0_UZ };
+
 /**
  * @brief a short human-readable/markdown description of the node -- content is not contractual and subject to change
  */
@@ -711,6 +718,12 @@ concept sink_node = requires(Node &node, typename traits::node::input_port_types
 template<source_node Left, sink_node Right, std::size_t OutId, std::size_t InId>
 class merged_node : public node<merged_node<Left, Right, OutId, InId>, meta::concat<typename traits::node::input_ports<Left>, meta::remove_at<InId, typename traits::node::input_ports<Right>>>,
                                 meta::concat<meta::remove_at<OutId, typename traits::node::output_ports<Left>>, typename traits::node::output_ports<Right>>> {
+    static std::atomic<std::size_t> _unique_id_counter;
+
+public:
+    const std::size_t unique_id   = _unique_id_counter++;
+    const std::string unique_name = fmt::format("merged_node<{}:{},{}:{}>#{}", fair::meta::type_name<Left>(), OutId, fair::meta::type_name<Right>(), InId, unique_id);
+
 private:
     // copy-paste from above, keep in sync
     using base = node<merged_node<Left, Right, OutId, InId>, meta::concat<typename traits::node::input_ports<Left>, meta::remove_at<InId, typename traits::node::input_ports<Right>>>,
@@ -854,6 +867,9 @@ public:
         return base::work();
     }
 };
+
+template<source_node Left, sink_node Right, std::size_t OutId, std::size_t InId>
+inline std::atomic<std::size_t> merged_node<Left, Right, OutId, InId>::_unique_id_counter{ 0_UZ };
 
 /**
  * This methods can merge simple blocks that are defined via a single `auto process_one(..)` producing a

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -193,7 +193,7 @@ output_ports(Self *self) noexcept {
  */
 template<typename Derived, typename... Arguments>
 class node : protected std::tuple<Arguments...> {
-    static std::atomic<std::size_t> _unique_id_counter;
+    static std::atomic_size_t _unique_id_counter;
 
 public:
     using derived_t                                       = Derived;
@@ -641,7 +641,7 @@ public:
 };
 
 template<typename Derived, typename... Arguments>
-inline std::atomic<std::size_t> node<Derived, Arguments...>::_unique_id_counter{ 0_UZ };
+inline std::atomic_size_t node<Derived, Arguments...>::_unique_id_counter{ 0_UZ };
 
 /**
  * @brief a short human-readable/markdown description of the node -- content is not contractual and subject to change
@@ -718,7 +718,7 @@ concept sink_node = requires(Node &node, typename traits::node::input_port_types
 template<source_node Left, sink_node Right, std::size_t OutId, std::size_t InId>
 class merged_node : public node<merged_node<Left, Right, OutId, InId>, meta::concat<typename traits::node::input_ports<Left>, meta::remove_at<InId, typename traits::node::input_ports<Right>>>,
                                 meta::concat<meta::remove_at<OutId, typename traits::node::output_ports<Left>>, typename traits::node::output_ports<Right>>> {
-    static std::atomic<std::size_t> _unique_id_counter;
+    static std::atomic_size_t _unique_id_counter;
 
 public:
     const std::size_t unique_id   = _unique_id_counter++;
@@ -869,7 +869,7 @@ public:
 };
 
 template<source_node Left, sink_node Right, std::size_t OutId, std::size_t InId>
-inline std::atomic<std::size_t> merged_node<Left, Right, OutId, InId>::_unique_id_counter{ 0_UZ };
+inline std::atomic_size_t merged_node<Left, Right, OutId, InId>::_unique_id_counter{ 0_UZ };
 
 /**
  * This methods can merge simple blocks that are defined via a single `auto process_one(..)` producing a

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -78,8 +78,8 @@ concept Settings = requires(T t, Node& n, std::span<const std::string> parameter
 
 template<typename Node>
 struct settings_base {
-    Node             *_node = nullptr;
-    std::atomic<bool> _changed{ false };
+    Node            *_node = nullptr;
+    std::atomic_bool _changed{ false };
 
     settings_base() = delete;
 

--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -327,19 +327,23 @@ class BasicThreadPool {
     using TaskQueue = thread_pool::detail::TaskQueue;
     static std::atomic<uint64_t> _globalPoolId;
     static std::atomic<uint64_t> _taskID;
-    static std::string           generateName() { return fmt::format("BasicThreadPool#{}", _globalPoolId.fetch_add(1)); }
 
-    std::atomic<bool>            _initialised = ATOMIC_FLAG_INIT;
+    static std::string
+    generateName() {
+        return fmt::format("BasicThreadPool#{}", _globalPoolId.fetch_add(1));
+    }
+
+    std::atomic_bool             _initialised = ATOMIC_FLAG_INIT;
     bool                         _shutdown    = false;
 
     std::condition_variable      _condition;
-    std::atomic<std::size_t>     _numTaskedQueued = 0U; // cache for _taskQueue.size()
-    std::atomic<std::size_t>     _numTasksRunning = 0U;
+    std::atomic_size_t           _numTaskedQueued = 0U; // cache for _taskQueue.size()
+    std::atomic_size_t           _numTasksRunning = 0U;
     TaskQueue                    _taskQueue;
     TaskQueue                    _recycledTasks;
 
     std::mutex                   _threadListMutex;
-    std::atomic<std::size_t>     _numThreads = 0U;
+    std::atomic_size_t           _numThreads = 0U;
     std::list<std::thread>       _threads;
 
     std::vector<bool>            _affinityMask;

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -307,6 +307,19 @@ const boost::ut::suite SettingsTests = [] {
         expect(eq(block.vector_setting, std::vector{ 42.f, 2.f, 3.f }));
         expect(eq(block.update_count, 1)) << fmt::format("actual update count: {}\n", block.update_count);
     };
+
+    "unique ID"_test = [] {
+        graph flow_graph;
+        auto &block1 = flow_graph.make_node<TestBlock<float>>();
+        auto &block2 = flow_graph.make_node<TestBlock<float>>();
+        expect(not eq(block1.unique_id, block2.unique_id)) << "unique per-type block id (size_t)";
+        expect(not eq(block1.unique_name, block2.unique_name)) << "unique per-type block id (string)";
+
+        auto merged1 = merge<"out", "in">(TestBlock<float>(), TestBlock<float>());
+        auto merged2 = merge<"out", "in">(TestBlock<float>(), TestBlock<float>());
+        expect(not eq(merged1.unique_id, merged2.unique_id)) << "unique per-type block id (size_t) ";
+        expect(not eq(merged1.unique_name, merged2.unique_name)) << "unique per-type block id (string) ";
+    };
 };
 
 const boost::ut::suite AnnotationTests = [] {


### PR DESCRIPTION
This adds a unique technical identifier for each node created during run-time. The intentional use is to be able to disambiguate between blocks that have been created through cloning and/or for which users set the same `name()` but, for example, require different settings.