### PR TITLE
scheduler: have run_and_wait reset a stopped scheduler

### DIFF
--- a/bench/bm_scheduler.cpp
+++ b/bench/bm_scheduler.cpp
@@ -102,7 +102,6 @@ void exec_bm(auto& scheduler, const std::string& test_case) {
     scheduler.run_and_wait();
     expect(eq(test::n_samples_produced, N_SAMPLES)) << fmt::format("did not produce enough output samples for {}", test_case);
     expect(ge(test::n_samples_consumed, N_SAMPLES)) << fmt::format("did not consume enough input samples for {}", test_case);
-    scheduler.reset();
 }
 
 [[maybe_unused]] inline const boost::ut::suite scheduler_tests = [] {

--- a/include/scheduler.hpp
+++ b/include/scheduler.hpp
@@ -243,8 +243,7 @@ public:
                 break;
         }
         if (this->_state != INITIALISED) {
-            fmt::print("simple scheduler work(): graph not initialised");
-            return;
+            throw std::runtime_error("simple scheduler work(): graph not initialised");
         }
         if constexpr (executionPolicy == single_threaded) {
             this->_state = RUNNING;
@@ -376,8 +375,7 @@ public:
                 break;
         }
         if (this->_state != INITIALISED) {
-            fmt::print("simple scheduler work(): graph not initialised");
-            return;
+            throw std::runtime_error("simple scheduler work(): graph not initialised");
         }
         if constexpr (executionPolicy == single_threaded) {
             this->_state = RUNNING;


### PR DESCRIPTION
Fixes benchmarks that run an existing scheduler repeatedly.