### PR TITLE
CI: fix clang dependency conflicts by updating the installed clang14 package

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -63,8 +63,6 @@ jobs:
     - name: Install clang-15
       if: matrix.configurations.compiler == 'clang15'
       run: |
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
         sudo apt update
         sudo apt install -y clang-15 libc++-15-dev libc++abi-15-dev
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 110

--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -64,6 +64,7 @@ jobs:
       if: matrix.configurations.compiler == 'clang15'
       run: |
         sudo apt update
+        sudo apt upgrade -y # update clang14 to fix packaging conflicts
         sudo apt install -y clang-15 libc++-15-dev libc++abi-15-dev
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 110
 
@@ -73,6 +74,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
         sudo apt update
+        sudo apt upgrade -y # update clang14 to fix packaging conflicts
         sudo apt install -y clang-16 libc++-16-dev libc++abi-16-dev
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-16 110
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,6 @@ jobs:
     - name: Install clang-15
       if: matrix.configurations.compiler == 'clang15'
       run: |
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
         sudo apt update
         sudo apt install -y clang-15 libc++-15-dev libc++abi-15-dev
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 110

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
       if: matrix.configurations.compiler == 'clang15'
       run: |
         sudo apt update
+        sudo apt upgrade -y # update clang14 to fix packaging conflicts
         sudo apt install -y clang-15 libc++-15-dev libc++abi-15-dev
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-15 110
 
@@ -66,6 +67,7 @@ jobs:
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
         sudo apt update
+        sudo apt upgrade -y # update clang14 to fix packaging conflicts
         sudo apt install -y clang-16 libc++-16-dev libc++abi-16-dev
         sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-16 110
 


### PR DESCRIPTION
Since the last ubuntu22.04 runner image [release](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230724.1), installation of clang from the llvm mirros fails:
https://github.com/fair-acc/graph-prototype/actions/runs/5708009811/job/15465254832#step:5:121

```
$ sudo apt install -y clang-15 libc++-15-dev libc++abi-15-dev
The following packages have unmet dependencies:
 libc++1-14 : Conflicts: libc++-x.y
 libc++1-15 : Conflicts: libc++-x.y
 libc++abi1-14 : Conflicts: libc++abi-x.y
 libc++abi1-15 : Conflicts: libc++abi-x.y
 libunwind-14 : Conflicts: libunwind-x.y
 libunwind-14-dev : Conflicts: libunwind-x.y-dev
                    Breaks: libunwind-dev
 libunwind-15 : Conflicts: libunwind-x.y
 libunwind-15-dev : Conflicts: libunwind-x.y-dev
E: Error, pkgProblemResolver::Resolve generated breaks, this may be caused by held packages.
```

this switches clang15 from the llvm repository to the one from ubuntu's own repository, to see if this fixes the issue. Clang 16 ins not yet available in the ubuntu repositories unfortunately.

update: the error also occurs with installing clang15 from ubuntu's repos, but running `apt upgrade` before fixes the issues. Now trying to reduce this to only upgrade clang, as there are currently 139 outdated packages in the image that would have to be updated for every run.

update: just adding the conflicting packages to the install command did not fix the issue so we'll have to live with a full upgrade for now.

This adds ~90s of build time so it might make sense to improve this or remove it if it is not necessary any more with the next image release.