### PR TITLE
Fix compiler warnings and incorporate clang-tidy suggestions

### DIFF
--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -595,11 +595,11 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
         to_si_prefix(T value_base, std::string_view unit = "s", std::size_t significant_digits = 0) {
             static constexpr std::array si_prefixes{'q', 'r', 'y', 'z', 'a', 'f', 'p', 'n', 'u', 'm', ' ', 'k', 'M',
                                                     'G', 'T', 'P', 'E', 'Z', 'Y', 'R', 'Q'};
-            static constexpr double base = 1000.0;
+            static constexpr long double base = 1000.0l;
             long double value = value_base;
 
-            std::size_t exponent = 10;
-            if (value == 0) {
+            std::size_t exponent = 10u;
+            if (value == 0.0l) {
                 return fmt::format("{:.{}f}{}{}{}", value, significant_digits, unit.empty() ? "" : " ",
                                    si_prefixes[exponent], unit);
             }
@@ -607,22 +607,22 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
                 value /= base;
                 ++exponent;
             }
-            while (value < 1.0 && exponent > 0) {
+            while (value < 1.0l && exponent > 0u) {
                 value *= base;
                 --exponent;
             }
             if (significant_digits == 0 && exponent > 10) {
-              if (value < 10.0) {
-                significant_digits = 2;
-              } else if (value < 100.0) {
-                significant_digits = 1;
+              if (value < 10.0l) {
+                significant_digits = 2u;
+              } else if (value < 100.0l) {
+                significant_digits = 1u;
               }
-            } else if (significant_digits == 1 && value >= 100.0) {
+            } else if (significant_digits == 1 && value >= 100.0l) {
               --significant_digits;
-            } else if (significant_digits >= 2) {
-              if (value >= 100.0) {
-                significant_digits -= 2;
-              } else if (value >= 10.0) {
+            } else if (significant_digits >= 2u) {
+              if (value >= 100.0l) {
+                significant_digits -= 2u;
+              } else if (value >= 10.0l) {
                 --significant_digits;
               }
             }
@@ -789,7 +789,7 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
                 // not time-critical post-processing starts here
                 const auto time_differences_ns = utils::diff<N_ITERATIONS, long double>(stop_iter, start);
                 const auto ns = stop_iter[N_ITERATIONS - 1] - start;
-                const long double duration_s = 1e-9 * static_cast<long double>(ns.count());
+                const long double duration_s = 1e-9l * static_cast<long double>(ns.count());
 
                 const auto add_statistics = [&]<typename T>(ResultMap &map, const T &time_diff) {
                     if constexpr (N_ITERATIONS != 1) {

--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -531,7 +531,7 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
         diff(const std::vector<time_point> &stop, time_point start) {
             std::vector<T> ret(N);
             for (auto i = 0LU; i < N; i++) {
-                ret[i] = 1e-9 * static_cast<T>((stop[i] - start).count());
+                ret[i] = 1e-9l * static_cast<T>((stop[i] - start).count());
                 start = stop[i];
             }
             return ret;
@@ -543,7 +543,7 @@ for details see: https://www.kernel.org/doc/Documentation/sysctl/kernel.txt)";
         diff(const std::vector<time_point> &stop, const std::vector<time_point> &start) {
             std::vector<T> ret(N);
             for (auto i = 0LU; i < N; i++) {
-                ret[i] = 1e-9 * static_cast<T>((stop[i] - start[i]).count());
+                ret[i] = 1e-9l * static_cast<T>((stop[i] - start[i]).count());
             }
             return ret;
         }

--- a/bench/bm_buffer.cpp
+++ b/bench/bm_buffer.cpp
@@ -44,7 +44,7 @@ setCpuAffinity(const int cpuID) {}
 #endif
 #else
 void
-setCpuAffinity(const int cpuID) {}
+setCpuAffinity(const int /*cpuID*/) {}
 #endif
 
 enum class WriteApi { via_lambda, via_split_request_publish_RAII };

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -64,6 +64,7 @@ function(set_project_warnings project_name)
       -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
       -Wuseless-cast # warn if you perform a cast to the same type
       -Wno-interference-size # suppress ABI compatibility warnings for hardware inferred size
+      -Wno-maybe-uninitialized # false positives if asan is enabled: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=1056h6
   )
 
   if(MSVC)

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -99,7 +99,7 @@ class dynamic_port {
             if constexpr (T::IS_INPUT) {
                 return _value.update_reader_internal(buffer_other);
             } else {
-                assert(!"This works only on input ports");
+                assert(false && "This works only on input ports");
                 return false;
             }
         }
@@ -175,7 +175,7 @@ class dynamic_port {
                 auto src_buffer = _value.writer_handler_internal();
                 return dst_port.update_reader_internal(src_buffer) ? connection_result_t::SUCCESS : connection_result_t::FAILED;
             } else {
-                assert(!"This works only on input ports");
+                assert(false && "This works only on input ports");
                 return connection_result_t::FAILED;
             }
         }
@@ -350,7 +350,7 @@ protected:
     dynamic_ports _dynamic_input_ports;
     dynamic_ports _dynamic_output_ports;
 
-    node_model(){};
+    node_model()= default;
 
 public:
     node_model(const node_model &) = delete;
@@ -374,13 +374,13 @@ public:
         return _dynamic_output_ports[index];
     }
 
-    auto
+    [[nodiscard]] auto
     dynamic_input_ports_size() const {
         assert(_dynamic_ports_loaded);
         return _dynamic_input_ports.size();
     }
 
-    auto
+    [[nodiscard]] auto
     dynamic_output_ports_size() const {
         assert(_dynamic_ports_loaded);
         return _dynamic_output_ports.size();
@@ -487,13 +487,13 @@ public:
 
     template<typename Arg>
         requires(!std::is_same_v<std::remove_cvref_t<Arg>, T>)
-    node_wrapper(Arg &&arg) : _node(std::forward<Arg>(arg)) {
+    explicit node_wrapper(Arg &&arg) : _node(std::forward<Arg>(arg)) {
         init_dynamic_ports();
     }
 
     template<typename... Args>
         requires(sizeof...(Args) > 1)
-    node_wrapper(Args &&...args) : _node{ std::forward<Args>(args)... } {
+    explicit node_wrapper(Args &&...args) : _node{ std::forward<Args>(args)... } {
         init_dynamic_ports();
     }
 
@@ -544,7 +544,7 @@ public: // TODO: consider making this private and to use accessors (that can be 
     std::size_t _min_buffer_size;
     int32_t     _weight;
     std::string _name; // custom edge name
-    bool        _connected;
+    bool        _connected{};
 
 public:
     edge()             = delete;
@@ -622,7 +622,7 @@ private:
             }
         }();
 
-        if (it == _nodes.end()) throw fmt::format("No such node in this graph");
+        if (it == _nodes.end()) throw std::runtime_error(fmt::format("No such node in this graph"));
         return *it;
     }
 

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -337,12 +337,12 @@ public:
         return { _tags_at_output.data(), _tags_at_output.size() };
     }
 
-    constexpr settings_base &
+    [[nodiscard]] constexpr settings_base &
     settings() const noexcept {
         return *_settings;
     }
 
-    constexpr settings_base &
+    [[nodiscard]] constexpr settings_base &
     settings() noexcept {
         return *_settings;
     }
@@ -542,7 +542,7 @@ public:
 
         _input_tags_present      = false;
         _output_tags_changed     = false;
-        bool auto_change         = false;
+        //bool auto_change         = false;
         if (tags_to_process) {
             property_map merged_tag_map;
             _input_tags_present    = true;
@@ -565,11 +565,11 @@ public:
             if (_input_tags_present) { // apply tags as new settings if matching
                 if (!merged_tag_map.empty()) {
                     settings().auto_update(merged_tag_map);
-                    auto_change = true;
+                    //auto_change = true;
                 }
             }
 
-            if constexpr (tag_policy == tag_propagation_policy_t::TPP_ALL_TO_ALL) {
+            if constexpr (Derived::tag_policy == tag_propagation_policy_t::TPP_ALL_TO_ALL) {
                 // N.B. ranges omitted because of missing Clang/Emscripten support
                 std::for_each(_tags_at_output.begin(), _tags_at_output.end(), [&merged_tag_map](property_map &tag) { tag = merged_tag_map; });
                 _output_tags_changed = true;
@@ -970,10 +970,12 @@ merge_by_index(A &&a, B &&b) -> merged_node<std::remove_cvref_t<A>, std::remove_
 template<fixed_string OutName, fixed_string InName, source_node A, sink_node B>
 constexpr auto
 merge(A &&a, B &&b) {
-    constexpr std::size_t OutId = meta::indexForName<OutName, typename traits::node::output_ports<A>>();
-    constexpr std::size_t InId  = meta::indexForName<InName, typename traits::node::input_ports<B>>();
-    static_assert(OutId != -1);
-    static_assert(InId != -1);
+    constexpr int OutIdUnchecked = meta::indexForName<OutName, typename traits::node::output_ports<A>>();
+    constexpr int InIdUnchecked  = meta::indexForName<InName, typename traits::node::input_ports<B>>();
+    static_assert(OutIdUnchecked != -1);
+    static_assert(InIdUnchecked != -1);
+    constexpr auto OutId = static_cast<std::size_t>(OutIdUnchecked);
+    constexpr auto InId = static_cast<std::size_t>(InIdUnchecked);
     static_assert(std::same_as<typename traits::node::output_port_types<std::remove_cvref_t<A>>::template at<OutId>, typename traits::node::input_port_types<std::remove_cvref_t<B>>::template at<InId>>,
                   "Port types do not match");
     return merged_node<std::remove_cvref_t<A>, std::remove_cvref_t<B>, OutId, InId>{ std::forward<A>(a), std::forward<B>(b) };
@@ -984,7 +986,7 @@ namespace test {
 struct copy : public node<copy, IN<float, 0, -1_UZ, "in">, OUT<float, 0, -1_UZ, "out">> {
 public:
     template<meta::t_or_simd<float> V>
-    constexpr V
+    [[nodiscard]] constexpr V
     process_one(const V &a) const noexcept {
         return a;
     }

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -659,7 +659,7 @@ public:
         } else {
             // Non-SIMD loop
             for (std::size_t i = 0; i < samples_to_process; ++i) {
-                const auto results = std::apply([this, i](auto &...inputs) { return invoke_process_one(inputs[i]...); }, input_spans);
+                const auto results = std::apply([this, i](auto &...inputs) { return this->invoke_process_one(inputs[i]...); }, input_spans);
                 meta::tuple_for_each([i](auto &output_range, auto &result) { output_range[i] = std::move(result); }, writers_tuple, results);
             }
         }

--- a/include/plugin_loader.hpp
+++ b/include/plugin_loader.hpp
@@ -48,23 +48,23 @@ private:
     }
 
 public:
-    plugin_handler() {}
+    plugin_handler() = default;
 
-    plugin_handler(std::string plugin_file) {
+    explicit plugin_handler(const std::string& plugin_file) {
         _dl_handle = dlopen(plugin_file.c_str(), RTLD_LAZY);
         if (!_dl_handle) {
             _status = "Failed to load the plugin file";
             return;
         }
 
-        _create_fn = (plugin_create_function_t) (dlsym(_dl_handle, "gp_plugin_make"));
+        _create_fn = reinterpret_cast<plugin_create_function_t>(dlsym(_dl_handle, "gp_plugin_make"));
         if (!_create_fn) {
             _status = "Failed to load symbol gp_plugin_make";
             release();
             return;
         }
 
-        _destroy_fn = (plugin_destroy_function_t) (dlsym(_dl_handle, "gp_plugin_free"));
+        _destroy_fn = reinterpret_cast<plugin_destroy_function_t>(dlsym(_dl_handle, "gp_plugin_free"));
         if (!_destroy_fn) {
             _status = "Failed to load symbol gp_plugin_free";
             release();
@@ -110,7 +110,7 @@ public:
 
     explicit operator bool() const { return _instance; }
 
-    const std::string &
+    [[nodiscard]] const std::string &
     status() const {
         return _status;
     }

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -48,8 +48,8 @@ public:
         bool run = true;
         while (run) {
             bool something_happened = false;
-            for (const auto &node : _graph.blocks()) {
-                auto result = node->work();
+            for (const auto &current_node : _graph.blocks()) {
+                auto result = current_node->work();
                 if (result == work_return_t::ERROR) {
                     return work_return_t::ERROR;
                 } else if (result == work_return_t::INSUFFICIENT_INPUT_ITEMS) {
@@ -90,7 +90,7 @@ public:
             _source_nodes.push_back(e._src_node);
             node_reached.insert(e._dst_node);
         }
-        _source_nodes.erase(std::remove_if(_source_nodes.begin(), _source_nodes.end(), [&node_reached](auto node) { return node_reached.contains(node); }), _source_nodes.end());
+        _source_nodes.erase(std::remove_if(_source_nodes.begin(), _source_nodes.end(), [&node_reached](auto current_node) { return node_reached.contains(current_node); }), _source_nodes.end());
         // traverse graph
         std::queue<node_t> queue{};
         std::set<node_t>   reached;
@@ -101,11 +101,11 @@ public:
         }
         // process all nodes, adding all unvisited child nodes to the queue
         while (!queue.empty()) {
-            node_t node = queue.front();
+            node_t current_node = queue.front();
             queue.pop();
-            _nodelist.push_back(node);
-            if (_adjacency_list.contains(node)) { // node has outgoing edges
-                for (auto &dst : _adjacency_list.at(node)) {
+            _nodelist.push_back(current_node);
+            if (_adjacency_list.contains(current_node)) { // current_node has outgoing edges
+                for (auto &dst : _adjacency_list.at(current_node)) {
                     if (!reached.contains(dst)) { // detect cycles. this could be removed if we guarantee cycle free graphs earlier
                         queue.push(dst);
                         reached.insert(dst);
@@ -122,8 +122,8 @@ public:
         }
         while (true) {
             bool anything_happened = false;
-            for (auto node : _nodelist) {
-                auto res = node->work();
+            for (auto current_node : _nodelist) {
+                auto res = current_node->work();
                 anything_happened |= (res == work_return_t::OK || res == work_return_t::INSUFFICIENT_OUTPUT_ITEMS);
             }
             if (!anything_happened) {

--- a/include/settings.hpp
+++ b/include/settings.hpp
@@ -359,6 +359,8 @@ public:
                             member(*_node) = std::get<Type>(staged_value);
                             if constexpr (requires { _node->init(/* old settings */ _active, /* new settings */ staged); }) {
                                 staged.insert_or_assign(key, staged_value);
+                            } else {
+                                std::ignore = staged; // help clang to see why staged is not unused
                             }
                             if (_auto_forward.contains(get_display_name(member))) {
                                 forward_parameters.insert_or_assign(key, staged_value);

--- a/include/vir/simd.h
+++ b/include/vir/simd.h
@@ -825,7 +825,7 @@ namespace vir::stdx
 
   template <typename T>
     constexpr bool
-    some_of(simd_mask<T, simd_abi::scalar> k) noexcept
+    some_of(simd_mask<T, simd_abi::scalar> /*k*/) noexcept
     { return false; }
 
   template <typename T>

--- a/include/wait_strategy.hpp
+++ b/include/wait_strategy.hpp
@@ -344,7 +344,7 @@ struct NO_SPIN_WAIT {};
 
 template<typename SPIN_WAIT = NO_SPIN_WAIT>
 class AtomicMutex {
-    std::atomic_flag _lock = ATOMIC_FLAG_INIT;
+    std::atomic_flag _lock{};
     SPIN_WAIT        _spin_wait;
 
 public:

--- a/test/app_plugins_test.cpp
+++ b/test/app_plugins_test.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 
 #include <fmt/format.h>
-#include <fmt/ranges.h>
 
 using namespace std::chrono_literals;
 using namespace fair::literals;
@@ -15,7 +14,7 @@ using namespace fair::literals;
 namespace fg = fair::graph;
 
 struct test_context {
-    test_context(std::vector<std::filesystem::path> paths) : registry(), loader(&registry, std::move(paths)) {}
+    explicit test_context(std::vector<std::filesystem::path> paths) : registry(), loader(&registry, std::move(paths)) {}
 
     fg::node_registry registry;
     fg::plugin_loader loader;
@@ -78,11 +77,11 @@ int
 main(int argc, char *argv[]) {
     std::vector<std::filesystem::path> paths;
     if (argc < 2) {
-        paths.push_back("test/plugins");
-        paths.push_back("plugins");
+        paths.emplace_back("test/plugins");
+        paths.emplace_back("plugins");
     } else {
         for (int i = 1; i < argc; ++i) {
-            paths.push_back(argv[i]);
+            paths.emplace_back(argv[i]);
         }
     }
 
@@ -93,18 +92,18 @@ main(int argc, char *argv[]) {
     fmt::print("PluginLoaderTests\n");
     using namespace gr;
 
-    for (const auto &plugin : context.loader.plugins()) {
+    for (const auto &plugin [[maybe_unused]] : context.loader.plugins()) {
         assert(plugin->metadata->plugin_name.starts_with("Good"));
     }
 
-    for (const auto &plugin : context.loader.failed_plugins()) {
+    for (const auto &plugin [[maybe_unused]] : context.loader.failed_plugins()) {
         assert(plugin.first.ends_with("bad_plugin.so"));
     }
 
     auto        known = context.loader.known_nodes();
     std::vector requireds{ names::cout_sink, names::fixed_source, names::divide, names::multiply };
 
-    for (const auto &required : requireds) {
+    for (const auto &required [[maybe_unused]] : requireds) {
         assert(std::ranges::find(known, required) != known.end());
     }
 
@@ -132,10 +131,10 @@ main(int argc, char *argv[]) {
     assert(node_sink_load);
     auto &node_sink    = flow_graph.add_node(std::move(node_sink_load));
 
-    auto  connection_1 = flow_graph.dynamic_connect(node_source, 0, node_multiply_1, 0);
-    auto  connection_2 = flow_graph.dynamic_connect(node_multiply_1, 0, node_multiply_2, 0);
-    auto  connection_3 = flow_graph.dynamic_connect(node_multiply_2, 0, node_counter, 0);
-    auto  connection_4 = flow_graph.dynamic_connect(node_counter, 0, node_sink, 0);
+    auto connection_1 [[maybe_unused]] = flow_graph.dynamic_connect(node_source, 0, node_multiply_1, 0);
+    auto connection_2 [[maybe_unused]] = flow_graph.dynamic_connect(node_multiply_1, 0, node_multiply_2, 0);
+    auto connection_3 [[maybe_unused]] = flow_graph.dynamic_connect(node_multiply_2, 0, node_counter, 0);
+    auto connection_4 [[maybe_unused]] = flow_graph.dynamic_connect(node_counter, 0, node_sink, 0);
 
     assert(connection_1 == fg::connection_result_t::SUCCESS);
     assert(connection_2 == fg::connection_result_t::SUCCESS);
@@ -143,11 +142,11 @@ main(int argc, char *argv[]) {
     assert(connection_4 == fg::connection_result_t::SUCCESS);
 
     for (std::size_t i = 0; i < repeats; ++i) {
-        node_source.work();
-        node_multiply_1.work();
-        node_multiply_2.work();
-        node_counter.work();
-        node_sink.work();
+        std::ignore = node_source.work();
+        std::ignore = node_multiply_1.work();
+        std::ignore = node_multiply_2.work();
+        std::ignore = node_counter.work();
+        std::ignore = node_sink.work();
     }
 
     fmt::print("repeats {} event_count {}\n", repeats, builtin_counter<double>::s_event_count);

--- a/test/plugins/bad_plugin.cpp
+++ b/test/plugins/bad_plugin.cpp
@@ -2,7 +2,7 @@
 #include <vector>
 
 namespace {
-gp_plugin_metadata plugin_metadata{ "Bad Plugin", "Unknown", "Public Domain", "v0" };
+gp_plugin_metadata plugin_metadata [[maybe_unused]]{ "Bad Plugin", "Unknown", "Public Domain", "v0" };
 
 class bad_plugin : public gp_plugin_base {
 private:
@@ -10,16 +10,16 @@ private:
 
 public:
     std::unique_ptr<fair::graph::node_model>
-    create_node(std::string_view name, std::string_view type, const fair::graph::property_map &) override {
+    create_node(std::string_view /*name*/, std::string_view /*type*/, const fair::graph::property_map &) override {
         return {};
     }
 
-    std::uint8_t
+    [[nodiscard]] std::uint8_t
     abi_version() const override {
         return 0;
     }
 
-    std::span<const std::string>
+    [[nodiscard]] std::span<const std::string>
     provided_nodes() const override {
         return node_types;
     }

--- a/test/qa_buffer.cpp
+++ b/test/qa_buffer.cpp
@@ -253,7 +253,7 @@ const boost::ut::suite CircularBufferTests = [] {
             [](const Allocator &allocator) {
                 using namespace gr;
                 Buffer auto buffer = circular_buffer<int32_t>(1024, allocator);
-                expect(ge(buffer.size(), 1024));
+                expect(ge(buffer.size(), 1024u));
 
                 BufferWriter auto writer = buffer.new_writer();
                 expect(nothrow([&writer] { expect(eq(writer.buffer().n_readers(), std::size_t{ 0 })); })); // no reader, just writer
@@ -353,7 +353,7 @@ const boost::ut::suite CircularBufferTests = [] {
             }
             | std::vector{
 #ifndef __EMSCRIPTEN__
-                  Allocator(gr::double_mapped_memory_resource::allocator<int32_t>()),
+                  gr::double_mapped_memory_resource::allocator<int32_t>(),
 #endif
                   Allocator()
               };
@@ -364,7 +364,7 @@ const boost::ut::suite CircularBufferExceptionTests = [] {
     "CircularBufferExceptions"_test = [] {
         using namespace gr;
         Buffer auto buffer = circular_buffer<int32_t>(1024);
-        expect(ge(buffer.size(), 1024));
+        expect(ge(buffer.size(), 1024u));
 
         BufferWriter auto writer = buffer.new_writer();
         BufferReader auto reader = buffer.new_reader();
@@ -385,7 +385,7 @@ const boost::ut::suite UserDefinedTypeCasting = [] {
     "UserDefinedTypeCasting"_test = [] {
         using namespace gr;
         Buffer auto buffer = circular_buffer<std::complex<float>>(1024);
-        expect(ge(buffer.size(), 1024));
+        expect(ge(buffer.size(), 1024u));
 
         BufferWriter auto writer = buffer.new_writer();
         BufferReader auto reader = buffer.new_reader();
@@ -433,8 +433,8 @@ const boost::ut::suite StreamTagConcept = [] {
         expect(eq(sizeof(buffer_tag), std::size_t{ 64 })) << "tag size";
         Buffer auto buffer    = circular_buffer<int32_t>(1024);
         Buffer auto tagBuffer = circular_buffer<buffer_tag>(32);
-        expect(ge(buffer.size(), 1024));
-        expect(ge(tagBuffer.size(), 32));
+        expect(ge(buffer.size(), 1024u));
+        expect(ge(tagBuffer.size(), 32u));
 
         BufferWriter auto writer    = buffer.new_writer();
         BufferReader auto reader    = buffer.new_reader();
@@ -479,10 +479,10 @@ const boost::ut::suite NonPowerTwoTests = [] {
         constexpr std::size_t typeSize = sizeof(std::vector<int>);
         expect(not std::has_single_bit(typeSize)) << "type is non-power-of-two";
         Buffer auto buffer = circular_buffer<Type>(1024);
-        expect(ge(buffer.size(), 1024));
+        expect(ge(buffer.size(), 1024u));
         if (gr::has_posix_mmap_interface) {
-            expect(buffer.size() % typeSize == 0) << "divisible by the type size";
-            expect(buffer.size() % static_cast<std::size_t>(getpagesize()) == 0) << "divisible by the memory page size";
+            expect(buffer.size() % typeSize == 0u) << "divisible by the type size";
+            expect(buffer.size() % static_cast<std::size_t>(getpagesize()) == 0u) << "divisible by the memory page size";
         }
 
         BufferWriter auto writer     = buffer.new_writer();
@@ -506,7 +506,7 @@ const boost::ut::suite NonPowerTwoTests = [] {
                 const auto vectorData = reader.get();
                 for (auto &vector : vectorData) {
                     static int offset = -1;
-                    expect(eq(vector.size(), 1)) << "vector size == 1";
+                    expect(eq(vector.size(), 1u)) << "vector size == 1";
                     expect(eq(vector[0] - offset, 1)) << "vector offset == 1";
                     offset = vector[0];
                 }
@@ -529,7 +529,7 @@ const boost::ut::suite HistoryBufferTest = [] {
     "history_buffer<double>"_test = [](const std::size_t &capacity) {
         history_buffer<int> hb(capacity);
         expect(eq(hb.capacity(), capacity));
-        expect(eq(hb.size(), 0));
+        expect(eq(hb.size(), 0u));
 
         for (std::size_t i = 1; i <= capacity + 1; ++i) {
             hb.push_back(static_cast<int>(i));
@@ -537,19 +537,19 @@ const boost::ut::suite HistoryBufferTest = [] {
         expect(eq(hb.capacity(), capacity));
         expect(eq(hb.size(), capacity));
 
-        expect(eq(hb[0], capacity + 1)) << "access the last/actual sample";
-        expect(eq(hb[-1], capacity)) << "access the previous sample";
+        expect(eq(hb[0], static_cast<int>(capacity + 1))) << "access the last/actual sample";
+        expect(eq(hb[-1], static_cast<int>(capacity))) << "access the previous sample";
 
-        expect(eq(hb.at(0), capacity + 1)) << "checked access the last/actual sample";
-        expect(eq(hb.at(-1), capacity)) << "checked access the previous sample";
+        expect(eq(hb.at(0), static_cast<int>(capacity + 1))) << "checked access the last/actual sample";
+        expect(eq(hb.at(-1), static_cast<int>(capacity))) << "checked access the previous sample";
     } | std::vector<std::size_t>{ 5, 3, 10 };
 
     "history_buffer - range tests"_test = [] {
         history_buffer<int> hb(5);
         hb.push_back_bulk(std::array{ 1, 2, 3 });
         hb.push_back_bulk(std::vector{ 4, 5, 6 });
-        expect(eq(hb.capacity(), 5));
-        expect(eq(hb.size(), 5));
+        expect(eq(hb.capacity(), 5u));
+        expect(eq(hb.size(), 5u));
 
         auto equal = [](const auto &range1, const auto &range2) { // N.B. TODO replacement until libc++ fully supports ranges
             return std::equal(range1.begin(), range1.end(), range2.begin(), range2.end());
@@ -583,12 +583,12 @@ const boost::ut::suite HistoryBufferTest = [] {
 
         // Create a history buffer of size 1
         history_buffer<int> hb_one(1);
-        expect(eq(hb_one.capacity(), 1));
-        expect(eq(hb_one.size(), 0));
+        expect(eq(hb_one.capacity(), 1u));
+        expect(eq(hb_one.size(), 0u));
         hb_one.push_back(41);
         hb_one.push_back(42);
-        expect(eq(hb_one.capacity(), 1));
-        expect(eq(hb_one.size(), 1));
+        expect(eq(hb_one.capacity(), 1u));
+        expect(eq(hb_one.size(), 1u));
         expect(eq(hb_one[0], 42));
 
         expect(throws<std::out_of_range>([&hb_one] { [[maybe_unused]] auto a = hb_one.at(1); })) << "throws for index > 0";
@@ -609,8 +609,8 @@ const boost::ut::suite HistoryBufferTest = [] {
         for (int i = 0; i < 10; ++i) {
             hb_double.push_back(i * 0.1);
         }
-        expect(eq(hb_double.capacity(), 5));
-        expect(eq(hb_double.size(), 5));
+        expect(eq(hb_double.capacity(), 5u));
+        expect(eq(hb_double.size(), 5u));
     };
 };
 

--- a/test/qa_dynamic_node.cpp
+++ b/test/qa_dynamic_node.cpp
@@ -96,7 +96,7 @@ public:
                 },
                 available_samples);
 
-        for (auto &input_port : _input_ports) {
+        for (auto &input_port [[maybe_unused]] : _input_ports) {
             assert(available_samples == input_port.streamReader().consume(available_samples));
         }
         return fg::work_return_t::OK;

--- a/test/qa_dynamic_port.cpp
+++ b/test/qa_dynamic_port.cpp
@@ -114,7 +114,7 @@ const boost::ut::suite PortApiTests = [] {
     "PortBufferApi"_test = [] {
         OUT<float, 0, std::numeric_limits<std::size_t>::max(), "out0"> output_port;
         BufferWriter auto                                             &writer    = output_port.streamWriter();
-        BufferWriter auto                                             &tagWriter = output_port.tagWriter();
+        // BufferWriter auto                                             &tagWriter = output_port.tagWriter();
         expect(ge(writer.available(), 32_UZ));
 
         IN<float, 0, std::numeric_limits<std::size_t>::max(), "int0"> input_port;

--- a/test/qa_filter.cpp
+++ b/test/qa_filter.cpp
@@ -83,9 +83,9 @@ const boost::ut::suite SequenceTests = [] {
         const std::size_t fir_settling_time  = estimate_settling_time<double>(fir_response);
         const std::size_t iir_settling_time1 = estimate_settling_time<double>(iir_response1);
         const std::size_t iir_settling_time2 = estimate_settling_time<double>(iir_response2);
-        expect(eq(fir_settling_time, 10)) << "FIR settling time";
-        expect(eq(iir_settling_time1, 5)) << "IIR (I) settling time";
-        expect(eq(iir_settling_time2, 5)) << "IIR (II) settling time";
+        expect(eq(fir_settling_time, 10u)) << "FIR settling time";
+        expect(eq(iir_settling_time1, 5u)) << "IIR (I) settling time";
+        expect(eq(iir_settling_time2, 5u)) << "IIR (II) settling time";
 
         //        fmt::print("FIR      filter settling time: {} ms\n", fir_settling_time);
         //        fmt::print("IIR (I)  filter settling time: {} ms\n", iir_settling_time1);

--- a/test/qa_hier_node.cpp
+++ b/test/qa_hier_node.cpp
@@ -8,7 +8,7 @@ namespace fg = fair::graph;
 template<typename T, typename R = decltype(std::declval<T>() * std::declval<T>())>
 class scale : public fg::node<scale<T, R>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "original">, fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "scaled">> {
 public:
-    scale(std::string_view name = "") { this->_name = name; }
+    explicit scale(std::string_view name = "") { this->_name = name; }
 
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
@@ -21,7 +21,7 @@ template<typename T, typename R = decltype(std::declval<T>() + std::declval<T>()
 class adder : public fg::node<adder<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend0">, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend1">,
                               fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "sum">> {
 public:
-    adder(std::string_view name = "") { this->_name = name; }
+    explicit adder(std::string_view name = "") { this->_name = name; }
 
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
@@ -58,8 +58,8 @@ protected:
         auto     &left_scale_block  = graph.make_node<scale<double>>();
         auto     &right_scale_block = graph.make_node<scale<double>>();
 
-        graph.connect<"scaled">(left_scale_block).to<"addend0">(adder_block);
-        graph.connect<"scaled">(right_scale_block).to<"addend1">(adder_block);
+        std::ignore = graph.connect<"scaled">(left_scale_block).to<"addend0">(adder_block);
+        std::ignore = graph.connect<"scaled">(right_scale_block).to<"addend1">(adder_block);
 
         _dynamic_input_ports.emplace_back(fg::input_port<0>(&left_scale_block));
         _dynamic_input_ports.emplace_back(fg::input_port<0>(&right_scale_block));
@@ -74,23 +74,23 @@ public:
 
     ~hier_node() override = default;
 
-    std::string_view
+    [[nodiscard]] std::string_view
     name() const override {
         return _unique_name;
     }
 
-    virtual fg::work_return_t
+    fg::work_return_t
     work() override {
         return _scheduler.work();
     }
 
-    virtual void *
+    void *
     raw() override {
         return this;
     }
 
     void
-    set_name(std::string name) noexcept override {}
+    set_name(std::string /*name*/) noexcept override {}
 
     [[nodiscard]] fg::property_map &
     meta_information() noexcept override {
@@ -117,7 +117,7 @@ private:
     std::size_t _remaining_events_count;
 
 public:
-    fixed_source(std::size_t events_count) : _remaining_events_count(events_count) {}
+    explicit fixed_source(std::size_t events_count) : _remaining_events_count(events_count) {}
 
     T value = 1;
 
@@ -151,7 +151,7 @@ class cout_sink : public fg::node<cout_sink<T>, fg::IN<T, 0, 1024, "in">> {
     std::size_t _remaining = 0;
 
 public:
-    cout_sink() {}
+    cout_sink() = default;
 
     explicit cout_sink(std::size_t count) : _remaining(count) {}
 

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -331,7 +331,7 @@ const boost::ut::suite SettingsTests = [] {
         wrapped1.set_name("test_name");
         expect(eq(wrapped1.name(), "test_name"sv)) << "node_model wrapper name";
         expect(not wrapped1.unique_name().empty()) << "unique name";
-        wrapped1.settings().set({ { "context", "a string" } });
+        std::ignore = wrapped1.settings().set({ { "context", "a string" } });
         (wrapped1.meta_information())["key"] = "value";
         expect(eq(std::get<std::string>(wrapped1.meta_information().at("key")), "value"sv)) << "node_model meta-information";
     };

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -83,13 +83,13 @@ struct Source : public node<Source<T>> {
     float        sample_rate        = 1000.0f;
 
     void
-    init(const property_map &old_settings, const property_map &new_settings) {
+    init(const property_map &/*old_settings*/, const property_map &/*new_settings*/) {
         // optional init function that is called after construction and whenever settings change
-        fair::graph::publish_tag(out, { { "n_samples_max", n_samples_max } }, n_tag_offset);
+        fair::graph::publish_tag(out, { { "n_samples_max", n_samples_max } }, static_cast<std::size_t >(n_tag_offset));
     }
 
     constexpr std::make_signed_t<std::size_t>
-    available_samples(const Source &self) noexcept {
+    available_samples(const Source &/*self*/) noexcept {
         const auto ret = static_cast<std::make_signed_t<std::size_t>>(n_samples_max - n_samples_produced);
         return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
     }
@@ -170,7 +170,7 @@ struct Sink : public node<Sink<T>> {
         */
 
         if constexpr (fair::meta::any_simd<V>) {
-            n_samples_consumed += V::size();
+            n_samples_consumed += static_cast<std::int32_t>(V::size());
         } else {
             n_samples_consumed++;
         }
@@ -230,7 +230,7 @@ const boost::ut::suite SettingsTests = [] {
         expect(ret2.empty()) << "setting one known parameter";
         expect(block1.settings().changed()) << "settings changed";
         auto forwarding_parameter = block1.settings().apply_staged_parameters();
-        expect(eq(forwarding_parameter.size(), 1)) << "initial forward declarations";
+        expect(eq(forwarding_parameter.size(), 1u)) << "initial forward declarations";
         block1.settings().update_active_parameters();
 
         // src -> block1 -> block2 -> sink
@@ -272,9 +272,9 @@ const boost::ut::suite SettingsTests = [] {
 #if !defined(__clang_major__) && __clang_major__ <= 15
         "with init parameter"_test = [] {
             auto block = TestBlock<float>({ { "scaling_factor", 2.f } });
-            expect(eq(block.settings().staged_parameters().size(), 1));
+            expect(eq(block.settings().staged_parameters().size(), 1u));
             std::ignore = block.settings().apply_staged_parameters();
-            expect(eq(block.settings().staged_parameters().size(), 0));
+            expect(eq(block.settings().staged_parameters().size(), 0u));
             block.settings().update_active_parameters();
             expect(eq(block.settings().get().size(), 5UL));
             expect(eq(block.scaling_factor, 2.f));


### PR DESCRIPTION
This commit tries to reduce the number of compiler warnings to zero and performs changes suggested by clang-tidy.

reduction of the number of lines in the respective build steps:
- gcc: 2800 -> 400: all will be fixed by https://github.com/gnuradio/pmt/pull/100, the only one remaining is the node constructor with pmt based settings initialisation. [error message](https://github.com/fair-acc/graph-prototype/actions/runs/5314768958/jobs/9622354105?pr=92#step:10:149)
  I had to disable the `maybe-unused` waring in gcc because it triggers a massive amount of false positives in the standard library in combination with asan. There is an open gcc issue that I linked from the line in the cmake where I disabled it.
- clang: 1800 -> 112: caused by 1 [simd related warning](https://github.com/fair-acc/graph-prototype/actions/runs/5314768958/jobs/9622354392?pr=92#step:10:67)
- emscripten:  4000 -> 2600: mostly caused by size_t related conversion errors in pmt, ut and local code.