### PR TITLE
clean-up some more compiler-warnings & enabled `-Werror`

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -32,6 +32,7 @@ function(set_project_warnings project_name)
   )
 
   set(CLANG_WARNINGS
+      # -Werror # avoid warnings since they are often indicative of immature API and/or potential sources of bugs # TODO: enable
       -Wall
       -Wextra # reasonable and standard
       -Wshadow # warn the user if a variable declaration shadows one from a parent context
@@ -57,15 +58,16 @@ function(set_project_warnings project_name)
   endif()
 
   set(GCC_WARNINGS
-      ${CLANG_WARNINGS}
-      -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
-      -Wduplicated-cond # warn if if / else chain has duplicated conditions
-      -Wduplicated-branches # warn if if / else branches have duplicated code
-      -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
-      -Wuseless-cast # warn if you perform a cast to the same type
-      -Wno-interference-size # suppress ABI compatibility warnings for hardware inferred size
-      -Wno-maybe-uninitialized # false positives if asan is enabled: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=1056h6
-  )
+          ${CLANG_WARNINGS}
+          -Wno-dangling-reference # TODO: remove this once the fmt dangling reference bug is fixed
+          -Wmisleading-indentation # warn if indentation implies blocks where blocks do not exist
+          -Wduplicated-cond # warn if if / else chain has duplicated conditions
+          -Wduplicated-branches # warn if if / else branches have duplicated code
+          -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
+          -Wuseless-cast # warn if you perform a cast to the same type
+          -Wno-interference-size # suppress ABI compatibility warnings for hardware inferred size
+          -Wno-maybe-uninitialized # false positives if asan is enabled: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=1056h6
+          )
 
   if(MSVC)
     set(PROJECT_WARNINGS ${MSVC_WARNINGS})

--- a/include/claim_strategy.hpp
+++ b/include/claim_strategy.hpp
@@ -129,14 +129,18 @@ struct MultiThreadedStrategySizeMembers
 };
 
 template <>
-struct MultiThreadedStrategySizeMembers<std::dynamic_extent>
-{
-    explicit MultiThreadedStrategySizeMembers(std::size_t size)
-    : _size(static_cast<std::int32_t>(size)), _indexShift(static_cast<std::int32_t>(std::bit_width(size)))
-    {}
-
+struct MultiThreadedStrategySizeMembers<std::dynamic_extent> {
     const std::int32_t _size;
     const std::int32_t _indexShift;
+
+    #ifdef __clang__
+    explicit MultiThreadedStrategySizeMembers(std::size_t size) : _size(static_cast<std::int32_t>(size)), _indexShift(static_cast<std::int32_t>(std::bit_width(size))) {} //NOSONAR
+    #else
+    #pragma GCC diagnostic push // std::bit_width seems to be compiler and platform specific
+    #pragma GCC diagnostic ignored "-Wuseless-cast"
+    explicit MultiThreadedStrategySizeMembers(std::size_t size) : _size(static_cast<std::int32_t>(size)), _indexShift(static_cast<std::int32_t>(std::bit_width(size))) {} //NOSONAR
+    #pragma GCC diagnostic pop
+    #endif
 };
 
 /**

--- a/include/port.hpp
+++ b/include/port.hpp
@@ -267,12 +267,12 @@ public:
     void
     setBuffer(gr::Buffer auto streamBuffer, gr::Buffer auto tagBuffer) noexcept {
         if constexpr (IS_INPUT) {
-            _ioHandler    = std::move(streamBuffer.new_reader());
-            _tagIoHandler = std::move(tagBuffer.new_reader());
-            _connected    = true;
+            _ioHandler = streamBuffer.new_reader();
+            _tagIoHandler = tagBuffer.new_reader();
+            _connected = true;
         } else {
-            _ioHandler    = std::move(streamBuffer.new_writer());
-            _tagIoHandler = std::move(tagBuffer.new_reader());
+            _ioHandler = streamBuffer.new_writer();
+            _tagIoHandler = tagBuffer.new_reader();
         }
     }
 

--- a/include/reflection.hpp
+++ b/include/reflection.hpp
@@ -1,6 +1,9 @@
 #ifndef GRAPH_PROTOTYPE_REFLECTION_HPP
 #define GRAPH_PROTOTYPE_REFLECTION_HPP
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wshadow"
 #include <refl.hpp>
 
 /**
@@ -133,6 +136,5 @@
 
 #define GP_REGISTER_NODE(Register, Name, ...) fair::graph::detail::register_node<Name, __VA_ARGS__> GP_MACRO_CONCAT(GP_REGISTER_NODE_, __COUNTER__)(Register, #Name);
 
-
-
+#pragma GCC diagnostic pop
 #endif //GRAPH_PROTOTYPE_REFLECTION_HPP

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -1,30 +1,30 @@
 #ifndef GRAPH_PROTOTYPE_SCHEDULER_HPP
 #define GRAPH_PROTOTYPE_SCHEDULER_HPP
+#include <barrier>
 #include <graph.hpp>
 #include <set>
-#include <queue>
 #include <thread_pool.hpp>
-#include <barrier>
 #include <utility>
+#include <queue>
 
 namespace fair::graph::scheduler {
 using fair::thread_pool::BasicThreadPool;
 
 enum execution_policy { single_threaded, multi_threaded };
-enum SchedulerState { IDLE, INITIALISED, RUNNING, REQUESTED_STOP, REQUESTED_PAUSE, STOPPED, PAUSED, SHUTTING_DOWN, ERROR};
+
+enum SchedulerState { IDLE, INITIALISED, RUNNING, REQUESTED_STOP, REQUESTED_PAUSE, STOPPED, PAUSED, SHUTTING_DOWN, ERROR };
 
 class scheduler_base {
 protected:
-    SchedulerState                    _state = IDLE;
-    fair::graph::graph                _graph;
-    std::shared_ptr<BasicThreadPool>  _pool;
-    std::atomic_uint64_t              _progress;
-    std::atomic_size_t                _running_threads;
-    std::atomic_bool                  _stop_requested;
+    SchedulerState                   _state = IDLE;
+    fair::graph::graph               _graph;
+    std::shared_ptr<BasicThreadPool> _pool;
+    std::atomic_uint64_t             _progress;
+    std::atomic_size_t               _running_threads;
+    std::atomic_bool                 _stop_requested;
 
 public:
-    explicit scheduler_base(fair::graph::graph              &&graph,
-                            std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("simple-scheduler-pool", thread_pool::CPU_BOUND))
+    explicit scheduler_base(fair::graph::graph &&graph, std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("simple-scheduler-pool", thread_pool::CPU_BOUND))
         : _graph(std::move(graph)), _pool(std::move(thread_pool)){};
 
     ~scheduler_base() {
@@ -32,8 +32,9 @@ public:
         _state = SHUTTING_DOWN;
     }
 
-    void stop(){
-        if (_state == STOPPED || _state == ERROR){
+    void
+    stop() {
+        if (_state == STOPPED || _state == ERROR) {
             return;
         }
         if (_state == RUNNING) {
@@ -43,8 +44,9 @@ public:
         _state = STOPPED;
     }
 
-    void pause(){
-        if (_state == PAUSED || _state == ERROR){
+    void
+    pause() {
+        if (_state == PAUSED || _state == ERROR) {
             return;
         }
         if (_state == RUNNING) {
@@ -54,21 +56,24 @@ public:
         _state = PAUSED;
     }
 
-    void wait_done() {
+    void
+    wait_done() {
         for (auto running = _running_threads.load(); running > 0ul; running = _running_threads.load()) {
             _running_threads.wait(running);
         }
         _state = STOPPED;
     }
 
-    void request_stop() {
+    void
+    request_stop() {
         _stop_requested = true;
-        _state = REQUESTED_STOP;
+        _state          = REQUESTED_STOP;
     }
 
-    void request_pause() {
+    void
+    request_pause() {
         _stop_requested = true;
-        _state = REQUESTED_PAUSE;
+        _state          = REQUESTED_PAUSE;
     }
 
     void
@@ -77,7 +82,7 @@ public:
             return;
         }
         auto result = std::all_of(_graph.connection_definitions().begin(), _graph.connection_definitions().end(),
-                                             [this](auto &connection_definition) { return connection_definition(_graph) == connection_result_t::SUCCESS; });
+                                  [this](auto &connection_definition) { return connection_definition(_graph) == connection_result_t::SUCCESS; });
         if (result) {
             _graph.clear_connection_definitions();
             _state = INITIALISED;
@@ -90,14 +95,13 @@ public:
     reset() {
         // since it is not possible to setup the graph connections a second time, this method leaves the graph in the initialized state with clear buffers.
         switch (_state) {
-        case IDLE:
-            init();
-            break;
+        case IDLE: init(); break;
         case RUNNING:
         case REQUESTED_STOP:
         case REQUESTED_PAUSE:
             pause();
             // intentional fallthrough
+            FMT_FALLTHROUGH;
         case STOPPED:
         case PAUSED:
             // clear buffers
@@ -108,26 +112,21 @@ public:
             break;
         case SHUTTING_DOWN:
         case INITIALISED:
-        case ERROR:
-            break;
+        case ERROR: break;
         }
     }
 
     void
-    run_on_pool(const std::vector<std::vector<node_model *>> &jobs, const std::function<work_return_t(const std::span<node_model * const>&)> work_function) {
-        _progress = 0;
+    run_on_pool(const std::vector<std::vector<node_model *>> &jobs, const std::function<work_return_t(const std::span<node_model *const> &)> work_function) {
+        _progress        = 0;
         _running_threads = jobs.size();
         for (auto &jobset : jobs) {
-            _pool->execute([this, &jobset, work_function, &jobs]() {
-                pool_worker([&work_function, &jobset]() {
-                    return work_function(jobset);
-                }, jobs.size());
-            });
+            _pool->execute([this, &jobset, work_function, &jobs]() { pool_worker([&work_function, &jobset]() { return work_function(jobset); }, jobs.size()); });
         }
     }
 
     void
-    pool_worker(const std::function<work_return_t()>& work, std::size_t n_batches) {
+    pool_worker(const std::function<work_return_t()> &work, std::size_t n_batches) {
         uint32_t done           = 0;
         uint32_t progress_count = 0;
         while (done < n_batches && !_stop_requested) {
@@ -162,7 +161,6 @@ public:
         _running_threads.fetch_sub(1);
         _running_threads.notify_all();
     }
-
 };
 
 /**
@@ -170,10 +168,11 @@ public:
  */
 template<execution_policy executionPolicy = single_threaded>
 class simple : public scheduler_base {
-    std::vector<std::vector<node_model *>>  _job_lists{};
+    std::vector<std::vector<node_model *>> _job_lists{};
+
 public:
     explicit simple(fair::graph::graph &&graph, std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("simple-scheduler-pool", thread_pool::CPU_BOUND))
-            : scheduler_base(std::forward<fair::graph::graph>(graph), thread_pool) { }
+        : scheduler_base(std::forward<fair::graph::graph>(graph), thread_pool) {}
 
     void
     init() {
@@ -230,7 +229,7 @@ public:
         if constexpr (executionPolicy == single_threaded) {
             this->_state = RUNNING;
             work_return_t result;
-            auto nodelist = std::span{this->_graph.blocks()};
+            auto          nodelist = std::span{ this->_graph.blocks() };
             while ((result = work_once(nodelist)) == work_return_t::OK) {
                 if (result == work_return_t::ERROR) {
                     this->_state = ERROR;
@@ -239,7 +238,7 @@ public:
             }
             this->_state = STOPPED;
         } else if (executionPolicy == multi_threaded) {
-            this->run_on_pool(this->_job_lists, [this](auto &job) {return this->work_once(job);} );
+            this->run_on_pool(this->_job_lists, [this](auto &job) { return this->work_once(job); });
         } else {
             throw std::invalid_argument("Unknown execution Policy");
         }
@@ -252,12 +251,12 @@ public:
  */
 template<execution_policy executionPolicy = single_threaded>
 class breadth_first : public scheduler_base {
-    std::vector<node_model *> _nodelist;
-    std::vector<std::vector<node_model *>>  _job_lists{};
+    std::vector<node_model *>              _nodelist;
+    std::vector<std::vector<node_model *>> _job_lists{};
+
 public:
     explicit breadth_first(fair::graph::graph &&graph, std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("breadth-first-pool", thread_pool::CPU_BOUND))
-                : scheduler_base(std::move(graph), thread_pool) {
-    }
+        : scheduler_base(std::move(graph), thread_pool) {}
 
     void
     init() {
@@ -348,7 +347,7 @@ public:
         if constexpr (executionPolicy == single_threaded) {
             this->_state = RUNNING;
             work_return_t result;
-            auto nodelist = std::span{this->_nodelist};
+            auto          nodelist = std::span{ this->_nodelist };
             while ((result = work_once(nodelist)) == work_return_t::OK) {
                 if (result == work_return_t::ERROR) {
                     this->_state = ERROR;
@@ -357,13 +356,14 @@ public:
             }
             this->_state = STOPPED;
         } else if (executionPolicy == multi_threaded) {
-            this->run_on_pool(this->_job_lists, [this](auto &job) {return this->work_once(job);});
+            this->run_on_pool(this->_job_lists, [this](auto &job) { return this->work_once(job); });
         } else {
             throw std::invalid_argument("Unknown execution Policy");
         }
     }
 
-    [[nodiscard]] const std::vector<std::vector<node_model *>> &getJobLists() const {
+    [[nodiscard]] const std::vector<std::vector<node_model *>> &
+    getJobLists() const {
         return _job_lists;
     }
 };

--- a/include/sequence.hpp
+++ b/include/sequence.hpp
@@ -201,7 +201,7 @@ struct fmt::formatter<gr::Sequence> {
 namespace gr {
 inline std::ostream &
 operator<<(std::ostream &os, const Sequence &v) {
-    return os << fmt::format("{}", v);
+    return os << fmt::format("{}", v.value());
 }
 } // namespace gr
 

--- a/meson.build
+++ b/meson.build
@@ -2,8 +2,10 @@ project('graph-prototype', 'cpp',
   version : '0.1',
   default_options : ['warning_level=0', 'cpp_std=gnu++20'])
 
-clang_warnings = ['-Wall', '-Wextra', '-Wshadow','-Wnon-virtual-dtor','-Wold-style-cast','-Wcast-align','-Wunused','-Woverloaded-virtual','-Wpedantic','-Wconversion','-Wsign-conversion','-Wnull-dereference','-Wdouble-promotion','-Wformat=2','-Wno-unknown-pragmas','-Wimplicit-fallthrough']
-gcc_warnings = clang_warnings + ['-Wmisleading-indentation','-Wduplicated-cond','-Wduplicated-branches','-Wlogical-op','-Wuseless-cast','-Wno-interference-size']
+clang_warnings = [ # '-Werror', # TODO: enable once the flags are set for the graph-prototype only and not also it's depenencies
+'-Wall', '-Wextra', '-Wshadow','-Wnon-virtual-dtor','-Wold-style-cast','-Wcast-align','-Wunused','-Woverloaded-virtual','-Wpedantic','-Wconversion','-Wsign-conversion','-Wnull-dereference','-Wdouble-promotion','-Wformat=2','-Wno-unknown-pragmas','-Wimplicit-fallthrough']
+gcc_warnings = clang_warnings + [ '-Wno-dangling-reference', # TODO: remove this once the fmt dangling reference bug is fixed
+'-Wmisleading-indentation','-Wduplicated-cond','-Wduplicated-branches','-Wlogical-op','-Wuseless-cast','-Wno-interference-size']
 
 compiler = meson.get_compiler('cpp')
 if compiler.get_id() == 'gcc'

--- a/test/app_grc.cpp
+++ b/test/app_grc.cpp
@@ -6,7 +6,7 @@
 #include <scheduler.hpp>
 
 #include <fstream>
-#include <strstream>
+#include <sstream>
 
 #include "build_configure.hpp"
 #include "blocklib/core/unit-test/common_nodes.hpp"
@@ -70,7 +70,7 @@ main(int argc, char *argv[]) {
 
         auto graph_2            = fg::load_grc(context.loader, graph_saved_source);
 
-        auto collect_nodes      = [](fg::graph &graph) {
+        [[maybe_unused]] auto collect_nodes      = [](fg::graph &graph) {
             std::set<std::string> result;
             graph.for_each_node([&](const auto &node) { result.insert(fmt::format("{}-{}", node.name(), node.type_name())); });
             return result;
@@ -78,7 +78,7 @@ main(int argc, char *argv[]) {
 
         assert(collect_nodes(graph_1) == collect_nodes(graph_2));
 
-        auto collect_edges = [](fg::graph &graph) {
+        [[maybe_unused]] auto collect_edges = [](fg::graph &graph) {
             std::set<std::string> result;
             graph.for_each_edge([&](const auto &edge) { result.insert(fmt::format("{}#{} - {}#{}", edge.src_node().name(), edge.src_port_index(), edge.dst_node().name(), edge.dst_port_index())); });
             return result;

--- a/test/blocklib/core/unit-test/common_nodes.hpp
+++ b/test/blocklib/core/unit-test/common_nodes.hpp
@@ -194,8 +194,11 @@ ENABLE_REFLECTION_FOR_TEMPLATE(multi_adder, input_port_count);
 template<typename Registry>
 void
 register_builtin_nodes(Registry *registry) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
     GP_REGISTER_NODE(registry, builtin_multiply, double, float);
     GP_REGISTER_NODE(registry, builtin_counter, double, float);
+#pragma GCC diagnostic pop
 }
 
 #endif // include guard

--- a/test/blocklib/core/unit-test/tag_monitors.hpp
+++ b/test/blocklib/core/unit-test/tag_monitors.hpp
@@ -10,97 +10,102 @@
 
 namespace fair::graph::tag_test {
 
+enum class ProcessFunction {
+    USE_PROCESS_ONE  = 0, ///
+    USE_PROCESS_BULK = 1  ///
+};
 
-    enum class ProcessFunction {
-        USE_PROCESS_ONE = 0, ///
-        USE_PROCESS_BULK = 1  ///
-    };
-
-    void
-    print_tag(const tag_t &tag, std::string_view prefix = {}) {
-        fmt::print("{} @index= {}: {{", prefix, tag.index);
-        if (tag.map.empty()) {
-            fmt::print("}}\n");
-            return;
-        }
-        for (const auto &[key, value]: tag.map) {
-            fmt::print(" {:>5}: {} ", key, value);
+void
+print_tag(const tag_t &tag, std::string_view prefix = {}) {
+    fmt::print("{} @index= {}: {{", prefix, tag.index);
+    if (tag.map.empty()) {
+        fmt::print("}}\n");
+        return;
+    }
+    const auto& map = tag.map;
+    for (const auto &[key, value] : map) {
+        // workaround for:
+        // fmt/core.h:1674:10: warning: possibly dangling reference to a temporary [-Wdangling-reference]
+        // 1674 |   auto&& arg = arg_mapper<Context>().map(FMT_FORWARD(val));
+        //      |          ^~~
+        // #pragma GCC diagnostic push
+        // #pragma GCC diagnostic ignored "-Wdangling-reference"
+        fmt::print(" {:>5}: {} ", key, value);
+        // #pragma GCC diagnostic pop
     }
     fmt::print("}}\n");
 }
 
-    template<typename T, ProcessFunction UseProcessOne>
-    struct TagSource : public node<TagSource<T, UseProcessOne>> {
-        OUT<T> out;
-        std::vector<tag_t> tags{};
-        std::size_t next_tag{0};
-        std::uint64_t n_samples_max = 1024;
-        std::uint64_t n_samples_produced{0};
+template<typename T, ProcessFunction UseProcessOne>
+struct TagSource : public node<TagSource<T, UseProcessOne>> {
+    OUT<T>             out;
+    std::vector<tag_t> tags{};
+    std::size_t        next_tag{ 0 };
+    std::uint64_t      n_samples_max = 1024;
+    std::uint64_t      n_samples_produced{ 0 };
 
-        constexpr std::make_signed_t<std::size_t>
-        available_samples(const TagSource &) noexcept {
-            if constexpr (UseProcessOne == ProcessFunction::USE_PROCESS_ONE) {
-                return n_samples_produced < n_samples_max ? 1 : -1; // '-1' -> DONE, produced enough samples
-            } else if constexpr (UseProcessOne == ProcessFunction::USE_PROCESS_BULK) {
-                std::make_signed_t<std::size_t> nextTagIn =
-                        next_tag < tags.size() ? (tags[next_tag].index - n_samples_produced) : n_samples_max -
-                                                                                               n_samples_produced;
-                return n_samples_produced < n_samples_max ? std::max(1L, nextTagIn)
-                                                          : -1; // '-1' -> DONE, produced enough samples
-            } else {
-                static_assert(fair::meta::always_false<T>, "ProcessFunction-type not handled");
-            }
+    constexpr std::make_signed_t<std::size_t>
+    available_samples(const TagSource &) noexcept {
+        if constexpr (UseProcessOne == ProcessFunction::USE_PROCESS_ONE) {
+            return n_samples_produced < n_samples_max ? 1 : -1; // '-1' -> DONE, produced enough samples
+        } else if constexpr (UseProcessOne == ProcessFunction::USE_PROCESS_BULK) {
+            std::make_signed_t<std::size_t> nextTagIn = next_tag < tags.size() ? tags[next_tag].index - static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)
+                                                                               : static_cast<std::make_signed_t<std::size_t>>(n_samples_max - n_samples_produced);
+            return n_samples_produced < n_samples_max ? std::max(1L, nextTagIn) : -1L; // '-1L' -> DONE, produced enough samples
+        } else {
+            static_assert(fair::meta::always_false<T>, "ProcessFunction-type not handled");
         }
+    }
 
-        T
-        process_one() noexcept requires(UseProcessOne == ProcessFunction::USE_PROCESS_ONE) {
-            if (next_tag < tags.size() &&
-                tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)) {
-                print_tag(tags[next_tag],
-                          fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name(), n_samples_produced));
-                tag_t &out_tag = this->output_tags()[0];
-                out_tag = tags[next_tag];
-                out_tag.index = 0; // indices > 0 write tags in the future ... handle with care
-                this->forward_tags();
-                next_tag++;
-                n_samples_produced++;
-                return static_cast<T>(1);
-            }
-
+    T
+    process_one() noexcept
+        requires(UseProcessOne == ProcessFunction::USE_PROCESS_ONE)
+    {
+        if (next_tag < tags.size() && tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)) {
+            print_tag(tags[next_tag], fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name(), n_samples_produced));
+            tag_t &out_tag = this->output_tags()[0];
+            out_tag        = tags[next_tag];
+            out_tag.index  = 0; // indices > 0 write tags in the future ... handle with care
+            this->forward_tags();
+            next_tag++;
             n_samples_produced++;
-            return static_cast<T>(0);
+            return static_cast<T>(1);
         }
 
-        work_return_t
-        process_bulk(std::span<T> output) noexcept requires(UseProcessOne == ProcessFunction::USE_PROCESS_BULK) {
-            if (next_tag < tags.size() &&
-                tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)) {
-                print_tag(tags[next_tag],
-                          fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name(), n_samples_produced));
-                tag_t &out_tag = this->output_tags()[0];
-                out_tag = tags[next_tag];
-                out_tag.index = 0; // indices > 0 write tags in the future ... handle with care
-                this->forward_tags();
-                next_tag++;
-            }
+        n_samples_produced++;
+        return static_cast<T>(0);
+    }
 
-            n_samples_produced += output.size();
-            return n_samples_produced < n_samples_max ? work_return_t::OK : work_return_t::DONE;
+    work_return_t
+    process_bulk(std::span<T> output) noexcept
+        requires(UseProcessOne == ProcessFunction::USE_PROCESS_BULK)
+    {
+        if (next_tag < tags.size() && tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)) {
+            print_tag(tags[next_tag], fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name(), n_samples_produced));
+            tag_t &out_tag = this->output_tags()[0];
+            out_tag        = tags[next_tag];
+            out_tag.index  = 0; // indices > 0 write tags in the future ... handle with care
+            this->forward_tags();
+            next_tag++;
         }
-    };
 
-    static_assert(HasRequiredProcessFunction<TagSource<int, ProcessFunction::USE_PROCESS_ONE>>);
-    static_assert(HasRequiredProcessFunction<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>);
+        n_samples_produced += output.size();
+        return n_samples_produced < n_samples_max ? work_return_t::OK : work_return_t::DONE;
+    }
+};
 
-    template<typename T, ProcessFunction UseProcessOne>
-    struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
-        IN<T> in;
-        OUT<T> out;
-        std::vector<tag_t> tags{};
-        std::uint64_t n_samples_produced{0};
+static_assert(HasRequiredProcessFunction<TagSource<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(HasRequiredProcessFunction<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>);
 
-        constexpr T
-        process_one(const T &input) noexcept
+template<typename T, ProcessFunction UseProcessOne>
+struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
+    IN<T>              in;
+    OUT<T>             out;
+    std::vector<tag_t> tags{};
+    std::uint64_t      n_samples_produced{ 0 };
+
+    constexpr T
+    process_one(const T &input) noexcept
         requires(UseProcessOne == ProcessFunction::USE_PROCESS_ONE)
     {
         if (this->input_tags_present()) {
@@ -176,16 +181,13 @@ struct TagSink : public node<TagSink<T, UseProcessOne>> {
     }
 };
 
-    static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_ONE>>);
-    static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_BULK>>);
+static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_BULK>>);
 
 } // namespace fair::graph::tag_test
 
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b),
-                                    (fair::graph::tag_test::TagSource<T, b>), out, n_samples_max);
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b),
-                                    (fair::graph::tag_test::TagMonitor<T, b>), in, out);
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b),
-                                    (fair::graph::tag_test::TagSink<T, b>), in);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b), (fair::graph::tag_test::TagSource<T, b>), out, n_samples_max);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b), (fair::graph::tag_test::TagMonitor<T, b>), in, out);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b), (fair::graph::tag_test::TagSink<T, b>), in);
 
 #endif // GRAPH_PROTOTYPE_TAG_MONITORS_HPP

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -83,13 +83,13 @@ struct Source : public node<Source<T>> {
     float        sample_rate        = 1000.0f;
 
     void
-    init(const property_map &/*old_settings*/, const property_map &/*new_settings*/) {
+    init(const property_map & /*old_settings*/, const property_map & /*new_settings*/) {
         // optional init function that is called after construction and whenever settings change
-        fair::graph::publish_tag(out, { { "n_samples_max", n_samples_max } }, static_cast<std::size_t >(n_tag_offset));
+        fair::graph::publish_tag(out, {{"n_samples_max", n_samples_max}}, static_cast<std::size_t>(n_tag_offset));
     }
 
     constexpr std::make_signed_t<std::size_t>
-    available_samples(const Source &/*self*/) noexcept {
+    available_samples(const Source & /*self*/) noexcept {
         const auto ret = static_cast<std::make_signed_t<std::size_t>>(n_samples_max - n_samples_produced);
         return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
     }
@@ -112,16 +112,16 @@ some test doc documentation
 
 template<typename T>
 struct TestBlock : public node<TestBlock<T>, BlockingIO, TestBlockDoc, SupportedTypes<float, double>> {
-    IN<T>  in;
-    OUT<T> out;
+    IN<T> in{};
+    OUT<T> out{};
     // parameters
     A<T, "scaling factor", Visible, Doc<"y = a * x">, Unit<"As">> scaling_factor = static_cast<T>(1); // N.B. unit 'As' = 'Coulomb'
-    A<std::string, "context information", Visible>                context;
-    std::int32_t                                                  n_samples_max = -1;
-    float                                                         sample_rate   = 1000.0f;
-    std::vector<T>                                                vector_setting{ T(3), T(2), T(1) };
-    int                                                           update_count = 0;
-    bool                                                          debug        = false;
+    A<std::string, "context information", Visible> context{};
+    std::int32_t n_samples_max = -1;
+    float sample_rate = 1000.0f;
+    std::vector<T> vector_setting{T(3), T(2), T(1)};
+    int update_count = 0;
+    bool debug = false;
 
     void
     init(const property_map &old_setting, const property_map &new_setting) noexcept {
@@ -332,7 +332,7 @@ const boost::ut::suite SettingsTests = [] {
         wrapped1.set_name("test_name");
         expect(eq(wrapped1.name(), "test_name"sv)) << "node_model wrapper name";
         expect(not wrapped1.unique_name().empty()) << "unique name";
-        std::ignore = wrapped1.settings().set({ { "context", "a string" } });
+        std::ignore = wrapped1.settings().set({{"context", "a string"}});
         (wrapped1.meta_information())["key"] = "value";
         expect(eq(std::get<std::string>(wrapped1.meta_information().at("key")), "value"sv)) << "node_model meta-information";
     };

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -65,24 +65,27 @@ const boost::ut::suite TagPropagation = [] {
         auto &src = flow_graph.make_node<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>(
                 {{"n_samples_max", n_samples},
                  {"name",          "TagSource"}});
-        src.tags          = { // TODO: allow parameter settings to include maps?!?
-                {0,    {{"key", "value@0"}}},
-                {1,    {{"key", "value@1"}}},
-                {100,  {{"key", "value@100"}}},
-                {150,  {{"key", "value@150"}}},
-                {1000, {{"key", "value@1000"}}},
-                {1001, {{"key", "value@1001"}}},
-                {1002, {{"key", "value@1002"}}},
-                {1023, {{"key", "value@1023"}}}
+        src.tags = {
+                // TODO: allow parameter settings to include maps?!?
+                {0,    {{"key", "value@0"}}},       //
+                {1,    {{"key", "value@1"}}},       //
+                {100,  {{"key", "value@100"}}},   //
+                {150,  {{"key", "value@150"}}},   //
+                {1000, {{"key", "value@1000"}}}, //
+                {1001, {{"key", "value@1001"}}}, //
+                {1002, {{"key", "value@1002"}}}, //
+                {1023, {{"key", "value@1023"}}}  //
         };
         src.set_name("TagSource"); // TODO: enable property_map to base-class parameter propagation
-        auto &monitor1 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_BULK>>({ { "name", "TagMonitor1" } });
+        auto &monitor1 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_BULK>>(
+                {{"name", "TagMonitor1"}});
         monitor1.set_name("TagMonitor1");
-        auto &monitor2 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagMonitor2" } });
+        auto &monitor2 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_ONE>>(
+                {{"name", "TagMonitor2"}});
         monitor2.set_name("TagMonitor2");
-        auto &sink1 = flow_graph.make_node<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({ { "name", "TagSink1" } });
+        auto &sink1 = flow_graph.make_node<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({{"name", "TagSink1"}});
         sink1.set_name("TagSink1");
-        auto &sink2 = flow_graph.make_node<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagSink2" } });
+        auto &sink2 = flow_graph.make_node<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "TagSink2"}});
         sink2.set_name("TagSink2");
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(monitor1)));
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor1).to<"in">(monitor2)));


### PR DESCRIPTION
The only remaining warning that needed to be masked were:

  * in graph_yampl_importer.hpp:
```cpp
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wold-style-cast"
#include <yaml-cpp/yaml.h>
#pragma GCC diagnostic pop
```
  -> to be followed up with the yampl-cpp community

  * And in tag_monitors.cpp:
```cpp
for (const auto &[key, value] : map) {
    // workaround for:
    // fmt/core.h:1674:10: warning: possibly dangling reference to a temporary [-Wdangling-reference]
    // 1674 |   auto&& arg = arg_mapper<Context>().map(FMT_FORWARD(val));
    //      |          ^~~
    #pragma GCC diagnostic push
    #pragma GCC diagnostic ignored "-Wdangling-reference"
    fmt::print(" {:>5}: {} ", key, value);
    #pragma GCC diagnostic pop
}

Thanks a lot for the tremendous preparatory work by @drslebedev and @wirew0rm in the previous commits inside and outside the graph-prototype.