### PR TITLE
refactored node name, meta_info as reflectable properties

### DIFF
--- a/bench/bm_scheduler.cpp
+++ b/bench/bm_scheduler.cpp
@@ -10,7 +10,7 @@ namespace fg                           = fair::graph;
 
 inline constexpr std::size_t N_ITER    = 10;
 inline constexpr std::size_t N_SAMPLES = gr::util::round_up(10'000'000, 1024);
-inline constexpr std::size_t N_NODES     = 5;
+inline constexpr std::size_t N_NODES   = 5;
 
 template<typename T, char op>
 class math_op : public fg::node<math_op<T, op>, fg::IN<T, 0, N_MAX, "in">, fg::OUT<T, 0, N_MAX, "out">> {
@@ -19,7 +19,7 @@ class math_op : public fg::node<math_op<T, op>, fg::IN<T, 0, N_MAX, "in">, fg::O
 public:
     math_op() = delete;
 
-    explicit math_op(T factor, std::string name = fair::graph::this_source_location()) : _factor(factor) { this->set_name(name); }
+    explicit math_op(T factor, std::string name_ = fair::graph::this_source_location()) : _factor(factor) { this->name = name_; }
 
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
@@ -44,12 +44,13 @@ template<typename T>
 using divide = math_op<T, '/'>;
 
 template<typename T, typename Sink, typename Source>
-void create_cascade(fg::graph& flow_graph, Sink& src, Source& sink, std::size_t depth = 1) {
+void
+create_cascade(fg::graph &flow_graph, Sink &src, Source &sink, std::size_t depth = 1) {
     using namespace boost::ut;
     using namespace benchmark;
 
     std::vector<multiply<T> *> mult1;
-    std::vector<divide<T> *> mult2;
+    std::vector<divide<T> *>   mult2;
     for (std::size_t i = 0; i < depth; i++) {
         mult1.emplace_back(std::addressof(flow_graph.make_node<multiply<T>>(T(2), fmt::format("mult.{}", i))));
         mult2.emplace_back(std::addressof(flow_graph.make_node<divide<T>>(T(2), fmt::format("div.{}", i))));
@@ -67,11 +68,12 @@ void create_cascade(fg::graph& flow_graph, Sink& src, Source& sink, std::size_t 
 }
 
 template<typename T>
-fg::graph test_graph_linear(std::size_t depth = 1) {
+fg::graph
+test_graph_linear(std::size_t depth = 1) {
     fg::graph flow_graph;
 
-    auto &src  = flow_graph.make_node<test::source<T>>(N_SAMPLES);
-    auto &sink = flow_graph.make_node<test::sink<T>>();
+    auto     &src  = flow_graph.make_node<test::source<T>>(N_SAMPLES);
+    auto     &sink = flow_graph.make_node<test::sink<T>>();
 
     create_cascade<T>(flow_graph, src, sink, depth);
 
@@ -79,14 +81,15 @@ fg::graph test_graph_linear(std::size_t depth = 1) {
 }
 
 template<typename T>
-fg::graph test_graph_bifurcated(std::size_t depth = 1) {
+fg::graph
+test_graph_bifurcated(std::size_t depth = 1) {
     using namespace boost::ut;
     using namespace benchmark;
     fg::graph flow_graph;
 
-    auto &src  = flow_graph.make_node<test::source<T>>(N_SAMPLES);
-    auto &sink1 = flow_graph.make_node<test::sink<T>>();
-    auto &sink2 = flow_graph.make_node<test::sink<T>>();
+    auto     &src   = flow_graph.make_node<test::source<T>>(N_SAMPLES);
+    auto     &sink1 = flow_graph.make_node<test::sink<T>>();
+    auto     &sink2 = flow_graph.make_node<test::sink<T>>();
 
     create_cascade<T>(flow_graph, src, sink1, depth);
     create_cascade<T>(flow_graph, src, sink2, depth);
@@ -94,7 +97,8 @@ fg::graph test_graph_bifurcated(std::size_t depth = 1) {
     return flow_graph;
 }
 
-void exec_bm(auto& scheduler, const std::string& test_case) {
+void
+exec_bm(auto &scheduler, const std::string &test_case) {
     using namespace boost::ut;
     using namespace benchmark;
     test::n_samples_produced = 0LU;
@@ -110,47 +114,31 @@ void exec_bm(auto& scheduler, const std::string& test_case) {
     using thread_pool = fair::thread_pool::BasicThreadPool;
     using fg::scheduler::execution_policy::multi_threaded;
 
-    auto pool = std::make_shared<thread_pool>("custom-pool", fair::thread_pool::CPU_BOUND, 2, 2);
+    auto                  pool = std::make_shared<thread_pool>("custom-pool", fair::thread_pool::CPU_BOUND, 2, 2);
 
     fg::scheduler::simple sched1(test_graph_linear<float>(2 * N_NODES), pool);
-    "linear graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1]() {
-        exec_bm(sched1, "linear-graph simple-sched");
-    };
+    "linear graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1]() { exec_bm(sched1, "linear-graph simple-sched"); };
 
     fg::scheduler::breadth_first sched2(test_graph_linear<float>(2 * N_NODES), pool);
-    "linear graph - BFS scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2]() {
-        exec_bm(sched2, "linear-graph BFS-sched");
-    };
+    "linear graph - BFS scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2]() { exec_bm(sched2, "linear-graph BFS-sched"); };
 
     fg::scheduler::simple sched3(test_graph_bifurcated<float>(N_NODES), pool);
-    "bifurcated graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3]() {
-         exec_bm(sched3, "bifurcated-graph simple-sched");
-    };
+    "bifurcated graph - simple scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3]() { exec_bm(sched3, "bifurcated-graph simple-sched"); };
 
     fg::scheduler::breadth_first sched4(test_graph_bifurcated<float>(N_NODES), pool);
-    "bifurcated graph - BFS scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4]() {
-        exec_bm(sched4, "bifurcated-graph BFS-sched");
-    };
+    "bifurcated graph - BFS scheduler"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4]() { exec_bm(sched4, "bifurcated-graph BFS-sched"); };
 
     fg::scheduler::simple<multi_threaded> sched1_mt(test_graph_linear<float>(2 * N_NODES), pool);
-    "linear graph - simple scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1_mt]() {
-        exec_bm(sched1_mt, "linear-graph simple-sched (multi-threaded)");
-    };
+    "linear graph - simple scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched1_mt]() { exec_bm(sched1_mt, "linear-graph simple-sched (multi-threaded)"); };
 
     fg::scheduler::breadth_first<multi_threaded> sched2_mt(test_graph_linear<float>(2 * N_NODES), pool);
-    "linear graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2_mt]() {
-        exec_bm(sched2_mt, "linear-graph BFS-sched (multi-threaded)");
-    };
+    "linear graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched2_mt]() { exec_bm(sched2_mt, "linear-graph BFS-sched (multi-threaded)"); };
 
     fg::scheduler::simple<multi_threaded> sched3_mt(test_graph_bifurcated<float>(N_NODES), pool);
-    "bifurcated graph - simple scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3_mt]() {
-        exec_bm(sched3_mt, "bifurcated-graph simple-sched (multi-threaded)");
-    };
+    "bifurcated graph - simple scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched3_mt]() { exec_bm(sched3_mt, "bifurcated-graph simple-sched (multi-threaded)"); };
 
     fg::scheduler::breadth_first<multi_threaded> sched4_mt(test_graph_bifurcated<float>(N_NODES), pool);
-    "bifurcated graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt]() {
-        exec_bm(sched4_mt, "bifurcated-graph BFS-sched (multi-threaded)");
-    };
+    "bifurcated graph - BFS scheduler (multi-threaded)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched4_mt]() { exec_bm(sched4_mt, "bifurcated-graph BFS-sched (multi-threaded)"); };
 };
 
 int

--- a/include/graph_yaml_importer.hpp
+++ b/include/graph_yaml_importer.hpp
@@ -63,8 +63,8 @@ load_grc(plugin_loader &loader, const std::string &yaml_source) {
     YAML::Node                          tree   = YAML::Load(yaml_source);
     auto                                blocks = tree["blocks"];
     for (const auto &grc_block : blocks) {
-        auto  name         = grc_block["name"].as<std::string>();
-        auto  id           = grc_block["id"].as<std::string>();
+        auto name = grc_block["name"].as<std::string>();
+        auto id   = grc_block["id"].as<std::string>();
 
         // TODO: Discuss how GRC should store the node types, how we should
         // in general handle nodes that are parametrised by more than one type
@@ -117,14 +117,14 @@ load_grc(plugin_loader &loader, const std::string &yaml_source) {
                     // clang-format on
 
                 } else {
-                    const auto &value = kv.second.as<std::string>();
+                    const auto &value                    = kv.second.as<std::string>();
                     current_node.meta_information()[key] = value;
                 }
             }
         }
 
         std::ignore = current_node.settings().set(new_properties);
-        std::ignore = current_node.settings().apply_staged_parameters();
+        current_node.init();
     }
 
     for (const auto &connection : tree["connections"]) {
@@ -175,7 +175,7 @@ save_grc(const fair::graph::graph &flow_graph) {
                 detail::YamlMap map(out);
                 map.write("name", std::string(node.name()));
 
-                const auto& full_type_name = node.type_name();
+                const auto &full_type_name = node.type_name();
                 std::string type_name(full_type_name.cbegin(), std::find(full_type_name.cbegin(), full_type_name.cend(), '<'));
                 map.write("id", std::move(type_name));
 

--- a/include/reflection.hpp
+++ b/include/reflection.hpp
@@ -127,9 +127,7 @@
  * };
  * ENABLE_REFLECTION_FOR_TEMPLATE(my_templated_struct, field_a, field_b);
  */
-#define ENABLE_REFLECTION_FOR_TEMPLATE(Type, ...) \
-    ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename ...Ts), (Type<Ts...>), __VA_ARGS__)
-
+#define ENABLE_REFLECTION_FOR_TEMPLATE(Type, ...) ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename... Ts), (Type<Ts...>), __VA_ARGS__)
 
 #define GP_CONCAT_IMPL(x, y) x##y
 #define GP_MACRO_CONCAT(x, y) GP_CONCAT_IMPL(x, y)

--- a/test/app_grc.cpp
+++ b/test/app_grc.cpp
@@ -51,7 +51,8 @@ main(int argc, char *argv[]) {
         auto graph_saved_source    = fg::save_grc(graph);
 
         auto graph_expected_source = read_file(TESTS_SOURCE_PATH "/grc/test.grc.expected");
-        assert(graph_saved_source + "\n" == graph_expected_source);
+        assert(graph_saved_source + "\n"
+               == graph_expected_source); // TODO: this is not a good assert since we will add new parameters regularly... should not be identity but checking critical parameter/aspects
 
         fair::graph::scheduler::simple scheduler(std::move(graph));
         scheduler.run_and_wait();

--- a/test/blocklib/core/filter/time_domain_filter.hpp
+++ b/test/blocklib/core/filter/time_domain_filter.hpp
@@ -25,7 +25,7 @@ struct fir_filter : node<fir_filter<T>> {
     history_buffer<T> inputHistory{ 32 };
 
     void
-    init(const property_map & /*old_settings*/, const property_map &new_settings) noexcept {
+    settings_changed(const property_map & /*old_settings*/, const property_map &new_settings) noexcept {
         if (new_settings.contains("b") && b.size() >= inputHistory.capacity()) {
             inputHistory = history_buffer<T>(std::bit_ceil(b.size()));
         }
@@ -63,7 +63,7 @@ struct iir_filter : node<iir_filter<T, form>> {
     history_buffer<T> outputHistory{ 32 };
 
     void
-    init(const property_map & /*old_settings*/, const property_map &new_settings) noexcept {
+    settings_changed(const property_map & /*old_settings*/, const property_map &new_settings) noexcept {
         const auto new_size = std::max(a.size(), b.size());
         if ((new_settings.contains("b") || new_settings.contains("a")) && (new_size >= inputHistory.capacity() || new_size >= inputHistory.capacity())) {
             inputHistory  = history_buffer<T>(std::bit_ceil(new_size));

--- a/test/blocklib/core/unit-test/common_nodes.hpp
+++ b/test/blocklib/core/unit-test/common_nodes.hpp
@@ -109,9 +109,12 @@ public:
     ~multi_adder() override = default;
 
     void
-    init(const fair::graph::property_map & /*old_setting*/, const fair::graph::property_map & /*new_setting*/) noexcept {
+    settings_changed(const fair::graph::property_map & /*old_setting*/, const fair::graph::property_map & /*new_setting*/) noexcept {
         apply_input_count();
     }
+
+    void
+    init() override {}
 
     [[nodiscard]] std::string_view
     name() const override {

--- a/test/blocklib/core/unit-test/tag_monitors.hpp
+++ b/test/blocklib/core/unit-test/tag_monitors.hpp
@@ -22,7 +22,7 @@ print_tag(const tag_t &tag, std::string_view prefix = {}) {
         fmt::print("}}\n");
         return;
     }
-    const auto& map = tag.map;
+    const auto &map = tag.map;
     for (const auto &[key, value] : map) {
         // workaround for:
         // fmt/core.h:1674:10: warning: possibly dangling reference to a temporary [-Wdangling-reference]
@@ -62,7 +62,7 @@ struct TagSource : public node<TagSource<T, UseProcessOne>> {
         requires(UseProcessOne == ProcessFunction::USE_PROCESS_ONE)
     {
         if (next_tag < tags.size() && tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)) {
-            print_tag(tags[next_tag], fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name(), n_samples_produced));
+            print_tag(tags[next_tag], fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name.value, n_samples_produced));
             tag_t &out_tag = this->output_tags()[0];
             out_tag        = tags[next_tag];
             out_tag.index  = 0; // indices > 0 write tags in the future ... handle with care
@@ -81,7 +81,7 @@ struct TagSource : public node<TagSource<T, UseProcessOne>> {
         requires(UseProcessOne == ProcessFunction::USE_PROCESS_BULK)
     {
         if (next_tag < tags.size() && tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced)) {
-            print_tag(tags[next_tag], fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name(), n_samples_produced));
+            print_tag(tags[next_tag], fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name, n_samples_produced));
             tag_t &out_tag = this->output_tags()[0];
             out_tag        = tags[next_tag];
             out_tag.index  = 0; // indices > 0 write tags in the future ... handle with care
@@ -110,7 +110,7 @@ struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
     {
         if (this->input_tags_present()) {
             const tag_t &tag = this->input_tags()[0];
-            print_tag(tag, fmt::format("{}::process_one(...)\t received tag at {:6}", this->name(), n_samples_produced));
+            print_tag(tag, fmt::format("{}::process_one(...)\t received tag at {:6}", this->name, n_samples_produced));
             tags.emplace_back(n_samples_produced, tag.map);
             this->forward_tags();
         }
@@ -124,7 +124,7 @@ struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
     {
         if (this->input_tags_present()) {
             const tag_t &tag = this->input_tags()[0];
-            print_tag(tag, fmt::format("{}::process_bulk(...)\t received tag at {:6}", this->name(), n_samples_produced));
+            print_tag(tag, fmt::format("{}::process_bulk(...)\t received tag at {:6}", this->name, n_samples_produced));
             tags.emplace_back(n_samples_produced, tag.map);
             this->forward_tags();
         }
@@ -156,7 +156,7 @@ struct TagSink : public node<TagSink<T, UseProcessOne>> {
     {
         if (this->input_tags_present()) {
             const tag_t &tag = this->input_tags()[0];
-            print_tag(tag, fmt::format("{}::process_one(...)\t received tag at {:6}", this->name(), n_samples_produced));
+            print_tag(tag, fmt::format("{}::process_one(...)\t received tag at {:6}", this->name, n_samples_produced));
             tags.emplace_back(n_samples_produced, tag.map);
             this->forward_tags();
         }
@@ -170,7 +170,7 @@ struct TagSink : public node<TagSink<T, UseProcessOne>> {
     {
         if (this->input_tags_present()) {
             const tag_t &tag = this->input_tags()[0];
-            print_tag(tag, fmt::format("{}::process_bulk(...)\t received tag at {:6}", this->name(), n_samples_produced));
+            print_tag(tag, fmt::format("{}::process_bulk(...)\t received tag at {:6}", this->name, n_samples_produced));
             tags.emplace_back(n_samples_produced, tag.map);
             this->forward_tags();
         }

--- a/test/grc/test.grc.expected
+++ b/test/grc/test.grc.expected
@@ -3,15 +3,61 @@ blocks:
     id: good::fixed_source
     parameters:
       event_count: 100
+      name: main_source
+      unique_name: good::fixed_source<double>#0
+      description: ""
+      meta_information::description: meta-information
+      meta_information::documentation: store non-graph-processing information like UI block position etc.
+      meta_information::unit: ""
+      meta_information::visible: 0
+      name::description: user-defined name
+      name::documentation: N.B. may not be unique -> ::unique_name
+      name::unit: ""
+      name::visible: 0
       unknown_property: 42
   - name: multiplier
     id: good::multiply
+    parameters:
+      name: multiplier
+      unique_name: good::multiply<double>#0
+      description: ""
+      meta_information::description: meta-information
+      meta_information::documentation: store non-graph-processing information like UI block position etc.
+      meta_information::unit: ""
+      meta_information::visible: 0
+      name::description: user-defined name
+      name::documentation: N.B. may not be unique -> ::unique_name
+      name::unit: ""
+      name::visible: 0
   - name: counter
     id: builtin_counter
+    parameters:
+      name: counter
+      unique_name: builtin_counter<double>#0
+      description: ""
+      meta_information::description: meta-information
+      meta_information::documentation: store non-graph-processing information like UI block position etc.
+      meta_information::unit: ""
+      meta_information::visible: 0
+      name::description: user-defined name
+      name::documentation: N.B. may not be unique -> ::unique_name
+      name::unit: ""
+      name::visible: 0
   - name: sink
     id: good::cout_sink
     parameters:
+      name: sink
       total_count: 100
+      unique_name: good::cout_sink<double>#0
+      description: ""
+      meta_information::description: meta-information
+      meta_information::documentation: store non-graph-processing information like UI block position etc.
+      meta_information::unit: ""
+      meta_information::visible: 0
+      name::description: user-defined name
+      name::documentation: N.B. may not be unique -> ::unique_name
+      name::unit: ""
+      name::visible: 0
       unknown_property: 42
 connections:
   - [main_source, 0, multiplier, 0]

--- a/test/qa_scheduler.cpp
+++ b/test/qa_scheduler.cpp
@@ -4,27 +4,31 @@
 
 #if defined(__clang__) && __clang_major__ >= 16
 // clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template <>
+template<>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
 #endif
 
-namespace fg = fair::graph;
+namespace fg            = fair::graph;
 
 using trace_vector_type = std::vector<std::string>;
-class tracer{
+
+class tracer {
     std::mutex        _trace_mutex;
     trace_vector_type _trace_vector;
+
 public:
-    void trace(std::string_view id) {
+    void
+    trace(std::string_view id) {
         std::scoped_lock lock{ _trace_mutex };
         if (_trace_vector.empty() || _trace_vector.back() != id) {
             _trace_vector.emplace_back(id);
         }
     }
 
-    trace_vector_type get_vec() {
-        std::scoped_lock lock{_trace_mutex};
-        return {_trace_vector};
+    trace_vector_type
+    get_vec() {
+        std::scoped_lock lock{ _trace_mutex };
+        return { _trace_vector };
     }
 };
 
@@ -33,43 +37,44 @@ template<typename T, std::size_t N>
 class count_source : public fg::node<count_source<T, N>, fg::OUT<T, 0, std::numeric_limits<std::size_t>::max(), "out">> {
     tracer     &_tracer;
     std::size_t _count = 0;
+
 public:
-    count_source(tracer &trace, std::string_view name) : _tracer{trace} { this->_name = name;}
+    count_source(tracer &trace, std::string_view name_) : _tracer{ trace } { this->name = name_; }
 
     constexpr std::make_signed_t<std::size_t>
-    available_samples(const count_source &/*d*/) noexcept {
+    available_samples(const count_source & /*d*/) noexcept {
         const auto ret = static_cast<std::make_signed_t<std::size_t>>(N - _count);
         return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
     }
 
     constexpr T
     process_one() {
-        _tracer.trace(this->name());
+        _tracer.trace(this->name);
         return static_cast<int>(_count++);
     }
 };
 
 template<typename T, std::int64_t N>
 class expect_sink : public fg::node<expect_sink<T, N>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "in">> {
-    tracer       &_tracer;
-    std::int64_t _count = 0;
+    tracer                                         &_tracer;
+    std::int64_t                                    _count = 0;
     std::function<void(std::int64_t, std::int64_t)> _checker;
-public:
-    expect_sink(tracer &trace, std::string_view name, std::function<void(std::int64_t, std::int64_t)> &&checker) : _tracer{trace}, _checker(std::move(checker)) { this->_name = name;}
 
-    ~expect_sink() {
-        boost::ut::expect(boost::ut::that % _count == N);
-    }
+public:
+    expect_sink(tracer &trace, std::string_view name_, std::function<void(std::int64_t, std::int64_t)> &&checker) : _tracer{ trace }, _checker(std::move(checker)) { this->name = name_; }
+
+    ~expect_sink() { boost::ut::expect(boost::ut::that % _count == N); }
 
     [[nodiscard]] fg::work_return_t
     process_bulk(std::span<const T> input) noexcept {
-        _tracer.trace(this->name());
-        for (auto data: input) {
+        _tracer.trace(this->name);
+        for (auto data : input) {
             _checker(_count, data);
             _count++;
         }
         return fg::work_return_t::OK;
     }
+
     constexpr void
     process_one(T /*a*/) noexcept {
         _tracer.trace(this->name());
@@ -79,25 +84,30 @@ public:
 template<typename T, T Scale, typename R = decltype(std::declval<T>() * std::declval<T>())>
 class scale : public fg::node<scale<T, Scale, R>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "original">, fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "scaled">> {
     tracer &_tracer;
+
 public:
-    scale(tracer &trace, std::string_view name) : _tracer{trace} {this->_name = name;}
+    scale(tracer &trace, std::string_view name_) : _tracer{ trace } { this->name = name_; }
+
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
     process_one(V a) noexcept {
-        _tracer.trace(this->name());
+        _tracer.trace(this->name);
         return a * Scale;
     }
 };
 
 template<typename T, typename R = decltype(std::declval<T>() + std::declval<T>())>
-class adder : public fg::node<adder<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend0">, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend1">, fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "sum">> {
+class adder : public fg::node<adder<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend0">, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend1">,
+                              fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "sum">> {
     tracer &_tracer;
+
 public:
-    adder(tracer &trace, std::string_view name) : _tracer(trace) {this->_name = name;}
+    adder(tracer &trace, std::string_view name_) : _tracer(trace) { this->name = name_; }
+
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto
     process_one(V a, V b) noexcept {
-        _tracer.trace(this->name());
+        _tracer.trace(this->name);
         return a + b;
     }
 };
@@ -107,19 +117,17 @@ get_graph_linear(tracer &trace) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-// Nodes need to be alive for as long as the flow is
+    // Nodes need to be alive for as long as the flow is
     fg::graph flow;
-// Generators
-    auto& source1 = flow.make_node<count_source<int, 100000>>(trace, "s1");
-    auto& scale_block1 = flow.make_node<scale<int, 2>>(trace, "mult1");
-    auto& scale_block2 = flow.make_node<scale<int, 4>>(trace, "mult2");
-    auto& sink = flow.make_node<expect_sink<int, 100000>>(trace, "out", [](std::uint64_t count, std::uint64_t data) {
-        boost::ut::expect(boost::ut::that % data == 8 * count);
-    } );
+    // Generators
+    auto &source1      = flow.make_node<count_source<int, 100000>>(trace, "s1");
+    auto &scale_block1 = flow.make_node<scale<int, 2>>(trace, "mult1");
+    auto &scale_block2 = flow.make_node<scale<int, 4>>(trace, "mult2");
+    auto &sink         = flow.make_node<expect_sink<int, 100000>>(trace, "out", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 8 * count); });
 
-    std::ignore = flow.connect<"scaled">(scale_block2).to<"in">(sink);
-    std::ignore = flow.connect<"scaled">(scale_block1).to<"original">(scale_block2);
-    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1);
+    std::ignore        = flow.connect<"scaled">(scale_block2).to<"in">(sink);
+    std::ignore        = flow.connect<"scaled">(scale_block1).to<"original">(scale_block2);
+    std::ignore        = flow.connect<"out">(source1).to<"original">(scale_block1);
 
     return flow;
 }
@@ -129,31 +137,26 @@ get_graph_parallel(tracer &trace) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-// Nodes need to be alive for as long as the flow is
+    // Nodes need to be alive for as long as the flow is
     fg::graph flow;
-// Generators
-    auto& source1 = flow.make_node<count_source<int, 100000>>(trace, "s1");
-    auto& scale_block1a = flow.make_node<scale<int, 2>>(trace, "mult1a");
-    auto& scale_block2a = flow.make_node<scale<int, 3>>(trace, "mult2a");
-    auto& sink_a = flow.make_node<expect_sink<int, 100000>>(trace, "outa", [](std::uint64_t count, std::uint64_t data) {
-        boost::ut::expect(boost::ut::that % data == 6 * count);
-    } );
-    auto& scale_block1b = flow.make_node<scale<int, 3>>(trace, "mult1b");
-    auto& scale_block2b = flow.make_node<scale<int, 5>>(trace, "mult2b");
-    auto& sink_b = flow.make_node<expect_sink<int, 100000>>(trace, "outb", [](std::uint64_t count, std::uint64_t data) {
-        boost::ut::expect(boost::ut::that % data == 15 * count);
-    } );
+    // Generators
+    auto &source1       = flow.make_node<count_source<int, 100000>>(trace, "s1");
+    auto &scale_block1a = flow.make_node<scale<int, 2>>(trace, "mult1a");
+    auto &scale_block2a = flow.make_node<scale<int, 3>>(trace, "mult2a");
+    auto &sink_a        = flow.make_node<expect_sink<int, 100000>>(trace, "outa", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 6 * count); });
+    auto &scale_block1b = flow.make_node<scale<int, 3>>(trace, "mult1b");
+    auto &scale_block2b = flow.make_node<scale<int, 5>>(trace, "mult2b");
+    auto &sink_b        = flow.make_node<expect_sink<int, 100000>>(trace, "outb", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 15 * count); });
 
-    std::ignore = flow.connect<"scaled">(scale_block1a).to<"original">(scale_block2a);
-    std::ignore = flow.connect<"scaled">(scale_block1b).to<"original">(scale_block2b);
-    std::ignore = flow.connect<"scaled">(scale_block2b).to<"in">(sink_b);
-    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1a);
-    std::ignore = flow.connect<"scaled">(scale_block2a).to<"in">(sink_a);
-    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block1b);
+    std::ignore         = flow.connect<"scaled">(scale_block1a).to<"original">(scale_block2a);
+    std::ignore         = flow.connect<"scaled">(scale_block1b).to<"original">(scale_block2b);
+    std::ignore         = flow.connect<"scaled">(scale_block2b).to<"in">(sink_b);
+    std::ignore         = flow.connect<"out">(source1).to<"original">(scale_block1a);
+    std::ignore         = flow.connect<"scaled">(scale_block2a).to<"in">(sink_a);
+    std::ignore         = flow.connect<"out">(source1).to<"original">(scale_block1b);
 
     return flow;
 }
-
 
 /**
  * sets up an example graph
@@ -176,30 +179,29 @@ get_graph_scaled_sum(tracer &trace) {
     using fg::port_direction_t::INPUT;
     using fg::port_direction_t::OUTPUT;
 
-// Nodes need to be alive for as long as the flow is
+    // Nodes need to be alive for as long as the flow is
     fg::graph flow;
 
-// Generators
-    auto& source1 = flow.make_node<count_source<int, 100000>>(trace, "s1");
-    auto& source2 = flow.make_node<count_source<int, 100000>>(trace, "s2");
-    auto& scale_block = flow.make_node<scale<int, 2>>(trace, "mult");
-    auto& add_block = flow.make_node<adder<int>>(trace, "add");
-    auto& sink = flow.make_node<expect_sink<int, 100000>>(trace, "out", [](std::uint64_t count, std::uint64_t data) {
-        boost::ut::expect(boost::ut::that % data == (2 * count) + count);
-    } );
+    // Generators
+    auto &source1     = flow.make_node<count_source<int, 100000>>(trace, "s1");
+    auto &source2     = flow.make_node<count_source<int, 100000>>(trace, "s2");
+    auto &scale_block = flow.make_node<scale<int, 2>>(trace, "mult");
+    auto &add_block   = flow.make_node<adder<int>>(trace, "add");
+    auto &sink        = flow.make_node<expect_sink<int, 100000>>(trace, "out", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == (2 * count) + count); });
 
-    std::ignore = flow.connect<"out">(source1).to<"original">(scale_block);
-    std::ignore = flow.connect<"scaled">(scale_block).to<"addend0">(add_block);
-    std::ignore = flow.connect<"out">(source2).to<"addend1">(add_block);
-    std::ignore = flow.connect<"sum">(add_block).to<"in">(sink);
+    std::ignore       = flow.connect<"out">(source1).to<"original">(scale_block);
+    std::ignore       = flow.connect<"scaled">(scale_block).to<"addend0">(add_block);
+    std::ignore       = flow.connect<"out">(source2).to<"addend1">(add_block);
+    std::ignore       = flow.connect<"sum">(add_block).to<"in">(sink);
 
     return flow;
 }
 
 template<typename node_type>
-void check_node_names(const std::vector<node_type> &joblist, std::set<std::string> set) {
+void
+check_node_names(const std::vector<node_type> &joblist, std::set<std::string> set) {
     boost::ut::expect(boost::ut::that % joblist.size() == set.size());
-    for (auto &node: joblist) {
+    for (auto &node : joblist) {
         boost::ut::expect(boost::ut::that % set.contains(std::string(node->name()))) << fmt::format("{} not in {}\n", node->name(), set);
     }
 }
@@ -207,12 +209,12 @@ void check_node_names(const std::vector<node_type> &joblist, std::set<std::strin
 const boost::ut::suite SchedulerTests = [] {
     using namespace boost::ut;
     using namespace fair::graph;
-    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
+    auto thread_pool              = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
 
     "SimpleScheduler_linear"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::simple<>;
         tracer trace{};
-        auto sched = scheduler{get_graph_linear(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_linear(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 8u);
@@ -222,58 +224,74 @@ const boost::ut::suite SchedulerTests = [] {
     "BreadthFirstScheduler_linear"_test = [&] {
         using scheduler = fair::graph::scheduler::breadth_first<>;
         tracer trace{};
-        auto sched = scheduler{get_graph_linear(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_linear(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 8u);
-        expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out"});
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
     };
 
     "SimpleScheduler_parallel"_test = [&] {
         using scheduler = fair::graph::scheduler::simple<>;
         tracer trace{};
-        auto sched = scheduler{get_graph_parallel(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_parallel(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 14u);
-        expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb", "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb"});
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb", "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb" });
     };
 
     "BreadthFirstScheduler_parallel"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::breadth_first<>;
         tracer trace{};
-        auto sched = scheduler{get_graph_parallel(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_parallel(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 14u);
-        expect(boost::ut::that % t == trace_vector_type{"s1", "mult1a", "mult1b", "mult2a", "mult2b", "outa", "outb", "s1", "mult1a", "mult1b", "mult2a", "mult2b", "outa", "outb", });
+        expect(boost::ut::that % t
+               == trace_vector_type{
+                       "s1",
+                       "mult1a",
+                       "mult1b",
+                       "mult2a",
+                       "mult2b",
+                       "outa",
+                       "outb",
+                       "s1",
+                       "mult1a",
+                       "mult1b",
+                       "mult2a",
+                       "mult2b",
+                       "outa",
+                       "outb",
+               });
     };
 
     "SimpleScheduler_scaled_sum"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::simple<>;
         // construct an example graph and get an adjacency list for it
         tracer trace{};
-        auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_scaled_sum(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 10u);
-        expect(boost::ut::that % t == trace_vector_type{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out"});
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out" });
     };
 
     "BreadthFirstScheduler_scaled_sum"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::breadth_first<>;
         tracer trace{};
-        auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_scaled_sum(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() == 10u);
-        expect(boost::ut::that % t == trace_vector_type{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out"});
+        expect(boost::ut::that % t == trace_vector_type{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out" });
     };
 
     "SimpleScheduler_linear_multi_threaded"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::simple<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
-        auto sched = scheduler{get_graph_linear(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_linear(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(that % t.size() >= 8u);
@@ -282,11 +300,11 @@ const boost::ut::suite SchedulerTests = [] {
     "BreadthFirstScheduler_linear_multi_threaded"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
-        auto sched = scheduler{get_graph_linear(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_linear(trace), thread_pool };
         sched.init();
         expect(sched.getJobLists().size() == 2u);
-        check_node_names(sched.getJobLists()[0], {"s1", "mult2"});
-        check_node_names(sched.getJobLists()[1], {"mult1", "out"});
+        check_node_names(sched.getJobLists()[0], { "s1", "mult2" });
+        check_node_names(sched.getJobLists()[1], { "mult1", "out" });
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 8u);
@@ -295,7 +313,7 @@ const boost::ut::suite SchedulerTests = [] {
     "SimpleScheduler_parallel_multi_threaded"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::simple<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
-        auto sched = scheduler{get_graph_parallel(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_parallel(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 14u);
@@ -304,11 +322,11 @@ const boost::ut::suite SchedulerTests = [] {
     "BreadthFirstScheduler_parallel_multi_threaded"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
-        auto sched = scheduler{get_graph_parallel(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_parallel(trace), thread_pool };
         sched.init();
         expect(sched.getJobLists().size() == 2u);
-        check_node_names(sched.getJobLists()[0], {"s1", "mult1b", "mult2b",  "outb"});
-        check_node_names(sched.getJobLists()[1], {"mult1a", "mult2a",  "outa"});
+        check_node_names(sched.getJobLists()[0], { "s1", "mult1b", "mult2b", "outb" });
+        check_node_names(sched.getJobLists()[1], { "mult1a", "mult2a", "outa" });
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 14u);
@@ -318,7 +336,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler = fair::graph::scheduler::simple<fg::scheduler::execution_policy::multi_threaded>;
         // construct an example graph and get an adjacency list for it
         tracer trace{};
-        auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_scaled_sum(trace), thread_pool };
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 10u);
@@ -327,11 +345,11 @@ const boost::ut::suite SchedulerTests = [] {
     "BreadthFirstScheduler_scaled_sum_multi_threaded"_test = [&thread_pool] {
         using scheduler = fair::graph::scheduler::breadth_first<fg::scheduler::execution_policy::multi_threaded>;
         tracer trace{};
-        auto sched = scheduler{get_graph_scaled_sum(trace), thread_pool};
+        auto   sched = scheduler{ get_graph_scaled_sum(trace), thread_pool };
         sched.init();
         expect(sched.getJobLists().size() == 2u);
-        check_node_names(sched.getJobLists()[0], {"s1", "mult",  "out"});
-        check_node_names(sched.getJobLists()[1], {"s2", "add"});
+        check_node_names(sched.getJobLists()[0], { "s1", "mult", "out" });
+        check_node_names(sched.getJobLists()[1], { "s2", "add" });
         sched.run_and_wait();
         auto t = trace.get_vec();
         expect(boost::ut::that % t.size() >= 10u);

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -76,17 +76,17 @@ const boost::ut::suite TagPropagation = [] {
                 {1002, {{"key", "value@1002"}}}, //
                 {1023, {{"key", "value@1023"}}}  //
         };
-        src.set_name("TagSource"); // TODO: enable property_map to base-class parameter propagation
+        src.name = "TagSource"; // TODO: enable property_map to base-class parameter propagation
         auto &monitor1 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_BULK>>(
                 {{"name", "TagMonitor1"}});
-        monitor1.set_name("TagMonitor1");
+        monitor1.name = "TagMonitor1";
         auto &monitor2 = flow_graph.make_node<TagMonitor<float, ProcessFunction::USE_PROCESS_ONE>>(
                 {{"name", "TagMonitor2"}});
-        monitor2.set_name("TagMonitor2");
+        monitor2.name = "TagMonitor2";
         auto &sink1 = flow_graph.make_node<TagSink<float, ProcessFunction::USE_PROCESS_BULK>>({{"name", "TagSink1"}});
-        sink1.set_name("TagSink1");
+        sink1.name = "TagSink1";
         auto &sink2 = flow_graph.make_node<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({{"name", "TagSink2"}});
-        sink2.set_name("TagSink2");
+        sink2.name = "TagSink2";
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(monitor1)));
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor1).to<"in">(monitor2)));
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(monitor2).to<"in">(sink1)));


### PR DESCRIPTION
* added fmt definition for Annotated<>
* added implicit conversion operator from/to std::string for Annotated
* properties that cannot be matched to fields (settings().set(..)) end up in the node's meta_information map
* to note: `using property_map = std::map<std::string, pmtv::pmt, detail::transparent_less>;` changed to `pmtv::map_t` (needs follow-up in pmt w.r.t. key comparator)
* `node::meta_information` now stores the field/property annotation meta info (e.g. usable in UI) such as 
   * `<field_name>::description`, 
   * `<field_name>::documentation`,
   * `<field_name>::unit`,
   * `<field_name>::visible`, and 
   * other future annotation meta info.
* changed  `_node->init(/* old settings */ oldSettings, /* new settings */ staged);` to `_node->settings_changed(/* old settings */ oldSettings, /* new settings */ staged);`