### PR TITLE
changed node:work() signature

### DIFF
--- a/bench/bm_filter.cpp
+++ b/bench/bm_filter.cpp
@@ -24,7 +24,7 @@ loop_over_work(auto &node) {
     test::n_samples_produced = 0LU;
     test::n_samples_consumed = 0LU;
     while (test::n_samples_consumed < N_SAMPLES) {
-        node.work();
+        std::ignore = node.work(std::numeric_limits<std::size_t>::max());
     }
     expect(eq(test::n_samples_produced, N_SAMPLES)) << "produced too many/few samples";
     expect(eq(test::n_samples_consumed, N_SAMPLES)) << "consumed too many/few samples";
@@ -92,7 +92,7 @@ inline const boost::ut::suite _constexpr_bm = [] {
 
         expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(sink)));
 
-        fair::graph::scheduler::simple sched{std::move(flow_graph)};
+        fair::graph::scheduler::simple sched{ std::move(flow_graph) };
 
         "runtime   src->sink overhead"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
@@ -106,7 +106,7 @@ inline const boost::ut::suite _constexpr_bm = [] {
         expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect(src, &::test::source<float>::out).to<"in">(filter)));
         expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
-        fair::graph::scheduler::simple sched{std::move(flow_graph)};
+        fair::graph::scheduler::simple sched{ std::move(flow_graph) };
 
         "runtime   src->fir_filter->sink"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
@@ -120,7 +120,7 @@ inline const boost::ut::suite _constexpr_bm = [] {
         expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect(src, &::test::source<float>::out).to<"in">(filter)));
         expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
-        fair::graph::scheduler::simple sched{std::move(flow_graph)};
+        fair::graph::scheduler::simple sched{ std::move(flow_graph) };
 
         "runtime   src->iir_filter->sink - direct-form I"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }
@@ -134,7 +134,7 @@ inline const boost::ut::suite _constexpr_bm = [] {
         expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect(src, &::test::source<float>::out).to<"in">(filter)));
         expect(eq(fg::connection_result_t::SUCCESS, flow_graph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
-        fair::graph::scheduler::simple sched{std::move(flow_graph)};
+        fair::graph::scheduler::simple sched{ std::move(flow_graph) };
 
         "runtime   src->iir_filter->sink - direct-form II"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() { invoke_work(sched); };
     }

--- a/include/data_sink.hpp
+++ b/include/data_sink.hpp
@@ -473,7 +473,7 @@ public:
         }
     }
 
-    [[nodiscard]] work_return_t
+    [[nodiscard]] work_return_status_t
     process_bulk(std::span<const T> in_data) noexcept {
         std::optional<property_map> tagData;
         if (this->input_tags_present()) {
@@ -499,7 +499,7 @@ public:
             }
         }
 
-        return work_return_t::OK;
+        return work_return_status_t::OK;
     }
 
 private:
@@ -561,7 +561,7 @@ private:
 
     void
     ensure_history_size(std::size_t new_size) {
-        const auto old_size = _history ? _history->capacity() : std::size_t{0};
+        const auto old_size = _history ? _history->capacity() : std::size_t{ 0 };
         if (new_size <= old_size) {
             return;
         }

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -440,7 +440,8 @@ public:
             = 0;
 
     [[nodiscard]] virtual work_return_t
-    work() = 0;
+    work(std::size_t requested_work)
+            = 0;
 
     [[nodiscard]] virtual void *
     raw() = 0;
@@ -526,8 +527,8 @@ public:
     }
 
     [[nodiscard]] constexpr work_return_t
-    work() override {
-        return node_ref().work();
+    work(std::size_t requested_work = std::numeric_limits<std::size_t>::max()) override {
+        return node_ref().work(requested_work);
     }
 
     [[nodiscard]] std::string_view
@@ -645,9 +646,9 @@ public:
 
 class graph {
 private:
-    std::vector<std::function<connection_result_t(graph&)>> _connection_definitions;
-    std::vector<std::unique_ptr<node_model>>                _nodes;
-    std::vector<edge>                                       _edges;
+    std::vector<std::function<connection_result_t(graph &)>> _connection_definitions;
+    std::vector<std::unique_ptr<node_model>>                 _nodes;
+    std::vector<edge>                                        _edges;
 
     template<typename Node>
     std::unique_ptr<node_model> &
@@ -777,11 +778,16 @@ private:
     connect(Source &source, Port Source::*member_ptr);
 
 public:
-    graph(graph&) = delete;
-    graph(graph&&) = default;
-    graph() = default;
-    graph &operator=(graph&) = delete;
-    graph &operator=(graph&&) = default;
+    graph(graph &)  = delete;
+    graph(graph &&) = default;
+    graph()         = default;
+    graph &
+    operator=(graph &)
+            = delete;
+    graph &
+    operator=(graph &&)
+            = default;
+
     /**
      * @return a list of all blocks contained in this graph
      * N.B. some 'blocks' may be (sub-)graphs themselves
@@ -869,7 +875,7 @@ public:
         return result;
     }
 
-    const std::vector<std::function<connection_result_t(graph&)>> &
+    const std::vector<std::function<connection_result_t(graph &)>> &
     connection_definitions() {
         return _connection_definitions;
     }

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -42,14 +42,18 @@ simdize_tuple_load_and_apply(auto width, const std::tuple<Ts...> &rngs, auto off
     }(std::make_index_sequence<sizeof...(Ts)>());
 }
 
-enum class work_return_t {
+enum class work_return_status_t {
     ERROR                     = -100, /// error occurred in the work function
     INSUFFICIENT_OUTPUT_ITEMS = -3,   /// work requires a larger output buffer to produce output
     INSUFFICIENT_INPUT_ITEMS  = -2,   /// work requires a larger input buffer to produce output
     DONE                      = -1,   /// this block has completed its processing and the flowgraph should be done
     OK                        = 0,    /// work call was successful and return values in i/o structs are valid
-    CALLBACK_INITIATED        = 1,    /// rather than blocking in the work function, the block will call back to the
-                                      /// parent interface when it is ready to be called again
+};
+
+struct work_return_t {
+    std::size_t          requested_work = std::numeric_limits<std::size_t>::max();
+    std::size_t          performed_work = 0;
+    work_return_status_t status         = work_return_status_t::OK;
 };
 
 template<std::size_t Index, typename Self>
@@ -103,7 +107,7 @@ output_ports(Self *self) noexcept {
 }
 
 template<typename T>
-concept NodeType = requires(T t) {
+concept NodeType = requires(T t, std::size_t requested_work) {
     { t.unique_name } -> std::same_as<const std::string &>;
     { unwrap_if_wrapped_t<decltype(t.name)>{} } -> std::same_as<std::string>;
     { unwrap_if_wrapped_t<decltype(t.meta_information)>{} } -> std::same_as<property_map>;
@@ -112,7 +116,7 @@ concept NodeType = requires(T t) {
     { t.is_blocking() } noexcept -> std::same_as<bool>;
 
     { t.settings() } -> std::same_as<settings_base &>;
-    { t.work() } -> std::same_as<work_return_t>;
+    { t.work(requested_work) } -> std::same_as<work_return_t>;
 
     // N.B. TODO discuss these requirements
     requires !std::is_copy_constructible_v<T>;
@@ -192,9 +196,9 @@ concept HasRequiredProcessFunction = HasProcessOneFunction<Derived> != HasProces
  *     const auto n_readable = std::min(reader.available(), in_port.max_buffer_size());
  *     const auto n_writable = std::min(writer.available(), out_port.max_buffer_size());
  *     if (n_readable == 0) {
- *         return fair::graph::work_return_t::INSUFFICIENT_INPUT_ITEMS;
+ *         return { 0, fair::graph::work_return_status_t::INSUFFICIENT_INPUT_ITEMS };
  *     } else if (n_writable == 0) {
- *         return fair::graph::work_return_t::INSUFFICIENT_OUTPUT_ITEMS;
+ *         return { 0, fair::graph::work_return_status_t::INSUFFICIENT_OUTPUT_ITEMS };
  *     }
  *     const std::size_t n_to_publish = std::min(n_readable, n_writable); // N.B. here enforcing N_input == N_output
  *
@@ -206,9 +210,9 @@ concept HasRequiredProcessFunction = HasProcessOneFunction<Derived> != HasProces
  *     }, n_to_publish);
  *
  *     if (!reader.consume(n_to_publish)) {
- *         return fair::graph::work_return_t::ERROR;
+ *         return { n_to_publish, fair::graph::work_return_status_t::ERROR };
  *     }
- *     return fair::graph::work_return_t::OK;
+ *     return { n_to_publish, fair::graph::work_return_status_t::OK };
  * }
  * @endcode
  * <li> <b>case 4</b>:  Python -> map to cases 1-3 and/or dedicated callback (to-be-implemented)
@@ -480,9 +484,14 @@ public:
         std::for_each(_tags_at_output.begin(), _tags_at_output.end(), [](tag_t &tag) { tag.reset(); });
     }
 
-public:
+protected:
+    /**
+     * @brief
+     * @return struct { std::size_t produced_work, work_return_t}
+     */
     work_return_t
-    work() noexcept {
+    work_internal(std::size_t requested_work) noexcept {
+        using fair::graph::work_return_status_t;
         using input_types                       = traits::node::input_port_types<Derived>;
         using output_types                      = traits::node::output_port_types<Derived>;
 
@@ -500,17 +509,17 @@ public:
                 meta::tuple_for_each([&max_buffer](auto &&out) { max_buffer = std::min(max_buffer, out.streamWriter().available()); }, output_ports(&self()));
                 const std::make_signed_t<std::size_t> available_samples = self().available_samples(self());
                 if (available_samples < 0 && max_buffer > 0) {
-                    return work_return_t::DONE;
+                    return { requested_work, 0_UZ, work_return_status_t::DONE };
                 }
                 if (available_samples == 0) {
-                    return work_return_t::OK;
+                    return { requested_work, 0_UZ, work_return_status_t::OK };
                 }
                 samples_to_process = std::max(0UL, std::min(static_cast<std::size_t>(available_samples), max_buffer));
                 if (not enough_samples_for_output_ports(samples_to_process)) {
-                    return work_return_t::INSUFFICIENT_INPUT_ITEMS;
+                    return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_INPUT_ITEMS };
                 }
                 if (samples_to_process == 0) {
-                    return work_return_t::INSUFFICIENT_OUTPUT_ITEMS;
+                    return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_OUTPUT_ITEMS };
                 }
             } else if constexpr (requires(const Derived &d) {
                                      { available_samples(d) } -> std::same_as<std::size_t>;
@@ -518,13 +527,13 @@ public:
                 // the (source) node wants to determine the number of samples to process
                 samples_to_process = available_samples(self());
                 if (samples_to_process == 0) {
-                    return work_return_t::OK;
+                    return { requested_work, 0_UZ, work_return_status_t::OK };
                 }
                 if (not enough_samples_for_output_ports(samples_to_process)) {
-                    return work_return_t::INSUFFICIENT_INPUT_ITEMS;
+                    return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_INPUT_ITEMS };
                 }
                 if (not space_available_on_output_ports(samples_to_process)) {
-                    return work_return_t::INSUFFICIENT_OUTPUT_ITEMS;
+                    return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_OUTPUT_ITEMS };
                 }
             } else if constexpr (is_sink_node) {
                 // no input or output buffers, derive from internal "buffer sizes" (i.e. what the
@@ -537,7 +546,7 @@ public:
                 // derive value from output buffer size
                 samples_to_process = std::apply([&](const auto &...ports) { return std::min({ ports.streamWriter().available()..., ports.max_buffer_size()... }); }, output_ports(&self()));
                 if (not enough_samples_for_output_ports(samples_to_process)) {
-                    return work_return_t::INSUFFICIENT_OUTPUT_ITEMS;
+                    return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_OUTPUT_ITEMS };
                 }
                 // space_available_on_output_ports is true by construction of samples_to_process
             }
@@ -545,15 +554,15 @@ public:
             // Capturing structured bindings does not work in Clang...
             const auto [at_least_one_input_has_data, available_values_count, n_samples_until_next_tag_] = self().inputs_status(self());
             if (available_values_count == 0) {
-                return at_least_one_input_has_data ? work_return_t::INSUFFICIENT_INPUT_ITEMS : work_return_t::DONE;
+                return { requested_work, 0_UZ, at_least_one_input_has_data ? work_return_status_t::INSUFFICIENT_INPUT_ITEMS : work_return_status_t::DONE };
             }
             samples_to_process       = available_values_count;
             n_samples_until_next_tag = n_samples_until_next_tag_;
             if (not enough_samples_for_output_ports(samples_to_process)) {
-                return work_return_t::INSUFFICIENT_INPUT_ITEMS;
+                return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_INPUT_ITEMS };
             }
             if (not space_available_on_output_ports(samples_to_process)) {
-                return work_return_t::INSUFFICIENT_OUTPUT_ITEMS;
+                return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_OUTPUT_ITEMS };
             }
         }
 
@@ -622,14 +631,17 @@ public:
         // case sources: HW triggered vs. generating data per invocation (generators via Port::MIN)
         // case sinks: HW triggered vs. fixed-size consumer (may block/never finish for insufficient input data and fixed Port::MIN>0)
 
+        // clamp
+        samples_to_process = std::min(samples_to_process, requested_work);
+
         if constexpr (HasProcessBulkFunction<Derived>) {
-            const work_return_t ret = std::apply([this](auto... args) { return static_cast<Derived *>(this)->process_bulk(args...); },
-                                                 std::tuple_cat(input_spans, meta::tuple_transform([](auto &output_range) { return std::span(output_range); }, writers_tuple)));
+            const work_return_status_t ret = std::apply([this](auto... args) { return static_cast<Derived *>(this)->process_bulk(args...); },
+                                                        std::tuple_cat(input_spans, meta::tuple_transform([](auto &output_range) { return std::span(output_range); }, writers_tuple)));
 
             write_to_outputs(samples_to_process, writers_tuple);
             const bool success = consume_readers(self(), samples_to_process);
             forward_tags();
-            return success ? ret : work_return_t::ERROR;
+            return { requested_work, samples_to_process, success ? ret : work_return_status_t::ERROR };
         } else {
             //       if constexpr (HasProcessOneFunction<Derived>) { // TODO: nail down the required method parameters and return types
             // handle process_one(...)
@@ -674,13 +686,32 @@ public:
             }
 #endif
             forward_tags();
-            return success ? work_return_t::OK : work_return_t::ERROR;
+            return { requested_work, samples_to_process, success ? work_return_status_t::OK : work_return_status_t::ERROR };
         } // process_one(...) handling
         //        else {
         //            static_assert(fair::meta::always_false<Derived>, "neither process_bulk(...) nor process_one(...) implemented");
         //        }
-        return work_return_t::ERROR;
-    } // end: work_return_t work() noexcept { ..}
+        return { requested_work, 0_UZ, work_return_status_t::ERROR };
+    } // end: work_return_t work_internal() noexcept { ..}
+
+public:
+    /**
+     * @brief Process as many samples as available and compatible with the internal boundary requirements or limited by 'requested_work`
+     *
+     * @param requested_work: usually the processed number of input samples, but could be any other metric as long as
+     * requested_work limit as an affine relation with the returned performed_work.
+     * @return { requested_work, performed_work, status}
+     */
+    work_return_t
+    work(std::size_t requested_work = std::numeric_limits<std::size_t>::max()) noexcept {
+        constexpr bool is_blocking = node_template_parameters::template contains<BlockingIO>;
+        if constexpr (is_blocking) {
+            return work_internal(requested_work);
+            //static_assert(fair::meta::always_false<derived_t>, "not yet implemented");
+        } else {
+            return work_internal(requested_work);
+        }
+    }
 };
 
 template<typename Derived, typename... Arguments>
@@ -724,9 +755,9 @@ node_description() noexcept {
                     ret += fmt::format("{}{:10} {:<20} - annotated info: {} unit: [{}] documentation: {}{}\n",
                                        RawType::visible() ? "" : "_", //
                                        type_name,
-                                       member_name,                   //
+                                       member_name, //
                                        RawType::description(), RawType::unit(),
-                                       RawType::documentation(),      //
+                                       RawType::documentation(), //
                                        RawType::visible() ? "" : "_");
                 } else {
                     const std::string type_name   = refl::detail::get_type_name<Type>().str();
@@ -921,8 +952,8 @@ public:
     } // end:: process_one
 
     work_return_t
-    work() noexcept {
-        return base::work();
+    work(std::size_t requested_work) noexcept {
+        return base::work(requested_work);
     }
 };
 

--- a/test/app_plugins_test.cpp
+++ b/test/app_plugins_test.cpp
@@ -98,11 +98,11 @@ main(int argc, char *argv[]) {
     assert(connection_4 == fg::connection_result_t::SUCCESS);
 
     for (std::size_t i = 0; i < repeats; ++i) {
-        std::ignore = node_source.work();
-        std::ignore = node_multiply_1.work();
-        std::ignore = node_multiply_2.work();
-        std::ignore = node_counter.work();
-        std::ignore = node_sink.work();
+        std::ignore = node_source.work(std::numeric_limits<std::size_t>::max());
+        std::ignore = node_multiply_1.work(std::numeric_limits<std::size_t>::max());
+        std::ignore = node_multiply_2.work(std::numeric_limits<std::size_t>::max());
+        std::ignore = node_counter.work(std::numeric_limits<std::size_t>::max());
+        std::ignore = node_sink.work(std::numeric_limits<std::size_t>::max());
     }
 
     fmt::print("repeats {} event_count {}\n", repeats, builtin_counter<double>::s_event_count);

--- a/test/blocklib/core/unit-test/tag_monitors.hpp
+++ b/test/blocklib/core/unit-test/tag_monitors.hpp
@@ -76,7 +76,7 @@ struct TagSource : public node<TagSource<T, UseProcessOne>> {
         return static_cast<T>(0);
     }
 
-    work_return_t
+    work_return_status_t
     process_bulk(std::span<T> output) noexcept
         requires(UseProcessOne == ProcessFunction::USE_PROCESS_BULK)
     {
@@ -90,7 +90,7 @@ struct TagSource : public node<TagSource<T, UseProcessOne>> {
         }
 
         n_samples_produced += output.size();
-        return n_samples_produced < n_samples_max ? work_return_t::OK : work_return_t::DONE;
+        return n_samples_produced < n_samples_max ? work_return_status_t::OK : work_return_status_t::DONE;
     }
 };
 
@@ -118,7 +118,7 @@ struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
         return input;
     }
 
-    constexpr work_return_t
+    constexpr work_return_status_t
     process_bulk(std::span<const T> input, std::span<T> output) noexcept
         requires(UseProcessOne == ProcessFunction::USE_PROCESS_BULK)
     {
@@ -132,7 +132,7 @@ struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
         n_samples_produced += input.size();
         std::memcpy(output.data(), input.data(), input.size() * sizeof(T));
 
-        return work_return_t::OK;
+        return work_return_status_t::OK;
     }
 };
 
@@ -164,7 +164,7 @@ struct TagSink : public node<TagSink<T, UseProcessOne>> {
     }
 
     // template<fair::meta::t_or_simd<T> V>
-    constexpr work_return_t
+    constexpr work_return_status_t
     process_bulk(std::span<const T> input) noexcept
         requires(UseProcessOne == ProcessFunction::USE_PROCESS_BULK)
     {
@@ -177,7 +177,7 @@ struct TagSink : public node<TagSink<T, UseProcessOne>> {
 
         n_samples_produced += input.size();
 
-        return work_return_t::OK;
+        return work_return_status_t::OK;
     }
 };
 

--- a/test/plugins/good_base_plugin.cpp
+++ b/test/plugins/good_base_plugin.cpp
@@ -54,10 +54,10 @@ public:
     T value = 1;
 
     fg::work_return_t
-    work() {
+    work(std::size_t requested_work) {
         if (event_count == 0) {
             std::cerr << "fixed_source done\n";
-            return fg::work_return_t::DONE;
+            return { requested_work, 0_UZ, fg::work_return_status_t::DONE };
         }
 
         auto &port   = fair::graph::output_port<0>(this);
@@ -68,11 +68,11 @@ public:
 
         value += 1;
         if (event_count == -1_UZ) {
-            return fg::work_return_t::OK;
+            return { requested_work, 1_UZ, fg::work_return_status_t::OK };
         }
 
         event_count--;
-        return fg::work_return_t::OK;
+        return { requested_work, 1_UZ, fg::work_return_status_t::OK };
     }
 };
 } // namespace good

--- a/test/qa_dynamic_node.cpp
+++ b/test/qa_dynamic_node.cpp
@@ -14,18 +14,20 @@ struct fixed_source : public fg::node<fixed_source<T>, fg::OUT<T, 0, 1024, "out"
     T value = 1;
 
     fg::work_return_t
-    work() {
+    work(std::size_t requested_work) {
         using namespace fair::literals;
-        auto &port = fg::output_port<0>(this);
+        auto &port   = fg::output_port<0>(this);
         auto &writer = port.streamWriter();
-        auto data = writer.reserve_output_range(1_UZ);
-        data[0] = value;
+        auto  data   = writer.reserve_output_range(1_UZ);
+        data[0]      = value;
         data.publish(1_UZ);
 
         value += 1;
-        return fg::work_return_t::OK;
+        return { requested_work, 1_UZ, fg::work_return_status_t::OK };
     }
 };
+
+static_assert(fair::graph::NodeType<fixed_source<int>>);
 
 template<typename T>
 struct cout_sink : public fg::node<cout_sink<T>, fg::IN<T, 0, 1024, "in">> {
@@ -40,20 +42,22 @@ struct cout_sink : public fg::node<cout_sink<T>, fg::IN<T, 0, 1024, "in">> {
     }
 };
 
+static_assert(fair::graph::NodeType<cout_sink<int>>);
+
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (cout_sink<T>), remaining);
 
 int
 main() {
     constexpr const std::size_t sources_count = 10;
-    constexpr const std::size_t events_count = 5;
+    constexpr const std::size_t events_count  = 5;
 
-    fg::graph flow_graph;
+    fg::graph                   flow_graph;
 
     // Adder has sources_count inputs in total, but let's create
     // sources_count / 2 inputs on construction, and change the number
     // via settings
     auto &adder = flow_graph.add_node(std::make_unique<multi_adder<double>>(sources_count / 2));
-    auto &sink = flow_graph.make_node<cout_sink<double>>({{"remaining", events_count}});
+    auto &sink  = flow_graph.make_node<cout_sink<double>>({ { "remaining", events_count } });
 
     // Function that adds a new source node to the graph, and connects
     // it to one of adder's ports
@@ -71,9 +75,9 @@ main() {
 
     for (std::size_t i = 0; i < events_count; ++i) {
         for (auto *source : sources) {
-            source->work();
+            source->work(std::numeric_limits<std::size_t>::max());
         }
-        std::ignore = adder.work();
-        std::ignore = sink.work();
+        std::ignore = adder.work(std::numeric_limits<std::size_t>::max());
+        std::ignore = sink.work(std::numeric_limits<std::size_t>::max());
     }
 }

--- a/test/qa_plugins_test.cpp
+++ b/test/qa_plugins_test.cpp
@@ -140,9 +140,9 @@ const boost::ut::suite BasicPluginNodesConnectionTests = [] {
         expect(connection_2 == fg::connection_result_t::SUCCESS);
 
         for (std::size_t i = 0; i < repeats; ++i) {
-            node_source->work();
-            node_multiply->work();
-            node_sink->work();
+            std::ignore = node_source->work(std::numeric_limits<std::size_t>::max());
+            std::ignore = node_multiply->work(std::numeric_limits<std::size_t>::max());
+            std::ignore = node_sink->work(std::numeric_limits<std::size_t>::max());
         }
     };
 
@@ -155,7 +155,7 @@ const boost::ut::suite BasicPluginNodesConnectionTests = [] {
         // Instantiate a built-in node in a static way
         fair::graph::property_map node_multiply_1_params;
         node_multiply_1_params["factor"] = 2.0;
-        auto &node_multiply_1 = flow_graph.make_node<builtin_multiply<double>>(node_multiply_1_params);
+        auto &node_multiply_1            = flow_graph.make_node<builtin_multiply<double>>(node_multiply_1_params);
 
         // Instantiate a built-in node via the plugin loader
         auto &node_multiply_2 = context().loader.instantiate_in_graph(flow_graph, names::builtin_multiply, "double");
@@ -176,10 +176,10 @@ const boost::ut::suite BasicPluginNodesConnectionTests = [] {
         expect(connection_3 == fg::connection_result_t::SUCCESS);
 
         for (std::size_t i = 0; i < repeats; ++i) {
-            node_source.work();
-            node_multiply_1.work();
-            node_multiply_2.work();
-            node_sink.work();
+            std::ignore = node_source.work(std::numeric_limits<std::size_t>::max());
+            std::ignore = node_multiply_1.work(std::numeric_limits<std::size_t>::max());
+            std::ignore = node_multiply_2.work(std::numeric_limits<std::size_t>::max());
+            std::ignore = node_sink.work(std::numeric_limits<std::size_t>::max());
         }
     };
 };

--- a/test/qa_scheduler.cpp
+++ b/test/qa_scheduler.cpp
@@ -54,6 +54,8 @@ public:
     }
 };
 
+static_assert(fg::NodeType<count_source<float, 10U>>);
+
 template<typename T, std::int64_t N>
 class expect_sink : public fg::node<expect_sink<T, N>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "in">> {
     tracer                                         &_tracer;
@@ -65,14 +67,14 @@ public:
 
     ~expect_sink() { boost::ut::expect(boost::ut::that % _count == N); }
 
-    [[nodiscard]] fg::work_return_t
+    [[nodiscard]] fg::work_return_status_t
     process_bulk(std::span<const T> input) noexcept {
         _tracer.trace(this->name);
         for (auto data : input) {
             _checker(_count, data);
             _count++;
         }
-        return fg::work_return_t::OK;
+        return fg::work_return_status_t::OK;
     }
 
     constexpr void


### PR DESCRIPTION
...  to `{requested, performed, status} work(std::size requested) {..}`

This is preparatory to support:
 * limit amount of work to be processed based on explicit scheduler constraints, i.e.
   * optimise for latency
   * optimise for throughput
   * optimise for actual processing time (i.e. if '1k work' takes n-ms, then schedule next time 10k to minimise work overhead or vice verse)
 * transparent blocking IO calls: of `BlockingIO` is declared node-implicitly runs internal work function on independent io thread (injected by graph/scheduler tbd.) -- separation between public and internal work function required for decoupling.
 
 N.B. for non-blocking blocks nothing changes compared to before.