### PR TITLE
Extend process_one with optional offset parameter and allow process_bulk to publish less samples in an output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.22)
 
 project(graph-prototype CXX)
 set(CMAKE_CXX_STANDARD 20)

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -54,7 +54,7 @@ using divide = math_op<T, '/'>;
 // template<typename T> using sub = math_op<T, '-'>;
 
 #if !DISABLE_SIMD
-static_assert(fg::traits::node::can_process_simd<multiply<float>>);
+static_assert(fg::traits::node::can_process_one_with_simd<multiply<float>>);
 #endif
 
 template<typename T, char op>
@@ -141,7 +141,7 @@ public:
 
 ENABLE_REFLECTION_FOR_TEMPLATE(converting_multiply, in, out);
 #if !DISABLE_SIMD
-static_assert(fg::traits::node::can_process_simd<converting_multiply<float, double>>);
+static_assert(fg::traits::node::can_process_one_with_simd<converting_multiply<float, double>>);
 #endif
 
 //
@@ -167,7 +167,7 @@ public:
 
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, int addend), (add<T, addend>), in, out);
 #if !DISABLE_SIMD
-static_assert(fg::traits::node::can_process_simd<add<float, 1>>);
+static_assert(fg::traits::node::can_process_one_with_simd<add<float, 1>>);
 #endif
 
 //
@@ -257,7 +257,7 @@ public:
 
 // gen_operation_SIMD has built-in SIMD-enabled work function, that means
 // we don't see it as a SIMD-enabled node as we can not do simd<simd<something>>
-static_assert(not fg::traits::node::can_process_simd<gen_operation_SIMD<float, '*'>>);
+static_assert(not fg::traits::node::can_process_one_with_simd<gen_operation_SIMD<float, '*'>>);
 
 template<typename T>
 using multiply_SIMD = gen_operation_SIMD<T, '*'>;

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -108,7 +108,10 @@ using add_bulk = math_bulk_op<T, '+'>;
 template<typename T>
 using sub_bulk = math_bulk_op<T, '-'>;
 
+// Clang 15 and 16 crash on the following static_assert
+#ifndef __clang__
 static_assert(fg::traits::node::process_bulk_requires_ith_output_as_span<multiply_bulk<float>, 0>);
+#endif
 
 //
 // This defines a new node type that has only type template parameters.

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -108,6 +108,8 @@ using add_bulk = math_bulk_op<T, '+'>;
 template<typename T>
 using sub_bulk = math_bulk_op<T, '-'>;
 
+static_assert(fg::traits::node::process_bulk_requires_ith_output_as_span<multiply_bulk<float>, 0>);
+
 //
 // This defines a new node type that has only type template parameters.
 //

--- a/bench/bm_case1.cpp
+++ b/bench/bm_case1.cpp
@@ -54,7 +54,7 @@ using divide = math_op<T, '/'>;
 // template<typename T> using sub = math_op<T, '-'>;
 
 #if !DISABLE_SIMD
-static_assert(fg::traits::node::can_process_one_with_simd<multiply<float>>);
+static_assert(fg::traits::node::can_process_one_simd<multiply<float>>);
 #endif
 
 template<typename T, char op>
@@ -141,7 +141,7 @@ public:
 
 ENABLE_REFLECTION_FOR_TEMPLATE(converting_multiply, in, out);
 #if !DISABLE_SIMD
-static_assert(fg::traits::node::can_process_one_with_simd<converting_multiply<float, double>>);
+static_assert(fg::traits::node::can_process_one_simd<converting_multiply<float, double>>);
 #endif
 
 //
@@ -167,7 +167,7 @@ public:
 
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, int addend), (add<T, addend>), in, out);
 #if !DISABLE_SIMD
-static_assert(fg::traits::node::can_process_one_with_simd<add<float, 1>>);
+static_assert(fg::traits::node::can_process_one_simd<add<float, 1>>);
 #endif
 
 //
@@ -257,7 +257,7 @@ public:
 
 // gen_operation_SIMD has built-in SIMD-enabled work function, that means
 // we don't see it as a SIMD-enabled node as we can not do simd<simd<something>>
-static_assert(not fg::traits::node::can_process_one_with_simd<gen_operation_SIMD<float, '*'>>);
+static_assert(not fg::traits::node::can_process_one_simd<gen_operation_SIMD<float, '*'>>);
 
 template<typename T>
 using multiply_SIMD = gen_operation_SIMD<T, '*'>;
@@ -394,12 +394,12 @@ loop_over_process_one(auto &node) {
     test::n_samples_consumed = 0LU;
 #if DISABLE_SIMD
     for (std::size_t i = 0; i < N_SAMPLES; i++) {
-        node.process_one();
+        node.process_one(i);
     }
 #else
     constexpr int N = 32;
     for (std::size_t i = 0; i < N_SAMPLES / N; i++) {
-        node.template process_one_simd(std::integral_constant<std::size_t, N>{});
+        node.template process_one_simd(i, std::integral_constant<std::size_t, N>{});
     }
 #endif
     expect(eq(test::n_samples_produced, N_SAMPLES)) << "produced too many/few samples";
@@ -431,7 +431,11 @@ inline const boost::ut::suite _constexpr_bm = [] {
     }
 
     {
-        auto merged_node                                                  = merge<"out", "in">(merge<"out", "in">(test::source<float>(N_SAMPLES), copy<float>()), test::sink<float>());
+        auto merged_node = merge<"out", "in">(merge<"out", "in">(test::source<float>(N_SAMPLES), copy<float>()), test::sink<float>());
+#if !DISABLE_SIMD
+        static_assert(fair::graph::traits::node::can_process_one_simd<copy<float>>);
+        static_assert(fair::graph::traits::node::can_process_one_simd<test::sink<float>>);
+#endif
         "merged src->copy->sink"_benchmark.repeat<N_ITER>(N_SAMPLES)      = [&merged_node]() { loop_over_process_one(merged_node); };
         "merged src->copy->sink work"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&merged_node]() { loop_over_work(merged_node); };
     }

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -67,6 +67,7 @@ function(set_project_warnings project_name)
           -Wuseless-cast # warn if you perform a cast to the same type
           -Wno-interference-size # suppress ABI compatibility warnings for hardware inferred size
           -Wno-maybe-uninitialized # false positives if asan is enabled: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=1056h6
+          -fconcepts-diagnostics-depth=3
           )
 
   if(MSVC)

--- a/include/circular_buffer.hpp
+++ b/include/circular_buffer.hpp
@@ -307,6 +307,11 @@ class circular_buffer
         }
     }
 
+    constexpr bool
+    is_published() const noexcept {
+        return _published_data;
+    }
+
     constexpr std::size_t size() const noexcept { return _n_slots_to_claim; };
     constexpr std::size_t size_bytes() const noexcept { return _n_slots_to_claim * sizeof(T); };
     constexpr bool empty() const noexcept { return _n_slots_to_claim == 0; }

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -368,7 +368,7 @@ public:
             if (availableSamples < port.min_buffer_size()) availableSamples = 0;
             if (availableSamples > port.max_buffer_size()) availableSamples = port.max_buffer_size();
 
-            if (port.tagReader().available() == 0) {
+            if (port.tagReader().available() == 0) [[likely]] {
                 return { availableSamples, std::numeric_limits<std::size_t>::max() }; // default: no tags in sight
             }
 

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -654,7 +654,7 @@ protected:
 
             if constexpr ((is_sink_node or meta::simdize_size_v<output_simd_types> != 0) and ((is_source_node and requires(Derived &d) {
                                                                                                   { d.process_one_simd(width) };
-                                                                                              }) or (meta::simdize_size_v<input_simd_types> != 0 and traits::node::can_process_simd<Derived>))) {
+                                                                                              }) or (meta::simdize_size_v<input_simd_types> != 0 and traits::node::can_process_one_with_simd<Derived>))) {
                 // SIMD loop
                 std::size_t i = 0;
                 for (; i + width <= samples_to_process; i += width) {
@@ -886,7 +886,7 @@ public:
     }
 
     template<meta::any_simd... Ts>
-        requires traits::node::can_process_simd<Left> && traits::node::can_process_simd<Right>
+        requires traits::node::can_process_one_with_simd<Left> && traits::node::can_process_one_with_simd<Right>
     constexpr meta::simdize<return_type, meta::simdize_size_v<std::tuple<Ts...>>>
     process_one(const Ts &...inputs) {
         static_assert(traits::node::output_port_types<Left>::size == 1, "TODO: SIMD for multiple output ports not implemented yet");
@@ -895,7 +895,7 @@ public:
 
     constexpr auto
     process_one_simd(auto N)
-        requires traits::node::can_process_simd<Right>
+        requires traits::node::can_process_one_with_simd<Right>
     {
         if constexpr (requires(Left &l) {
                           { l.process_one_simd(N) };
@@ -914,7 +914,7 @@ public:
 
     template<typename... Ts>
     // Nicer error messages for the following would be good, but not at the expense of breaking
-    // can_process_simd.
+    // can_process_one_with_simd.
         requires(input_port_types::template are_equal<std::remove_cvref_t<Ts>...>)
     constexpr return_type
     process_one(Ts &&...inputs) {
@@ -1045,8 +1045,10 @@ public:
 
 static_assert(traits::node::input_port_types<copy>::size() == 1);
 static_assert(std::same_as<traits::node::return_type<copy>, float>);
-static_assert(traits::node::can_process_simd<copy>);
-static_assert(traits::node::can_process_simd<decltype(merge_by_index<0, 0>(copy(), copy()))>);
+static_assert(traits::node::can_process_one_with_scalar<copy>);
+static_assert(traits::node::can_process_one_with_simd<copy>);
+static_assert(traits::node::can_process_one_with_scalar<decltype(merge_by_index<0, 0>(copy(), copy()))>);
+static_assert(traits::node::can_process_one_with_simd<decltype(merge_by_index<0, 0>(copy(), copy()))>);
 } // namespace test
 #endif
 

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -426,7 +426,7 @@ public:
     void
     write_to_outputs(std::size_t available_values_count, auto &writers_tuple) noexcept {
         if constexpr (traits::node::output_ports<Derived>::size > 0) {
-            meta::tuple_for_each(
+            meta::tuple_for_each_enumerate(
                     [available_values_count](auto i, auto &output_range) {
                         if constexpr (traits::node::can_process_one<Derived> or traits::node::process_bulk_requires_ith_output_as_span<Derived, i>) {
                             output_range.publish(available_values_count);

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -42,6 +42,14 @@ simdize_tuple_load_and_apply(auto width, const std::tuple<Ts...> &rngs, auto off
     }(std::make_index_sequence<sizeof...(Ts)>());
 }
 
+template<typename T, typename... Us>
+auto
+invoke_process_one_with_or_without_offset(T &node, std::size_t offset, const Us &...inputs) {
+    if constexpr (traits::node::can_process_one_with_offset<T>) return node.process_one(offset, inputs...);
+    else
+        return node.process_one(inputs...);
+}
+
 enum class work_return_status_t {
     ERROR                     = -100, /// error occurred in the work function
     INSUFFICIENT_OUTPUT_ITEMS = -3,   /// work requires a larger output buffer to produce output
@@ -125,14 +133,14 @@ concept NodeType = requires(T t, std::size_t requested_work) {
     // requires !std::is_move_assignable_v<T>;
 };
 
-template<typename Derived> // TODO: nail down the required method parameters and return types
-concept HasProcessOneFunction = requires { &Derived::process_one; };
+template<typename Derived>
+concept HasProcessOneFunction = traits::node::can_process_one<Derived>;
 
 template<typename Derived> // TODO: nail down the required method parameters and return types
 concept HasProcessBulkFunction = requires { &Derived::process_bulk; };
 
 template<typename Derived> // TODO: nail down the required method parameters and return types
-concept HasRequiredProcessFunction = HasProcessOneFunction<Derived> != HasProcessBulkFunction<Derived>;
+concept HasRequiredProcessFunction = (HasProcessOneFunction<Derived> + HasProcessBulkFunction<Derived>) == 1;
 
 /**
  * @brief The 'node<Derived>' is a base class for blocks that perform specific signal processing operations. It stores
@@ -427,31 +435,31 @@ public:
 
     template<typename... Ts>
     constexpr auto
-    invoke_process_one(Ts &&...inputs) {
+    invoke_process_one(std::size_t offset, Ts &&...inputs) {
         if constexpr (traits::node::output_ports<Derived>::size == 0) {
-            self().process_one(std::forward<Ts>(inputs)...);
+            invoke_process_one_with_or_without_offset(self(), offset, std::forward<Ts>(inputs)...);
             return std::tuple{};
         } else if constexpr (traits::node::output_ports<Derived>::size == 1) {
-            return std::tuple{ self().process_one(std::forward<Ts>(inputs)...) };
+            return std::tuple{ invoke_process_one_with_or_without_offset(self(), offset, std::forward<Ts>(inputs)...) };
         } else {
-            return self().process_one(std::forward<Ts>(inputs)...);
+            return invoke_process_one_with_or_without_offset(self(), offset, std::forward<Ts>(inputs)...);
         }
     }
 
     template<typename... Ts>
     constexpr auto
-    invoke_process_one_simd(auto width, Ts &&...input_simds) {
+    invoke_process_one_simd(std::size_t offset, auto width, Ts &&...input_simds) {
         if constexpr (sizeof...(Ts) == 0) {
             if constexpr (traits::node::output_ports<Derived>::size == 0) {
-                self().process_one_simd(width);
+                self().process_one_simd(offset, width);
                 return std::tuple{};
             } else if constexpr (traits::node::output_ports<Derived>::size == 1) {
-                return std::tuple{ self().process_one_simd(width) };
+                return std::tuple{ self().process_one_simd(offset, width) };
             } else {
-                return self().process_one_simd(width);
+                return self().process_one_simd(offset, width);
             }
         } else {
-            return invoke_process_one(std::forward<Ts>(input_simds)...);
+            return invoke_process_one(offset, std::forward<Ts>(input_simds)...);
         }
     }
 
@@ -642,8 +650,7 @@ protected:
             const bool success = consume_readers(self(), samples_to_process);
             forward_tags();
             return { requested_work, samples_to_process, success ? ret : work_return_status_t::ERROR };
-        } else {
-            //       if constexpr (HasProcessOneFunction<Derived>) { // TODO: nail down the required method parameters and return types
+        } else if constexpr (HasProcessOneFunction<Derived>) {
             // handle process_one(...)
             using input_simd_types  = meta::simdize<typename input_types::template apply<std::tuple>>;
             using output_simd_types = meta::simdize<typename output_types::template apply<std::tuple>>;
@@ -654,16 +661,16 @@ protected:
 
             if constexpr ((is_sink_node or meta::simdize_size_v<output_simd_types> != 0) and ((is_source_node and requires(Derived &d) {
                                                                                                   { d.process_one_simd(width) };
-                                                                                              }) or (meta::simdize_size_v<input_simd_types> != 0 and traits::node::can_process_one_with_simd<Derived>))) {
+                                                                                              }) or (meta::simdize_size_v<input_simd_types> != 0 and traits::node::can_process_one_simd<Derived>))) {
                 // SIMD loop
                 std::size_t i = 0;
                 for (; i + width <= samples_to_process; i += width) {
-                    const auto &results = simdize_tuple_load_and_apply(width, input_spans, i, [&](const auto &...input_simds) { return invoke_process_one_simd(width, input_simds...); });
+                    const auto &results = simdize_tuple_load_and_apply(width, input_spans, i, [&](const auto &...input_simds) { return invoke_process_one_simd(i, width, input_simds...); });
                     meta::tuple_for_each([i](auto &output_range, const auto &result) { result.copy_to(output_range.data() + i, stdx::element_aligned); }, writers_tuple, results);
                 }
                 simd_epilogue(width, [&](auto w) {
                     if (i + w <= samples_to_process) {
-                        const auto results = simdize_tuple_load_and_apply(w, input_spans, i, [&](auto &&...input_simds) { return invoke_process_one_simd(w, input_simds...); });
+                        const auto results = simdize_tuple_load_and_apply(w, input_spans, i, [&](auto &&...input_simds) { return invoke_process_one_simd(i, w, input_simds...); });
                         meta::tuple_for_each([i](auto &output_range, auto &result) { result.copy_to(output_range.data() + i, stdx::element_aligned); }, writers_tuple, results);
                         i += w;
                     }
@@ -671,7 +678,7 @@ protected:
             } else {
                 // Non-SIMD loop
                 for (std::size_t i = 0; i < samples_to_process; ++i) {
-                    const auto results = std::apply([this, i](auto &...inputs) { return this->invoke_process_one(inputs[i]...); }, input_spans);
+                    const auto results = std::apply([this, i](auto &...inputs) { return this->invoke_process_one(i, inputs[i]...); }, input_spans);
                     meta::tuple_for_each([i](auto &output_range, auto &result) { output_range[i] = std::move(result); }, writers_tuple, results);
                 }
             }
@@ -772,36 +779,14 @@ node_description() noexcept {
 }
 
 template<typename Node>
-concept source_node = requires(Node &node, typename traits::node::input_port_types<Node>::tuple_type const &inputs) {
-    {
-        [](Node &n, auto &inputs) {
-            constexpr std::size_t port_count = traits::node::input_port_types<Node>::size;
-            if constexpr (port_count > 0) {
-                return []<std::size_t... Is>(Node &n_inside, auto const &tup, std::index_sequence<Is...>) -> decltype(n_inside.process_one(std::get<Is>(tup)...)) {
-                    return {};
-                }(n, inputs, std::make_index_sequence<port_count>());
-            } else {
-                return n.process_one();
-            }
-        }(node, inputs)
-    } -> std::same_as<typename traits::node::return_type<Node>>;
-};
+concept source_node = traits::node::can_process_one<Node> and traits::node::template output_port_types<Node>::size > 0;
+
+static_assert(not source_node<int>);
 
 template<typename Node>
-concept sink_node = requires(Node &node, typename traits::node::input_port_types<Node>::tuple_type const &inputs) {
-    {
-        [](Node &n, auto &inputs) {
-            constexpr std::size_t port_count = traits::node::output_port_types<Node>::size;
-            []<std::size_t... Is>(Node &n_inside, auto const &tup, std::index_sequence<Is...>) {
-                if constexpr (port_count > 0) {
-                    std::ignore = n_inside.process_one(std::get<Is>(tup)...);
-                } else {
-                    n_inside.process_one(std::get<Is>(tup)...);
-                }
-            }(n, inputs, std::make_index_sequence<traits::node::input_port_types<Node>::size>());
-        }(node, inputs)
-    };
-};
+concept sink_node = traits::node::can_process_one<Node> and traits::node::template input_port_types<Node>::size > 0;
+
+static_assert(not sink_node<int>);
 
 template<source_node Left, sink_node Right, std::size_t OutId, std::size_t InId>
 class merged_node : public node<merged_node<Left, Right, OutId, InId>, meta::concat<typename traits::node::input_ports<Left>, meta::remove_at<InId, typename traits::node::input_ports<Right>>>,
@@ -853,18 +838,21 @@ private:
 
     template<std::size_t I>
     constexpr auto
-    apply_left(auto &&input_tuple) noexcept {
-        return [&]<std::size_t... Is>(std::index_sequence<Is...>) { return left.process_one(std::get<Is>(std::forward<decltype(input_tuple)>(input_tuple))...); }(std::make_index_sequence<I>());
+    apply_left(std::size_t offset, auto &&input_tuple) noexcept {
+        return [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+            return invoke_process_one_with_or_without_offset(left, offset, std::get<Is>(std::forward<decltype(input_tuple)>(input_tuple))...);
+        }(std::make_index_sequence<I>());
     }
 
     template<std::size_t I, std::size_t J>
     constexpr auto
-    apply_right(auto &&input_tuple, auto &&tmp) noexcept {
+    apply_right(std::size_t offset, auto &&input_tuple, auto &&tmp) noexcept {
         return [&]<std::size_t... Is, std::size_t... Js>(std::index_sequence<Is...>, std::index_sequence<Js...>) {
             constexpr std::size_t first_offset  = traits::node::input_port_types<Left>::size;
             constexpr std::size_t second_offset = traits::node::input_port_types<Left>::size + sizeof...(Is);
             static_assert(second_offset + sizeof...(Js) == std::tuple_size_v<std::remove_cvref_t<decltype(input_tuple)>>);
-            return right.process_one(std::get<first_offset + Is>(std::forward<decltype(input_tuple)>(input_tuple))..., std::forward<decltype(tmp)>(tmp), std::get<second_offset + Js>(input_tuple)...);
+            return invoke_process_one_with_or_without_offset(right, offset, std::get<first_offset + Is>(std::forward<decltype(input_tuple)>(input_tuple))..., std::forward<decltype(tmp)>(tmp),
+                                                             std::get<second_offset + Js>(input_tuple)...);
         }(std::make_index_sequence<I>(), std::make_index_sequence<J>());
     }
 
@@ -886,51 +874,56 @@ public:
     }
 
     template<meta::any_simd... Ts>
-        requires traits::node::can_process_one_with_simd<Left> && traits::node::can_process_one_with_simd<Right>
+        requires traits::node::can_process_one_simd<Left> and traits::node::can_process_one_simd<Right>
     constexpr meta::simdize<return_type, meta::simdize_size_v<std::tuple<Ts...>>>
-    process_one(const Ts &...inputs) {
+    process_one(std::size_t offset, const Ts &...inputs) {
         static_assert(traits::node::output_port_types<Left>::size == 1, "TODO: SIMD for multiple output ports not implemented yet");
-        return apply_right<InId, traits::node::input_port_types<Right>::size() - InId - 1>(std::tie(inputs...), apply_left<traits::node::input_port_types<Left>::size()>(std::tie(inputs...)));
+        return apply_right<InId, traits::node::input_port_types<Right>::size() - InId - 1>(offset, std::tie(inputs...),
+                                                                                           apply_left<traits::node::input_port_types<Left>::size()>(offset, std::tie(inputs...)));
     }
 
     constexpr auto
-    process_one_simd(auto N)
-        requires traits::node::can_process_one_with_simd<Right>
+    process_one_simd(std::size_t offset, auto N)
+        requires traits::node::can_process_one_simd<Right>
     {
         if constexpr (requires(Left &l) {
-                          { l.process_one_simd(N) };
+                          { l.process_one_simd(offset, N) };
                       }) {
-            return right.process_one(left.process_one_simd(N));
+            return invoke_process_one_with_or_without_offset(right, offset, left.process_one_simd(offset, N));
+        } else if constexpr (requires(Left &l) {
+                                 { l.process_one_simd(N) };
+                             }) {
+            return invoke_process_one_with_or_without_offset(right, offset, left.process_one_simd(N));
         } else {
             using LeftResult = typename traits::node::return_type<Left>;
             using V          = meta::simdize<LeftResult, N>;
             alignas(stdx::memory_alignment_v<V>) LeftResult tmp[V::size()];
             for (std::size_t i = 0; i < V::size(); ++i) {
-                tmp[i] = left.process_one();
+                tmp[i] = invoke_process_one_with_or_without_offset(left, offset + i);
             }
-            return right.process_one(V(tmp, stdx::vector_aligned));
+            return invoke_process_one_with_or_without_offset(right, offset, V(tmp, stdx::vector_aligned));
         }
     }
 
     template<typename... Ts>
-    // Nicer error messages for the following would be good, but not at the expense of breaking
-    // can_process_one_with_simd.
+    // Nicer error messages for the following would be good, but not at the expense of breaking can_process_one_simd.
         requires(input_port_types::template are_equal<std::remove_cvref_t<Ts>...>)
     constexpr return_type
-    process_one(Ts &&...inputs) {
+    process_one(std::size_t offset, Ts &&...inputs) {
         // if (sizeof...(Ts) == 0) we could call `return process_one_simd(integral_constant<size_t, width>)`. But if
         // the caller expects to process *one* sample (no inputs for the caller to explicitly
         // request simd), and we process more, we risk inconsistencies.
         if constexpr (traits::node::output_port_types<Left>::size == 1) {
             // only the result from the right node needs to be returned
-            return apply_right<InId, traits::node::input_port_types<Right>::size() - InId - 1>(std::forward_as_tuple(std::forward<Ts>(inputs)...),
-                                                                                               apply_left<traits::node::input_port_types<Left>::size()>(
-                                                                                                       std::forward_as_tuple(std::forward<Ts>(inputs)...)));
+            return apply_right<InId, traits::node::input_port_types<Right>::size() - InId - 1>(offset, std::forward_as_tuple(std::forward<Ts>(inputs)...),
+                                                                                               apply_left<traits::node::input_port_types<Left>::size()>(offset, std::forward_as_tuple(
+                                                                                                                                                                        std::forward<Ts>(inputs)...)));
 
         } else {
             // left produces a tuple
-            auto left_out  = apply_left<traits::node::input_port_types<Left>::size()>(std::forward_as_tuple(std::forward<Ts>(inputs)...));
-            auto right_out = apply_right<InId, traits::node::input_port_types<Right>::size() - InId - 1>(std::forward_as_tuple(std::forward<Ts>(inputs)...), std::move(std::get<OutId>(left_out)));
+            auto left_out  = apply_left<traits::node::input_port_types<Left>::size()>(offset, std::forward_as_tuple(std::forward<Ts>(inputs)...));
+            auto right_out = apply_right<InId, traits::node::input_port_types<Right>::size() - InId - 1>(offset, std::forward_as_tuple(std::forward<Ts>(inputs)...),
+                                                                                                         std::move(std::get<OutId>(left_out)));
 
             if constexpr (traits::node::output_port_types<Left>::size == 2 && traits::node::output_port_types<Right>::size == 1) {
                 return std::make_tuple(std::move(std::get<OutId ^ 1>(left_out)), std::move(right_out));
@@ -1045,10 +1038,14 @@ public:
 
 static_assert(traits::node::input_port_types<copy>::size() == 1);
 static_assert(std::same_as<traits::node::return_type<copy>, float>);
-static_assert(traits::node::can_process_one_with_scalar<copy>);
-static_assert(traits::node::can_process_one_with_simd<copy>);
-static_assert(traits::node::can_process_one_with_scalar<decltype(merge_by_index<0, 0>(copy(), copy()))>);
-static_assert(traits::node::can_process_one_with_simd<decltype(merge_by_index<0, 0>(copy(), copy()))>);
+static_assert(traits::node::can_process_one_scalar<copy>);
+static_assert(traits::node::can_process_one_simd<copy>);
+static_assert(traits::node::can_process_one_scalar_with_offset<decltype(merge_by_index<0, 0>(copy(), copy()))>);
+static_assert(traits::node::can_process_one_simd_with_offset<decltype(merge_by_index<0, 0>(copy(), copy()))>);
+static_assert(source_node<copy>);
+static_assert(sink_node<copy>);
+static_assert(source_node<decltype(merge_by_index<0, 0>(copy(), copy()))>);
+static_assert(sink_node<decltype(merge_by_index<0, 0>(copy(), copy()))>);
 } // namespace test
 #endif
 

--- a/include/node_traits.hpp
+++ b/include/node_traits.hpp
@@ -161,7 +161,7 @@ can_process_simd_invoke_test(auto &node, const auto &input, std::index_sequence<
  * `process_one_simd(integral_constant)`, which returns SIMD object(s) of width N.
  */
 template<typename Node>
-concept can_process_simd
+concept can_process_one_with_simd
         =
 #if DISABLE_SIMD
         false;
@@ -177,6 +177,17 @@ concept can_process_simd
           };
 #endif
 
-} // namespace node
+template<typename Node>
+concept can_process_one_with_scalar
+= requires(Node &node, const typename traits::node::input_port_types<Node>::template apply<std::tuple> &inputs) {
+  { detail::can_process_simd_invoke_test(
+      node, inputs, std::make_index_sequence<traits::node::input_ports<Node>::size()>())
+  };
+};
+
+template<typename Node>
+concept can_process_one = can_process_one_with_scalar<Node> or can_process_one_with_simd<Node>;
+
+} // namespace fair::graph::traits::node
 
 #endif // include guard

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -379,11 +379,19 @@ safe_pair_min(Arg &&arg, Args &&...args) {
 }
 
 template<typename Function, typename Tuple, typename... Tuples>
-auto
+void
 tuple_for_each(Function &&function, Tuple &&tuple, Tuples &&...tuples) {
     static_assert(((std::tuple_size_v<std::remove_cvref_t<Tuple>> == std::tuple_size_v<std::remove_cvref_t<Tuples>>) &&...));
-    return [&]<std::size_t... Idx>(std::index_sequence<Idx...>) {
-        (([&function, &tuple, &tuples...](auto I) { function(std::get<I>(tuple), std::get<I>(tuples)...); }(std::integral_constant<std::size_t, Idx>{}), ...));
+    [&]<std::size_t... Idx>(std::index_sequence<Idx...>) {
+        (
+                [&function](auto I, auto &&t0, auto &&...ts) {
+                    if constexpr (requires { function(std::get<I>(t0), std::get<I>(ts)...); }) {
+                        function(std::get<I>(t0), std::get<I>(ts)...);
+                    } else {
+                        function(I, std::get<I>(t0), std::get<I>(ts)...);
+                    }
+                }(std::integral_constant<std::size_t, Idx>{}, tuple, tuples...),
+                ...);
     }(std::make_index_sequence<std::tuple_size_v<std::remove_cvref_t<Tuple>>>());
 }
 

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -239,7 +239,9 @@ template<typename T, std::size_t N>
 using deduced_simd = stdx::simd<T, stdx::simd_abi::deduce_t<T, N>>;
 
 template<typename T, std::size_t N>
-struct simdize_impl;
+struct simdize_impl {
+    using type = T;
+};
 
 template<vectorizable_v T, std::size_t N>
     requires requires { typename stdx::native_simd<T>; }
@@ -270,6 +272,7 @@ struct simdize_impl<Tup, N> {
  * into a stdx::simd or std::tuple (recursively) of stdx::simd. If N is non-zero, N determines the
  * resulting SIMD width. Otherwise, of all vectorizable types U the maximum
  * stdx::native_simd<U>::size() determines the resulting SIMD width.
+ * If T is neither vectorizable nor a std::tuple with at least one member, simdize produces T.
  */
 template<typename T, std::size_t N = 0>
 using simdize = typename detail::simdize_impl<T, N>::type;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ main() {
 
         int                r = 0;
         for (std::size_t i = 0; i < 4; ++i) {
-            r += merged.process_one(a[i], b[i]);
+            r += merged.process_one(i, a[i], b[i]);
         }
 
         fmt::print("Result of graph execution: {}\n", r);
@@ -109,7 +109,7 @@ main() {
         std::array<int, 4> a = { 1, 2, 3, 4 };
 
         for (std::size_t i = 0; i < 4; ++i) {
-            auto tuple    = merged.process_one(a[i]);
+            auto tuple    = merged.process_one(i, a[i]);
             auto [r1, r2] = tuple;
             fmt::print("{} {} \n", r1, r2);
         }
@@ -124,7 +124,7 @@ main() {
 
         int                r = 0;
         for (std::size_t i = 0; i < 4; ++i) {
-            r += merged.process_one(a[i], b[i]);
+            r += merged.process_one(i, a[i], b[i]);
         }
 
         fmt::print("Result of graph execution: {}\n", r);
@@ -139,7 +139,7 @@ main() {
         std::array<int, 4> a = { 1, 2, 3, 4 };
 
         for (std::size_t i = 0; i < 4; ++i) {
-            auto tuple            = merged.process_one(a[i]);
+            auto tuple            = merged.process_one(i, a[i]);
             auto [r1, r2, r3, r4] = tuple;
             fmt::print("{} {} {} {} \n", r1, r2, r3, r4);
         }
@@ -151,13 +151,13 @@ main() {
         auto random = count_source<int>{};
 
         auto merged = merge_by_index<0, 0>(std::move(random), expect_sink<int>());
-        merged.process_one();
+        merged.process_one(0);
     }
 
     {
         auto random = count_source<int>{};
 
         auto merged = merge<"random", "original">(std::move(random), scale<int, 2>());
-        merged.process_one();
+        merged.process_one(0);
     }
 }

--- a/test/blocklib/core/unit-test/tag_monitors.hpp
+++ b/test/blocklib/core/unit-test/tag_monitors.hpp
@@ -47,7 +47,8 @@ struct TagSource : public node<TagSource<T, UseProcessOne>> {
     constexpr std::make_signed_t<std::size_t>
     available_samples(const TagSource &) noexcept {
         if constexpr (UseProcessOne == ProcessFunction::USE_PROCESS_ONE) {
-            return n_samples_produced < n_samples_max ? 1 : -1; // '-1' -> DONE, produced enough samples
+            // '-1' -> DONE, produced enough samples
+            return n_samples_max == n_samples_produced ? -1 : n_samples_max - n_samples_produced;
         } else if constexpr (UseProcessOne == ProcessFunction::USE_PROCESS_BULK) {
             tag_t::signed_index_type nextTagIn = next_tag < tags.size() ? tags[next_tag].index - n_samples_produced : n_samples_max - n_samples_produced;
             return n_samples_produced < n_samples_max ? std::max(1L, nextTagIn) : -1L; // '-1L' -> DONE, produced enough samples
@@ -57,14 +58,14 @@ struct TagSource : public node<TagSource<T, UseProcessOne>> {
     }
 
     T
-    process_one() noexcept
+    process_one(std::size_t offset) noexcept
         requires(UseProcessOne == ProcessFunction::USE_PROCESS_ONE)
     {
         if (next_tag < tags.size() && tags[next_tag].index <= n_samples_produced) {
             print_tag(tags[next_tag], fmt::format("{}::process_one(...)\t publish tag at  {:6}", this->name.value, n_samples_produced));
             tag_t &out_tag = this->output_tags()[0];
             out_tag        = tags[next_tag];
-            out_tag.index  = 0; // indices > 0 write tags in the future ... handle with care
+            out_tag.index  = offset;
             this->forward_tags();
             next_tag++;
             n_samples_produced++;
@@ -92,9 +93,6 @@ struct TagSource : public node<TagSource<T, UseProcessOne>> {
         return n_samples_produced < n_samples_max ? work_return_status_t::OK : work_return_status_t::DONE;
     }
 };
-
-static_assert(HasRequiredProcessFunction<TagSource<int, ProcessFunction::USE_PROCESS_ONE>>);
-static_assert(HasRequiredProcessFunction<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>);
 
 template<typename T, ProcessFunction UseProcessOne>
 struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
@@ -135,13 +133,6 @@ struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
     }
 };
 
-static_assert(HasProcessOneFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
-static_assert(not HasProcessOneFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
-static_assert(not HasProcessBulkFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
-static_assert(HasProcessBulkFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
-static_assert(HasRequiredProcessFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
-static_assert(HasRequiredProcessFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
-
 template<typename T, ProcessFunction UseProcessOne>
 struct TagSink : public node<TagSink<T, UseProcessOne>> {
     IN<T>              in;
@@ -180,13 +171,30 @@ struct TagSink : public node<TagSink<T, UseProcessOne>> {
     }
 };
 
-static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_ONE>>);
-static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_BULK>>);
-
 } // namespace fair::graph::tag_test
 
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b), (fair::graph::tag_test::TagSource<T, b>), out, n_samples_max);
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b), (fair::graph::tag_test::TagMonitor<T, b>), in, out);
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, fair::graph::tag_test::ProcessFunction b), (fair::graph::tag_test::TagSink<T, b>), in);
+
+namespace fair::graph::tag_test {
+// the concepts can only work as expected after ENABLE_REFLECTION_FOR_TEMPLATE_FULL
+static_assert(HasProcessOneFunction<TagSource<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(not HasProcessBulkFunction<TagSource<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(HasRequiredProcessFunction<TagSource<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(not HasProcessOneFunction<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>);
+static_assert(HasProcessBulkFunction<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>);
+static_assert(HasRequiredProcessFunction<TagSource<int, ProcessFunction::USE_PROCESS_BULK>>);
+
+static_assert(HasProcessOneFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(not HasProcessOneFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
+static_assert(not HasProcessBulkFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(HasProcessBulkFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
+static_assert(HasRequiredProcessFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(HasRequiredProcessFunction<TagMonitor<int, ProcessFunction::USE_PROCESS_BULK>>);
+
+static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_ONE>>);
+static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_BULK>>);
+} // namespace fair::graph::tag_test
 
 #endif // GRAPH_PROTOTYPE_TAG_MONITORS_HPP

--- a/test/qa_tags.cpp
+++ b/test/qa_tags.cpp
@@ -60,7 +60,7 @@ const boost::ut::suite TagPropagation = [] {
     using namespace fair::graph::tag_test;
 
     "tag_source"_test = [] {
-        std::uint64_t n_samples = 1024;
+        std::int64_t n_samples = 1024;
         graph flow_graph;
         auto &src = flow_graph.make_node<TagSource<float, ProcessFunction::USE_PROCESS_BULK>>(
                 {{"n_samples_max", n_samples},


### PR DESCRIPTION
For a detailed list of changes look at the commit messages.

Please review *naming*. Do you have ideas for better names?

Example: `Node::work_internal` calls `Node::invoke_process_one` / `Node::invoke_prcess_one_simd`. The latter calls `Derived::process_one_simd` for source nods (unconditionally with offset), otherwise `Node::invoke_process_one`. `Node::invoke_process_one` calls non-member `invoke_process_one_with_or_without_offset`, which in turn calls `Derived::process_one` (with or without offset argument, depending on `can_process_one_with_offset`).

For merged nodes the call stack is deeper still. (If this - for whatever reason - doesn't get `inline`d it's going to be expensive. I feel bad about omitting `always_inline`.)