### PR TITLE
refactored tag_t handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ include(FetchContent)
 FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-        GIT_TAG 8.1.1
+        GIT_TAG 10.0.0
 )
 
 FetchContent_Declare(

--- a/bench/bm_test_helper.hpp
+++ b/bench/bm_test_helper.hpp
@@ -98,8 +98,8 @@ struct sink : public fg::node<sink<T, N_MIN, N_MAX>> {
     process_one(V a) noexcept {
         // optional user-level tag processing
         if (this->input_tags_present()) {
-            if (this->input_tags_present() && this->input_tags()[0].contains("N_SAMPLES_MAX")) {
-                const auto value = this->input_tags()[0].at("N_SAMPLES_MAX");
+            if (this->input_tags_present() && this->input_tags()[0].map.contains("N_SAMPLES_MAX")) {
+                const auto value = this->input_tags()[0].map.at("N_SAMPLES_MAX");
                 if (std::holds_alternative<uint64_t>(value)) { // should be std::size_t but emscripten/pmtv seem to have issues with it
                     should_receive_n_samples = std::get<uint64_t>(value);
                     _last_tag_position       = in.streamReader().position();

--- a/include/tag.hpp
+++ b/include/tag.hpp
@@ -56,8 +56,25 @@ using property_map = std::map<std::string, pmtv::pmt, detail::transparent_less>;
  * so that there is only one tag per scheduler iteration. Multiple tags on the same sample shall be merged to one.
  */
 struct alignas(hardware_constructive_interference_size) tag_t {
-    std::make_signed_t<std::size_t> index = 0;
-    property_map                    map;
+    using signed_index_type = std::make_signed_t<std::size_t>;
+    signed_index_type index{ 0 };
+    property_map      map{};
+
+    tag_t() = default;
+
+    tag_t(signed_index_type index_, property_map map_) noexcept : index(index_), map(std::move(map_)) {}
+
+    tag_t(const tag_t &other) = default;
+
+    tag_t &
+    operator=(const tag_t &other)
+            = default;
+
+    tag_t(tag_t &&other) noexcept = default;
+
+    tag_t &
+    operator=(tag_t &&other) noexcept
+            = default;
 
     bool
     operator==(const tag_t &other) const

--- a/include/tag.hpp
+++ b/include/tag.hpp
@@ -57,28 +57,17 @@ using property_map = std::map<std::string, pmtv::pmt, detail::transparent_less>;
  */
 struct alignas(hardware_constructive_interference_size) tag_t {
     using signed_index_type = std::make_signed_t<std::size_t>;
-    signed_index_type index{ 0 };
-    property_map      map{};
+    signed_index_type index{0};
+    property_map map{};
 
-    tag_t() = default;
+    tag_t() = default; // TODO: remove -- needed only for Clang <=15
 
-    tag_t(signed_index_type index_, property_map map_) noexcept : index(index_), map(std::move(map_)) {}
-
-    tag_t(const tag_t &other) = default;
-
-    tag_t &
-    operator=(const tag_t &other)
-            = default;
-
-    tag_t(tag_t &&other) noexcept = default;
-
-    tag_t &
-    operator=(tag_t &&other) noexcept
-            = default;
+    tag_t(signed_index_type index_, property_map map_) noexcept: index(index_), map(std::move(
+            map_)) {} // TODO: remove -- needed only for Clang <=15
 
     bool
     operator==(const tag_t &other) const
-            = default;
+    = default;
 
     // TODO: do we need the convenience methods below?
     void

--- a/include/tag.hpp
+++ b/include/tag.hpp
@@ -60,6 +60,12 @@ struct alignas(hardware_constructive_interference_size) tag_t {
     property_map                    map;
 
     // TODO: do we need the convenience methods below?
+    void
+    reset() noexcept {
+        index = 0;
+        map.clear();
+    }
+
     [[nodiscard]] pmtv::pmt &
     at(const std::string &key) {
         return map.at(key);

--- a/include/tag.hpp
+++ b/include/tag.hpp
@@ -59,6 +59,10 @@ struct alignas(hardware_constructive_interference_size) tag_t {
     std::make_signed_t<std::size_t> index = 0;
     property_map                    map;
 
+    bool
+    operator==(const tag_t &other) const
+            = default;
+
     // TODO: do we need the convenience methods below?
     void
     reset() noexcept {

--- a/include/thread_affinity.hpp
+++ b/include/thread_affinity.hpp
@@ -2,6 +2,7 @@
 #define THREADAFFINITY_HPP
 
 #include <algorithm>
+#include <fmt/core.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <fstream>
@@ -34,71 +35,77 @@ class thread_exception : public std::error_category {
     using std::error_category::error_category;
 
 public:
-    constexpr thread_exception()
-        : std::error_category(){};
+    constexpr thread_exception() : std::error_category(){};
 
-    const char *name() const noexcept override { return "thread_exception"; };
-    std::string message(int errorCode) const override {
+    const char *
+    name() const noexcept override {
+        return "thread_exception";
+    };
+
+    std::string
+    message(int errorCode) const override {
         switch (errorCode) {
-        case THREAD_UNINITIALISED:
-            return "thread uninitialised or user does not have the appropriate rights (ie. CAP_SYS_NICE capability)";
-        case THREAD_ERROR_UNKNOWN:
-            return "thread error code 2";
-        case THREAD_INVALID_ARGUMENT:
-            return "invalid argument";
-        case THREAD_ERANGE:
-            return fmt::format("length of the string specified pointed to by name exceeds the allowed limit THREAD_MAX_NAME_LENGTH = '{}'", THREAD_MAX_NAME_LENGTH);
-        case THREAD_VALUE_RANGE:
-            return fmt::format("priority out of valid range for scheduling policy", THREAD_MAX_NAME_LENGTH);
-        default:
-            return fmt::format("unknown threading error code {}", errorCode);
+        case THREAD_UNINITIALISED: return "thread uninitialised or user does not have the appropriate rights (ie. CAP_SYS_NICE capability)";
+        case THREAD_ERROR_UNKNOWN: return "thread error code 2";
+        case THREAD_INVALID_ARGUMENT: return "invalid argument";
+        case THREAD_ERANGE: return fmt::format("length of the string specified pointed to by name exceeds the allowed limit THREAD_MAX_NAME_LENGTH = '{}'", THREAD_MAX_NAME_LENGTH);
+        case THREAD_VALUE_RANGE: return fmt::format("priority out of valid range for scheduling policy", THREAD_MAX_NAME_LENGTH);
+        default: return fmt::format("unknown threading error code {}", errorCode);
         }
     };
 };
 
 template<class type>
 #ifdef __EMSCRIPTEN__
-    concept thread_type = std::is_same_v<type, std::thread>;
+concept thread_type = std::is_same_v<type, std::thread>;
 #else
-    concept thread_type = std::is_same_v<type, std::thread> || std::is_same_v<type, std::jthread>;
+concept thread_type = std::is_same_v<type, std::thread> || std::is_same_v<type, std::jthread>;
 #endif
 
 namespace detail {
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-    template<typename Tp, typename... Us>
-    constexpr decltype(auto) firstElement(Tp && t, Us && ...) noexcept {
-        return std::forward<Tp>(t);
-    }
+template<typename Tp, typename... Us>
+constexpr decltype(auto)
+firstElement(Tp &&t, Us &&...) noexcept {
+    return std::forward<Tp>(t);
+}
 
-    inline constexpr pthread_t getPosixHandler(thread_type auto &...t) noexcept {
-        if constexpr (sizeof...(t) > 0) {
-            return firstElement(t...).native_handle();
-        } else {
-            return pthread_self();
-        }
+inline constexpr pthread_t
+getPosixHandler(thread_type auto &...t) noexcept {
+    if constexpr (sizeof...(t) > 0) {
+        return firstElement(t...).native_handle();
+    } else {
+        return pthread_self();
     }
+}
 
-    inline std::string getThreadName(const pthread_t &handle) {
-        if (handle == 0U) {
-            return "uninitialised thread";
-        }
-        char threadName[THREAD_MAX_NAME_LENGTH];
-        if (int rc = pthread_getname_np(handle, threadName, THREAD_MAX_NAME_LENGTH); rc != 0) {
-            throw std::system_error(rc, thread_exception(), "getThreadName(thread_type)");
-        }
-        return std::string{ threadName, std::min(strlen(threadName), THREAD_MAX_NAME_LENGTH) };
+inline std::string
+getThreadName(const pthread_t &handle) {
+    if (handle == 0U) {
+        return "uninitialised thread";
     }
+    char threadName[THREAD_MAX_NAME_LENGTH];
+    if (int rc = pthread_getname_np(handle, threadName, THREAD_MAX_NAME_LENGTH); rc != 0) {
+        throw std::system_error(rc, thread_exception(), "getThreadName(thread_type)");
+    }
+    return std::string{ threadName, std::min(strlen(threadName), THREAD_MAX_NAME_LENGTH) };
+}
 
-    inline int getPid() { return getpid(); }
+inline int
+getPid() {
+    return getpid();
+}
 #else
-    int getPid() {
-        return 0;
-    }
+int
+getPid() {
+    return 0;
+}
 #endif
 } // namespace detail
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline std::string getProcessName(const int pid = detail::getPid()) {
+inline std::string
+getProcessName(const int pid = detail::getPid()) {
     if (std::ifstream in(fmt::format("/proc/{}/comm", pid), std::ios::in); in.is_open()) {
         std::string fileContent;
         std::getline(in, fileContent, '\n');
@@ -107,13 +114,15 @@ inline std::string getProcessName(const int pid = detail::getPid()) {
     return "unknown_process";
 }
 #else
-inline std::string getProcessName(const int /*pid*/ = -1) {
+inline std::string
+getProcessName(const int /*pid*/ = -1) {
     return "unknown_process";
 }
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline std::string getThreadName(thread_type auto &...thread) {
+inline std::string
+getThreadName(thread_type auto &...thread) {
     const pthread_t handle = detail::getPosixHandler(thread...);
     if (handle == 0U) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), "getThreadName(thread_type)");
@@ -121,13 +130,15 @@ inline std::string getThreadName(thread_type auto &...thread) {
     return detail::getThreadName(handle);
 }
 #else
-inline std::string getThreadName(thread_type auto &.../*thread*/) {
+inline std::string
+getThreadName(thread_type auto &.../*thread*/) {
     return "unknown thread name";
 }
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline void setProcessName(const std::string_view &processName, int pid = detail::getPid()) {
+inline void
+setProcessName(const std::string_view &processName, int pid = detail::getPid()) {
     std::ofstream out(fmt::format("/proc/{}/comm", pid), std::ios::out);
     if (!out.is_open()) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setProcessName({},{})", processName, pid));
@@ -136,11 +147,13 @@ inline void setProcessName(const std::string_view &processName, int pid = detail
     out.close();
 }
 #else
-inline void setProcessName(const std::string_view &/*processName*/, int /*pid*/ = -1) {}
+inline void
+setProcessName(const std::string_view & /*processName*/, int /*pid*/ = -1) {}
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline void setThreadName(const std::string_view &threadName, thread_type auto &...thread) {
+inline void
+setThreadName(const std::string_view &threadName, thread_type auto &...thread) {
     const pthread_t handle = detail::getPosixHandler(thread...);
     if (handle == 0U) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setThreadName({}, thread_type)", threadName, detail::getThreadName(handle)));
@@ -150,12 +163,14 @@ inline void setThreadName(const std::string_view &threadName, thread_type auto &
     }
 }
 #else
-inline void setThreadName(const std::string_view &/*threadName*/, thread_type auto &.../*thread*/) {}
+inline void
+setThreadName(const std::string_view & /*threadName*/, thread_type auto &.../*thread*/) {}
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
 namespace detail {
-inline std::vector<bool> getAffinityMask(const cpu_set_t &cpuSet) {
+inline std::vector<bool>
+getAffinityMask(const cpu_set_t &cpuSet) {
     std::vector<bool> bitMask(std::min(sizeof(cpu_set_t), static_cast<size_t>(std::thread::hardware_concurrency())));
     for (size_t i = 0; i < bitMask.size(); i++) {
         bitMask[i] = CPU_ISSET(i, &cpuSet);
@@ -164,8 +179,9 @@ inline std::vector<bool> getAffinityMask(const cpu_set_t &cpuSet) {
 }
 
 template<class T>
-requires requires(T value) { value[0]; }
-inline constexpr cpu_set_t getAffinityMask(const T &threadMap) {
+    requires requires(T value) { value[0]; }
+inline constexpr cpu_set_t
+getAffinityMask(const T &threadMap) {
     cpu_set_t cpuSet;
     CPU_ZERO(&cpuSet);
     size_t nMax = std::min(threadMap.size(), static_cast<size_t>(std::thread::hardware_concurrency()));
@@ -182,7 +198,8 @@ inline constexpr cpu_set_t getAffinityMask(const T &threadMap) {
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline std::vector<bool> getThreadAffinity(thread_type auto &...thread) {
+inline std::vector<bool>
+getThreadAffinity(thread_type auto &...thread) {
     const pthread_t handle = detail::getPosixHandler(thread...);
     if (handle == 0U) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getThreadAffinity(thread_type)"));
@@ -194,32 +211,39 @@ inline std::vector<bool> getThreadAffinity(thread_type auto &...thread) {
     return detail::getAffinityMask(cpuSet);
 }
 #else
-std::vector<bool> getThreadAffinity(thread_type auto &...) {
+std::vector<bool>
+getThreadAffinity(thread_type auto &...) {
     return std::vector<bool>(std::thread::hardware_concurrency()); // cannot set affinity for non-posix threads
 }
 #endif
 
 template<class T>
-requires requires(T value) { value[0]; }
+    requires requires(T value) { value[0]; }
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline constexpr void setThreadAffinity(const T &threadMap, thread_type auto &...thread) {
+inline constexpr void
+setThreadAffinity(const T &threadMap, thread_type auto &...thread) {
     const pthread_t handle = detail::getPosixHandler(thread...);
     if (handle == 0U) {
-        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setThreadAffinity(std::vector<bool, {}> = {{{}}}, thread_type)", threadMap.size(), fmt::join(threadMap.begin(), threadMap.end(), ", ")));
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(),
+                                fmt::format("setThreadAffinity(std::vector<bool, {}> = {{{}}}, thread_type)", threadMap.size(), fmt::join(threadMap.begin(), threadMap.end(), ", ")));
     }
     cpu_set_t cpuSet = detail::getAffinityMask(threadMap);
     if (int rc = pthread_setaffinity_np(handle, sizeof(cpu_set_t), &cpuSet); rc != 0) {
-        throw std::system_error(rc, thread_exception(), fmt::format("setThreadAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap.begin(), threadMap.end(), ", "), detail::getThreadName(handle)));
+        throw std::system_error(rc, thread_exception(),
+                                fmt::format("setThreadAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap.begin(), threadMap.end(), ", "),
+                                            detail::getThreadName(handle)));
     }
 }
 #else
-constexpr bool setThreadAffinity(const T &/*threadMap*/, thread_type auto &...) {
+constexpr bool
+setThreadAffinity(const T & /*threadMap*/, thread_type auto &...) {
     return false; // cannot set affinity for non-posix threads
 }
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline std::vector<bool> getProcessAffinity(const int pid = detail::getPid()) {
+inline std::vector<bool>
+getProcessAffinity(const int pid = detail::getPid()) {
     if (pid <= 0) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getProcessAffinity({}) -- invalid pid", pid));
     }
@@ -230,21 +254,25 @@ inline std::vector<bool> getProcessAffinity(const int pid = detail::getPid()) {
     return detail::getAffinityMask(cpuSet);
 }
 #else
-inline std::vector<bool> getProcessAffinity(const int /*pid*/ = -1) {
+inline std::vector<bool>
+getProcessAffinity(const int /*pid*/ = -1) {
     return std::vector<bool>(std::thread::hardware_concurrency()); // cannot set affinity for non-posix threads
 }
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
 template<class T>
-requires requires(T value) { std::get<0>(value); }
-inline constexpr bool setProcessAffinity(const T &threadMap, const int pid = detail::getPid()) {
+    requires requires(T value) { std::get<0>(value); }
+inline constexpr bool
+setProcessAffinity(const T &threadMap, const int pid = detail::getPid()) {
     if (pid <= 0) {
-        throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setProcessAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap.begin(), threadMap.end(), ", "), pid));
+        throw std::system_error(THREAD_UNINITIALISED, thread_exception(),
+                                fmt::format("setProcessAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap.begin(), threadMap.end(), ", "), pid));
     }
     cpu_set_t cpuSet = detail::getAffinityMask(threadMap);
     if (int rc = sched_setaffinity(pid, sizeof(cpu_set_t), &cpuSet); rc != 0) {
-        throw std::system_error(rc, thread_exception(), fmt::format("setProcessAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap.begin(), threadMap.end(), ", "), pid));
+        throw std::system_error(rc, thread_exception(),
+                                fmt::format("setProcessAffinity(std::vector<bool, {}> = {{{}}}, {})", threadMap.size(), fmt::join(threadMap.begin(), threadMap.end(), ", "), pid));
     }
 
     return true;
@@ -252,16 +280,40 @@ inline constexpr bool setProcessAffinity(const T &threadMap, const int pid = det
 #else
 template<class T>
     requires requires(T value) { std::get<0>(value); }
-inline constexpr bool setProcessAffinity(const T &/*threadMap*/, const int /*pid*/ = -1) {
+inline constexpr bool
+setProcessAffinity(const T & /*threadMap*/, const int /*pid*/ = -1) {
     return false; // cannot set affinity for non-posix threads
 }
 #endif
-enum Policy {
-    UNKNOWN     = -1,
-    OTHER       = 0,
-    FIFO        = 1,
-    ROUND_ROBIN = 2
+enum Policy { UNKNOWN = -1, OTHER = 0, FIFO = 1, ROUND_ROBIN = 2 };
+} // namespace fair::thread_pool::thread
+
+template<>
+struct fmt::formatter<fair::thread_pool::thread::Policy> {
+    using Policy = fair::thread_pool::thread::Policy;
+
+    template<typename ParseContext>
+    constexpr auto
+    parse(ParseContext &ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto
+    format(Policy policy, FormatContext &ctx) {
+        std::string policy_name;
+        switch (policy) {
+        case Policy::UNKNOWN: policy_name = "UNKNOWN"; break;
+        case Policy::OTHER: policy_name = "OTHER"; break;
+        case Policy::FIFO: policy_name = "FIFO"; break;
+        case Policy::ROUND_ROBIN: policy_name = "ROUND_ROBIN"; break;
+        default: policy_name = "INVALID_POLICY"; break;
+        }
+        return fmt::format_to(ctx.out(), "{}", policy_name);
+    }
 };
+
+namespace fair::thread_pool::thread {
 
 struct SchedulingParameter {
     Policy policy; // e.g. SCHED_OTHER, SCHED_RR, FSCHED_FIFO
@@ -269,21 +321,22 @@ struct SchedulingParameter {
 };
 
 namespace detail {
-inline Policy getEnumPolicy(const int policy) {
+inline Policy
+getEnumPolicy(const int policy) {
     switch (policy) {
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
     case SCHED_FIFO: return Policy::FIFO;
     case SCHED_RR: return Policy::ROUND_ROBIN;
     case SCHED_OTHER: return Policy::OTHER;
 #endif
-    default:
-        return Policy::UNKNOWN;
+    default: return Policy::UNKNOWN;
     }
 }
 } // namespace detail
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline struct SchedulingParameter getProcessSchedulingParameter(const int pid = detail::getPid()) {
+inline struct SchedulingParameter
+getProcessSchedulingParameter(const int pid = detail::getPid()) {
     if (pid <= 0) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getProcessSchedulingParameter({}) -- invalid pid", pid));
     }
@@ -295,34 +348,41 @@ inline struct SchedulingParameter getProcessSchedulingParameter(const int pid = 
     return SchedulingParameter{ .policy = detail::getEnumPolicy(policy), .priority = param.sched_priority };
 }
 #else
-inline struct SchedulingParameter getProcessSchedulingParameter(const int /*pid*/ = -1) {
+inline struct SchedulingParameter
+getProcessSchedulingParameter(const int /*pid*/ = -1) {
     return {};
 }
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline void setProcessSchedulingParameter(Policy scheduler, int priority, const int pid = detail::getPid()) {
+inline void
+setProcessSchedulingParameter(Policy scheduler, int priority, const int pid = detail::getPid()) {
     if (pid <= 0) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setProcessSchedulingParameter({}, {}, {}) -- invalid pid", scheduler, priority, pid));
     }
     const int minPriority = sched_get_priority_min(scheduler);
     const int maxPriority = sched_get_priority_max(scheduler);
     if (priority < minPriority || priority > maxPriority) {
-        throw std::system_error(THREAD_VALUE_RANGE, thread_exception(), fmt::format("setProcessSchedulingParameter({}, {}, {}) -- requested priority out-of-range [{}, {}]", scheduler, priority, pid, minPriority, maxPriority));
+        throw std::system_error(THREAD_VALUE_RANGE, thread_exception(),
+                                fmt::format("setProcessSchedulingParameter({}, {}, {}) -- requested priority out-of-range [{}, {}]", scheduler, priority, pid, minPriority, maxPriority));
     }
+
     struct sched_param param {
         .sched_priority = priority
     };
+
     if (int rc = sched_setscheduler(pid, scheduler, &param); rc != 0) {
         throw std::system_error(rc, thread_exception(), fmt::format("setProcessSchedulingParameter({}, {}, {}) - sched_setscheduler return code: {}", scheduler, priority, pid, rc));
     }
 }
 #else
-inline void setProcessSchedulingParameter(Policy /*scheduler*/, int /*priority*/, const int /*pid*/ = -1) {}
+inline void
+setProcessSchedulingParameter(Policy /*scheduler*/, int /*priority*/, const int /*pid*/ = -1) {}
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline struct SchedulingParameter getThreadSchedulingParameter(thread_type auto &...thread) {
+inline struct SchedulingParameter
+getThreadSchedulingParameter(thread_type auto &...thread) {
     const pthread_t handle = detail::getPosixHandler(thread...);
     if (handle == 0U) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("getThreadSchedulingParameter(thread_type) -- invalid thread"));
@@ -335,13 +395,15 @@ inline struct SchedulingParameter getThreadSchedulingParameter(thread_type auto 
     return { .policy = detail::getEnumPolicy(policy), .priority = param.sched_priority };
 }
 #else
-inline struct SchedulingParameter getThreadSchedulingParameter(thread_type auto &.../*thread*/) {
+inline struct SchedulingParameter
+getThreadSchedulingParameter(thread_type auto &.../*thread*/) {
     return {};
 }
 #endif
 
 #if defined(_POSIX_VERSION) && not defined(__EMSCRIPTEN__)
-inline void setThreadSchedulingParameter(Policy scheduler, int priority, thread_type auto &...thread) {
+inline void
+setThreadSchedulingParameter(Policy scheduler, int priority, thread_type auto &...thread) {
     const pthread_t handle = detail::getPosixHandler(thread...);
     if (handle == 0U) {
         throw std::system_error(THREAD_UNINITIALISED, thread_exception(), fmt::format("setThreadSchedulingParameter({}, {}, thread_type) -- invalid thread", scheduler, priority));
@@ -364,9 +426,10 @@ inline void setThreadSchedulingParameter(Policy scheduler, int priority, thread_
     }
 }
 #else
-inline void setThreadSchedulingParameter(Policy /*scheduler*/, int /*priority*/, thread_type auto &.../*thread*/) {}
+inline void
+setThreadSchedulingParameter(Policy /*scheduler*/, int /*priority*/, thread_type auto &.../*thread*/) {}
 #endif
 
-} // namespace opencmw::thread
+} // namespace fair::thread_pool::thread
 
 #endif // THREADAFFINITY_HPP

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -361,6 +361,18 @@ safe_min(Arg &&arg, Args &&...args) {
     }
 }
 
+template<typename Arg, typename... Args>
+auto
+safe_pair_min(Arg &&arg, Args &&...args) {
+    if constexpr (sizeof...(Args) == 0) {
+        return arg;
+    } else {
+        return std::make_pair(
+                std::min(std::forward<Arg>(arg).first, std::forward<Args>(args).first ...),
+                std::min(std::forward<Arg>(arg).second, std::forward<Args>(args).second ...));
+    }
+}
+
 template<typename Function, typename Tuple, typename... Tuples>
 auto
 tuple_for_each(Function &&function, Tuple &&tuple, Tuples &&...tuples) {

--- a/test/blocklib/core/unit-test/tag_monitors.hpp
+++ b/test/blocklib/core/unit-test/tag_monitors.hpp
@@ -25,7 +25,7 @@ print_tag(const tag_t &tag, std::string_view prefix = {}) {
 
 template<typename T>
 struct TagSource : public node<TagSource<T>> {
-    OUT<T, 0, 1>       out;
+    OUT<T> out;
     std::vector<tag_t> tags{};
     std::size_t        next_tag{ 0 };
     std::uint64_t      n_samples_max = 1024;

--- a/test/blocklib/core/unit-test/tag_monitors.hpp
+++ b/test/blocklib/core/unit-test/tag_monitors.hpp
@@ -5,6 +5,9 @@
 #include <reflection.hpp>
 #include <tag.hpp>
 
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 namespace fair::graph::tag_test {
 
 void

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -159,12 +159,12 @@ struct Sink : public node<Sink<T>> {
         // alt: optional user-level tag processing
         /*
         if (this->input_tags_present()) {
-            if (this->input_tags_present() && this->input_tags()[0].contains("n_samples_max")) {
-                const auto value = this->input_tags()[0].at("n_samples_max");
+            if (this->input_tags_present() && this->input_tags()[0].map.contains("n_samples_max")) {
+                const auto value = this->input_tags()[0].map.at("n_samples_max");
                 assert(std::holds_alternative<std::int32_t>(value));
                 n_samples_max = std::get<std::int32_t>(value);
                 last_tag_position        = in.streamReader().position();
-                this->acknowledge_input_tags(); // clears further tag notifications
+                this->forward_tags(); // clears further notifications and forward tags to output ports
             }
         }
         */

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -11,7 +11,7 @@
 
 #include "blocklib/core/unit-test/tag_monitors.hpp"
 
-#if defined(__clang__) && __clang_major__ >= 16
+#if defined(__clang__) && __clang_major__ >= 15
 // clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
 template<>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
@@ -64,10 +64,14 @@ const boost::ut::suite TagPropagation = [] {
         graph         flow_graph;
         auto         &src = flow_graph.make_node<TagSource<float>>({ { "n_samples_max", n_samples }, { "name", "TagSource" } });
         src.tags          = { // TODO: allow parameter settings to include maps?!?
-            { 0, { { "key", "value@0" } } },
-            { 100, { { "key", "value@100" } } },
-            { 150, { { "key", "value@150" } } },
-            { 1000, { { "key", "value@1000" } } }
+                {0,    {{"key", "value@0"}}},
+                {1,    {{"key", "value@1"}}},
+                {100,  {{"key", "value@100"}}},
+                {150,  {{"key", "value@150"}}},
+                {1000, {{"key", "value@1000"}}},
+                {1001, {{"key", "value@1001"}}},
+                {1002, {{"key", "value@1002"}}},
+                {1023, {{"key", "value@1023"}}}
         };
         src.set_name("TagSource"); // TODO: enable property_map to base-class parameter propagation
         auto &monitor1 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_BULK>>({ { "name", "TagMonitor1" } });

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -1,10 +1,17 @@
 #include <boost/ut.hpp>
 
+#include <buffer.hpp>
+#include <graph.hpp>
+#include <node.hpp>
+#include <reflection.hpp>
+#include <scheduler.hpp>
 #include <tag.hpp>
+
+#include <fmt/format.h>
 
 #if defined(__clang__) && __clang_major__ >= 16
 // clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template <>
+template<>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
 #endif
 
@@ -42,6 +49,207 @@ const boost::ut::suite TagTests = [] {
         static_assert(tag::TRIGGER_NAME.shortKey() == "trigger_name");
         static_assert(tag::TRIGGER_TIME.shortKey() == "trigger_time");
         static_assert(tag::TRIGGER_OFFSET.shortKey() == "trigger_offset");
+    };
+};
+
+namespace fair::graph::tag_test {
+
+void
+print_tag(const tag_t &tag, std::string_view prefix = {}) {
+    fmt::print("{} @index={}: {{", prefix, tag.index);
+    if (tag.map.empty()) {
+        fmt::print("}}\n");
+        return;
+    }
+    for (const auto &[key, value] : tag.map) {
+        fmt::print(" {:>5}: {} ", key, value);
+    }
+    fmt::print("}}\n");
+}
+
+template<typename T>
+struct TagSource : public node<TagSource<T>> {
+    OUT<T, 0, 1>       out;
+    std::vector<tag_t> tags{ //
+                             { 0, { { "key", "value@0" } } },
+                             { 100, { { "key", "value@100" } } },
+                             { 150, { { "key", "value@150" } } },
+                             { 1000, { { "key", "value@1000" } } }
+    };
+    std::size_t   next_tag{ 0 };
+    std::uint64_t n_samples_max = 1024;
+    std::uint64_t n_samples_produced{ 0 };
+
+    constexpr std::make_signed_t<std::size_t>
+    available_samples(const TagSource &) noexcept {
+        const auto ret = static_cast<std::make_signed_t<std::size_t>>(n_samples_max - n_samples_produced);
+        return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
+    }
+
+    T
+    process_one() noexcept {
+        if (next_tag < tags.size() && tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)) {
+            fmt::print("publish sample at {} - {}\n", n_samples_produced, tags[next_tag].index);
+            tag_t &out_tag = this->output_tags()[0];
+            out_tag        = tags[next_tag];
+            this->forward_tags();
+            next_tag++;
+            n_samples_produced++;
+            return static_cast<T>(1);
+        }
+
+        n_samples_produced++;
+        return static_cast<T>(0);
+    }
+};
+    static_assert(HasRequiredProcessFunction<TagSource<int>>);
+
+enum class ProcessFunction {
+    USE_PROCESS_ONE  = 0, ///
+    USE_PROCESS_BULK = 1  ///
+};
+
+template<typename T, ProcessFunction UseProcessOne>
+struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
+    IN<T>              in;
+    OUT<T>             out;
+    std::vector<tag_t> tags{};
+    std::uint64_t      n_samples_produced{ 0 };
+
+    constexpr T
+    process_one(const T &input) noexcept
+        requires(UseProcessOne == ProcessFunction::USE_PROCESS_ONE)
+    {
+        if (this->input_tags_present()) {
+            const tag_t &tag = this->input_tags()[0];
+            print_tag(tag, fmt::format("monitor::process_one received tag at {}", n_samples_produced));
+            tags.emplace_back(n_samples_produced, tag.map);
+            this->forward_tags();
+        }
+        n_samples_produced++;
+        return input;
+    }
+
+    constexpr work_return_t
+    process_bulk(std::span<const T> input, std::span<T> output) noexcept
+        requires(UseProcessOne == ProcessFunction::USE_PROCESS_BULK)
+    {
+        if (this->input_tags_present()) {
+            const tag_t &tag = this->input_tags()[0];
+            print_tag(tag, fmt::format("monitor::process_bulk received tag at {}", n_samples_produced));
+            tags.emplace_back(n_samples_produced, tag.map);
+            this->forward_tags();
+        }
+
+        n_samples_produced += input.size();
+        std::memcpy(output.data(), input.data(), input.size() * sizeof(T));
+
+        return work_return_t::OK;
+    }
+};
+
+    static_assert(HasProcessOneFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
+    static_assert(not HasProcessOneFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
+    static_assert(not HasProcessBulkFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
+    static_assert(HasProcessBulkFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
+    static_assert(HasRequiredProcessFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
+    static_assert(HasRequiredProcessFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
+
+    template<typename T>
+    struct TagSink : public node<TagSink<T>> {
+        IN<T> in;
+        std::vector<tag_t> tags{};
+        std::uint64_t n_samples_produced{0};
+
+        // template<fair::meta::t_or_simd<T> V>
+        constexpr void
+        process_one(const T &) noexcept {
+            if (this->input_tags_present()) {
+                const tag_t &tag = this->input_tags()[0];
+                print_tag(tag, fmt::format("sink received tag at {}", n_samples_produced));
+                tags.emplace_back(n_samples_produced, tag.map);
+                this->forward_tags();
+            }
+            n_samples_produced++;
+        }
+    };
+
+    static_assert(HasRequiredProcessFunction<TagSink<int>>);
+
+} // namespace fair::graph::tag_test
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (fair::graph::tag_test::TagSource<T>), out, n_samples_max);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b), (fair::graph::tag_test::TagMonitor<T, b>), in, out);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (fair::graph::tag_test::TagSink<T>), in);
+
+const boost::ut::suite TagPropagation = [] {
+    using namespace boost::ut;
+    using namespace fair::graph;
+    using namespace fair::graph::tag_test;
+
+    "tag_source"_test = [] {
+        std::uint64_t n_samples = 1024;
+        graph         flow_graph;
+        auto         &src      = flow_graph.make_node<TagSource<float>>({ { "n_samples_max", n_samples } });
+        auto         &monitor1 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_BULK>>();
+        auto         &monitor2 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_ONE>>();
+        auto         &sink     = flow_graph.make_node<TagSink<float>>();
+        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(monitor1)));
+        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor1).to<"in">(monitor2)));
+        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor2).to<"in">(sink)));
+
+        scheduler::simple sched{std::move(flow_graph)};
+        sched.work();
+
+        expect(eq(src.n_samples_produced, n_samples)) << "src did not produce enough output samples";
+        expect(eq(monitor1.n_samples_produced, n_samples)) << "monitor1 did not consume enough input samples";
+        expect(eq(monitor2.n_samples_produced, n_samples)) << "monitor2 did not consume enough input samples";
+        expect(eq(sink.n_samples_produced, n_samples)) << "sink did not consume enough input samples";
+
+        auto equal_tag_lists = [](const std::vector<tag_t> &tags1, const std::vector<tag_t> &tags2) {
+            if (tags1.size() != tags2.size()) {
+                fmt::print("vectors have different sizes ({} vs {})\n", tags1.size(), tags2.size());
+                return false;
+            }
+
+            auto result = std::mismatch(tags1.begin(), tags1.end(), tags2.begin(),
+                                        [](const tag_t &tag1, const tag_t &tag2) {
+                                            return tag1.index == tag2.index && tag1.map == tag2.map;
+                                        });
+
+            if (result.first != tags1.end()) {
+                size_t index = std::distance(tags1.begin(), result.first);
+                const tag_t &tag1 = *result.first;
+                const tag_t &tag2 = *result.second;
+                fmt::print("mismatch at index {}\n", index);
+                if (tag1.index != tag2.index) {
+                    fmt::print("  - different index: {} vs {}\n", tag1.index, tag2.index);
+                }
+                if (tag1.map != tag2.map) {
+                    fmt::print("  - different map content:\n");
+                    for (const auto &[key, value]: tag1.map) {
+                        if (tag2.map.find(key) == tag2.map.end()) {
+                            fmt::print("    key '{}' is present in the first map but not in the second\n", key);
+                        } else if (tag2.map.at(key) != value) {
+                            fmt::print("    key '{}' has different values ('{}' vs '{}')\n", key, value,
+                                       tag2.map.at(key));
+                        }
+                    }
+                    for (const auto &[key, value]: tag2.map) {
+                        if (tag1.map.find(key) == tag1.map.end()) {
+                            fmt::print("    key '{}' is present in the second map but not in the first\n", key);
+                        }
+                    }
+                }
+                return false;
+            }
+
+            return true;
+        };
+
+        expect(equal_tag_lists(src.tags, monitor1.tags)) << "monitor1 did not receive the required tags";
+        expect(equal_tag_lists(src.tags, monitor2.tags)) << "monitor2 did not receive the required tags";
+        expect(equal_tag_lists(src.tags, sink.tags)) << "sink did not receive the required tags";
     };
 };
 

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -9,6 +9,8 @@
 
 #include <fmt/format.h>
 
+#include "blocklib/core/unit-test/tag_monitors.hpp"
+
 #if defined(__clang__) && __clang_major__ >= 16
 // clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
 template<>
@@ -22,7 +24,7 @@ const boost::ut::suite TagTests = [] {
     "TagReflection"_test = [] {
         static_assert(sizeof(tag_t) % 64 == 0, "needs to meet L1 cache size");
         static_assert(refl::descriptor::type_descriptor<fair::graph::tag_t>::name == "fair::graph::tag_t");
-        static_assert(refl::member_list<tag_t>::size == 2, "index and map bein declared");
+        static_assert(refl::member_list<tag_t>::size == 2, "index and map being declared");
         static_assert(refl::trait::get_t<0, refl::member_list<tag_t>>::name == "index", "class field index is public API");
         static_assert(refl::trait::get_t<1, refl::member_list<tag_t>>::name == "map", "class field map is public API");
     };
@@ -52,137 +54,6 @@ const boost::ut::suite TagTests = [] {
     };
 };
 
-namespace fair::graph::tag_test {
-
-void
-print_tag(const tag_t &tag, std::string_view prefix = {}) {
-    fmt::print("{} @index={}: {{", prefix, tag.index);
-    if (tag.map.empty()) {
-        fmt::print("}}\n");
-        return;
-    }
-    for (const auto &[key, value] : tag.map) {
-        fmt::print(" {:>5}: {} ", key, value);
-    }
-    fmt::print("}}\n");
-}
-
-template<typename T>
-struct TagSource : public node<TagSource<T>> {
-    OUT<T, 0, 1>       out;
-    std::vector<tag_t> tags{ //
-                             { 0, { { "key", "value@0" } } },
-                             { 100, { { "key", "value@100" } } },
-                             { 150, { { "key", "value@150" } } },
-                             { 1000, { { "key", "value@1000" } } }
-    };
-    std::size_t   next_tag{ 0 };
-    std::uint64_t n_samples_max = 1024;
-    std::uint64_t n_samples_produced{ 0 };
-
-    constexpr std::make_signed_t<std::size_t>
-    available_samples(const TagSource &) noexcept {
-        const auto ret = static_cast<std::make_signed_t<std::size_t>>(n_samples_max - n_samples_produced);
-        return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
-    }
-
-    T
-    process_one() noexcept {
-        if (next_tag < tags.size() && tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)) {
-            fmt::print("publish sample at {} - {}\n", n_samples_produced, tags[next_tag].index);
-            tag_t &out_tag = this->output_tags()[0];
-            out_tag        = tags[next_tag];
-            this->forward_tags();
-            next_tag++;
-            n_samples_produced++;
-            return static_cast<T>(1);
-        }
-
-        n_samples_produced++;
-        return static_cast<T>(0);
-    }
-};
-
-static_assert(HasRequiredProcessFunction<TagSource<int>>);
-
-enum class ProcessFunction {
-    USE_PROCESS_ONE  = 0, ///
-    USE_PROCESS_BULK = 1  ///
-};
-
-template<typename T, ProcessFunction UseProcessOne>
-struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
-    IN<T>              in;
-    OUT<T>             out;
-    std::vector<tag_t> tags{};
-    std::uint64_t      n_samples_produced{ 0 };
-
-    constexpr T
-    process_one(const T &input) noexcept
-        requires(UseProcessOne == ProcessFunction::USE_PROCESS_ONE)
-    {
-        if (this->input_tags_present()) {
-            const tag_t &tag = this->input_tags()[0];
-            print_tag(tag, fmt::format("monitor::process_one received tag at {}", n_samples_produced));
-            tags.emplace_back(n_samples_produced, tag.map);
-            this->forward_tags();
-        }
-        n_samples_produced++;
-        return input;
-    }
-
-    constexpr work_return_t
-    process_bulk(std::span<const T> input, std::span<T> output) noexcept
-        requires(UseProcessOne == ProcessFunction::USE_PROCESS_BULK)
-    {
-        if (this->input_tags_present()) {
-            const tag_t &tag = this->input_tags()[0];
-            print_tag(tag, fmt::format("monitor::process_bulk received tag at {}", n_samples_produced));
-            tags.emplace_back(n_samples_produced, tag.map);
-            this->forward_tags();
-        }
-
-        n_samples_produced += input.size();
-        std::memcpy(output.data(), input.data(), input.size() * sizeof(T));
-
-        return work_return_t::OK;
-    }
-};
-
-static_assert(HasProcessOneFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
-static_assert(not HasProcessOneFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
-static_assert(not HasProcessBulkFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
-static_assert(HasProcessBulkFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
-static_assert(HasRequiredProcessFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
-static_assert(HasRequiredProcessFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
-
-template<typename T>
-struct TagSink : public node<TagSink<T>> {
-    IN<T>              in;
-    std::vector<tag_t> tags{};
-    std::uint64_t      n_samples_produced{ 0 };
-
-    // template<fair::meta::t_or_simd<T> V>
-    constexpr void
-    process_one(const T &) noexcept {
-        if (this->input_tags_present()) {
-            const tag_t &tag = this->input_tags()[0];
-            print_tag(tag, fmt::format("sink received tag at {}", n_samples_produced));
-            tags.emplace_back(n_samples_produced, tag.map);
-            this->forward_tags();
-        }
-        n_samples_produced++;
-    }
-};
-
-static_assert(HasRequiredProcessFunction<TagSink<int>>);
-
-} // namespace fair::graph::tag_test
-
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (fair::graph::tag_test::TagSource<T>), out, n_samples_max);
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b), (fair::graph::tag_test::TagMonitor<T, b>), in, out);
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (fair::graph::tag_test::TagSink<T>), in);
-
 const boost::ut::suite TagPropagation = [] {
     using namespace boost::ut;
     using namespace fair::graph;
@@ -191,17 +62,26 @@ const boost::ut::suite TagPropagation = [] {
     "tag_source"_test = [] {
         std::uint64_t n_samples = 1024;
         graph         flow_graph;
-        auto         &src = flow_graph.make_node<TagSource<float>>({ { "n_samples_max", n_samples } });
-        src.set_name("src");
-        auto &monitor1 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_BULK>>();
-        monitor1.set_name("monitor1");
-        auto &monitor2 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_ONE>>();
-        monitor2.set_name("monitor2");
-        auto &sink = flow_graph.make_node<TagSink<float>>();
-        sink.set_name("sink");
+        auto         &src = flow_graph.make_node<TagSource<float>>({ { "n_samples_max", n_samples }, { "name", "TagSource" } });
+        src.tags          = { // TODO: allow parameter settings to include maps?!?
+            { 0, { { "key", "value@0" } } },
+            { 100, { { "key", "value@100" } } },
+            { 150, { { "key", "value@150" } } },
+            { 1000, { { "key", "value@1000" } } }
+        };
+        src.set_name("TagSource"); // TODO: enable property_map to base-class parameter propagation
+        auto &monitor1 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_BULK>>({ { "name", "TagMonitor1" } });
+        monitor1.set_name("TagMonitor1");
+        auto &monitor2 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagMonitor2" } });
+        monitor2.set_name("TagMonitor2");
+        auto &sink1 = flow_graph.make_node<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({ { "name", "TagSink1" } });
+        sink1.set_name("TagSink1");
+        auto &sink2 = flow_graph.make_node<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagSink2" } });
+        sink2.set_name("TagSink2");
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(monitor1)));
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor1).to<"in">(monitor2)));
-        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor2).to<"in">(sink)));
+        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor2).to<"in">(sink1)));
+        expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor2).to<"in">(sink2)));
 
         scheduler::simple sched{ std::move(flow_graph) };
         sched.work();
@@ -209,7 +89,8 @@ const boost::ut::suite TagPropagation = [] {
         expect(eq(src.n_samples_produced, n_samples)) << "src did not produce enough output samples";
         expect(eq(monitor1.n_samples_produced, n_samples)) << "monitor1 did not consume enough input samples";
         expect(eq(monitor2.n_samples_produced, n_samples)) << "monitor2 did not consume enough input samples";
-        expect(eq(sink.n_samples_produced, n_samples)) << "sink did not consume enough input samples";
+        expect(eq(sink1.n_samples_produced, n_samples)) << "sink1 did not consume enough input samples";
+        expect(eq(sink2.n_samples_produced, n_samples)) << "sink2 did not consume enough input samples";
 
         auto equal_tag_lists = [](const std::vector<tag_t> &tags1, const std::vector<tag_t> &tags2) {
             if (tags1.size() != tags2.size()) {
@@ -217,27 +98,23 @@ const boost::ut::suite TagPropagation = [] {
                 return false;
             }
 
-            auto result = std::mismatch(tags1.begin(), tags1.end(), tags2.begin(), [](const tag_t &tag1, const tag_t &tag2) { return tag1.index == tag2.index && tag1.map == tag2.map; });
-
-            if (result.first != tags1.end()) {
-                size_t       index = std::distance(tags1.begin(), result.first);
-                const tag_t &tag1  = *result.first;
-                const tag_t &tag2  = *result.second;
-                fmt::print("mismatch at index {}\n", index);
-                if (tag1.index != tag2.index) {
-                    fmt::print("  - different index: {} vs {}\n", tag1.index, tag2.index);
+            if (const auto [mismatchedTag1, mismatchedTag2] = std::mismatch(tags1.begin(), tags1.end(), tags2.begin(), std::equal_to<>()); mismatchedTag1 != tags1.end()) {
+                const auto index = static_cast<size_t>(std::distance(tags1.begin(), mismatchedTag1));
+                fmt::print("mismatch at index {}", index);
+                if (mismatchedTag1->index != mismatchedTag2->index) {
+                    fmt::print("  - different index: {} vs {}\n", mismatchedTag1->index, mismatchedTag2->index);
                 }
-                if (tag1.map != tag2.map) {
+                if (mismatchedTag1->map != mismatchedTag2->map) {
                     fmt::print("  - different map content:\n");
-                    for (const auto &[key, value] : tag1.map) {
-                        if (tag2.map.find(key) == tag2.map.end()) {
+                    for (const auto &[key, value] : mismatchedTag1->map) {
+                        if (!mismatchedTag2->map.contains(key)) {
                             fmt::print("    key '{}' is present in the first map but not in the second\n", key);
-                        } else if (tag2.map.at(key) != value) {
-                            fmt::print("    key '{}' has different values ('{}' vs '{}')\n", key, value, tag2.map.at(key));
+                        } else if (mismatchedTag2->map.at(key) != value) {
+                            fmt::print("    key '{}' has different values ('{}' vs '{}')\n", key, value, mismatchedTag2->map.at(key));
                         }
                     }
-                    for (const auto &[key, value] : tag2.map) {
-                        if (tag1.map.find(key) == tag1.map.end()) {
+                    for (const auto &[key, value] : mismatchedTag2->map) {
+                        if (!mismatchedTag1->map.contains(key)) {
                             fmt::print("    key '{}' is present in the second map but not in the first\n", key);
                         }
                     }
@@ -250,7 +127,8 @@ const boost::ut::suite TagPropagation = [] {
 
         expect(equal_tag_lists(src.tags, monitor1.tags)) << "monitor1 did not receive the required tags";
         expect(equal_tag_lists(src.tags, monitor2.tags)) << "monitor2 did not receive the required tags";
-        expect(equal_tag_lists(src.tags, sink.tags)) << "sink did not receive the required tags";
+        expect(equal_tag_lists(src.tags, sink1.tags)) << "sink1 did not receive the required tags";
+        expect(equal_tag_lists(src.tags, sink2.tags)) << "sink1 did not receive the required tags";
     };
 };
 

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -30,7 +30,7 @@ const boost::ut::suite TagTests = [] {
     };
 
     "DefaultTags"_test = [] {
-        tag_t testTag;
+        tag_t testTag{};
 
         testTag.insert_or_assign(tag::SAMPLE_RATE, pmtv::pmt(3.0f));
         testTag.insert_or_assign(tag::SAMPLE_RATE(4.0f));


### PR DESCRIPTION
* added source, monitor, and sink example.
* added basic concepts `HasProcessOneFunction<>`, `HasProcessBulkFunction<>`, and   `HasRequiredProcessFunction<>` for non-templated `process_one`  and `process_bulk` to better enforce/signal user-block implementation requirements

This PR only tackles the user-level tag_t propagation API and has still a corner case that needs to be fixed ... as discussed with @ivan-cukic. 