### PR TITLE
Add stride implementation for the node class.

### DIFF
--- a/include/annotated.hpp
+++ b/include/annotated.hpp
@@ -68,6 +68,11 @@ struct BlockingIO {};
 struct PerformDecimationInterpolation {};
 
 /**
+ * @brief Annotates node, indicating to perform stride
+ */
+struct PerformStride {};
+
+/**
  * @brief Annotates templated node, indicating which port data types are supported.
  */
 template<typename... Ts>

--- a/include/node.hpp
+++ b/include/node.hpp
@@ -249,14 +249,15 @@ class node : protected std::tuple<Arguments...> {
     using A = Annotated<T, description, Args...>;
 
 public:
-    using base_t                   = node<Derived, Arguments...>;
-    using derived_t                = Derived;
-    using node_template_parameters = meta::typelist<Arguments...>;
-    using Description              = typename node_template_parameters::template find_or_default<is_doc, EmptyDoc>;
-    constexpr static tag_propagation_policy_t                                                                      tag_policy  = tag_propagation_policy_t::TPP_ALL_TO_ALL;
-    A<uint64_t, "numerator", Doc<"decimation/interpolation settings">>                                             numerator   = 1_UZ;
-    A<uint64_t, "denominator", Doc<"decimation/interpolation settings">>                                           denominator = 1_UZ;
-    A<uint64_t, "stride", Doc<"stride doc">>                                                                       stride      = 1_UZ;
+    using base_t                                         = node<Derived, Arguments...>;
+    using derived_t                                      = Derived;
+    using node_template_parameters                       = meta::typelist<Arguments...>;
+    using Description                                    = typename node_template_parameters::template find_or_default<is_doc, EmptyDoc>;
+    constexpr static tag_propagation_policy_t tag_policy = tag_propagation_policy_t::TPP_ALL_TO_ALL;
+    A<std::size_t, "numerator", Doc<"The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)">>      numerator   = 1_UZ;
+    A<std::size_t, "denominator", Doc<"The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)">> denominator = 1_UZ;
+    A<std::size_t, "stride", Doc<"Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)">>                          stride      = 0_UZ;
+    std::size_t                                                                                                    stride_counter                                                                = 0_UZ;
     const std::size_t                                                                                              unique_id   = _unique_id_counter++;
     const std::string                                                                                              unique_name = fmt::format("{}#{}", fair::meta::type_name<Derived>(), unique_id);
     A<std::string, "user-defined name", Doc<"N.B. may not be unique -> ::unique_name">>                            name{ std::string(fair::meta::type_name<Derived>()) };
@@ -533,6 +534,7 @@ protected:
         constexpr bool is_source_node = input_types::size == 0;
         constexpr bool is_sink_node   = output_types::size == 0;
 
+        // TODO: these checks can be moved to setting changed
         if constexpr (node_template_parameters::template contains<PerformDecimationInterpolation>) {
             static_assert(!is_sink_node, "Decimation/interpolation is not available for sink blocks. Remove 'PerformDecimationInterpolation' from the block definition.");
             static_assert(!is_source_node, "Decimation/interpolation is not available for source blocks. Remove 'PerformDecimationInterpolation' from the block definition.");
@@ -542,6 +544,14 @@ protected:
             if (numerator != 1 || denominator != 1) {
                 throw std::runtime_error(
                         fmt::format("Block is not defined as `PerformDecimationInterpolation`, but numerator = {}, denominator = {}, they both must equal to 1.", numerator, denominator));
+            }
+        }
+
+        if constexpr (node_template_parameters::template contains<PerformStride>) {
+            static_assert(!is_source_node, "Stride is not available for source blocks. Remove 'PerformStride' from the block definition.");
+        } else {
+            if (stride != 0) {
+                throw std::runtime_error(fmt::format("Block is not defined as `PerformStride`, but stride = {}, it must equal to 0.", stride));
             }
         }
 
@@ -612,31 +622,33 @@ protected:
                 return { requested_work, 0_UZ, ports_status.in_at_least_one_port_has_data ? work_return_status_t::INSUFFICIENT_INPUT_ITEMS : work_return_status_t::DONE };
             }
 
-            if (numerator != 1. || denominator != 1.) {
-                // TODO: this ill-defined checks can be done only once after parameters were changed
-                const double ratio          = static_cast<double>(numerator) / static_cast<double>(denominator);
-                bool         is_ill_defined = (denominator > ports_status.in_max_samples) || (ports_status.in_min_samples * ratio > ports_status.out_max_samples)
-                                   || (ports_status.in_max_samples * ratio < ports_status.out_min_samples);
-                assert(!is_ill_defined);
-                if (is_ill_defined) {
-                    return { requested_work, 0_UZ, work_return_status_t::ERROR };
+            if constexpr (node_template_parameters::template contains<PerformDecimationInterpolation>) {
+                if (numerator != 1. || denominator != 1.) {
+                    // TODO: this ill-defined checks can be done only once after parameters were changed
+                    const double ratio          = static_cast<double>(numerator) / static_cast<double>(denominator);
+                    bool         is_ill_defined = (denominator > ports_status.in_max_samples) || (ports_status.in_min_samples * ratio > ports_status.out_max_samples)
+                                       || (ports_status.in_max_samples * ratio < ports_status.out_min_samples);
+                    assert(!is_ill_defined);
+                    if (is_ill_defined) {
+                        return { requested_work, 0_UZ, work_return_status_t::ERROR };
+                    }
+
+                    ports_status.in_samples          = static_cast<std::size_t>(ports_status.in_samples / denominator) * denominator; // remove reminder
+
+                    const std::size_t out_min_limit  = ports_status.out_min_samples;
+                    const std::size_t out_max_limit  = std::min(ports_status.out_available, ports_status.out_max_samples);
+
+                    std::size_t       in_min_samples = static_cast<std::size_t>(static_cast<double>(out_min_limit) / ratio);
+                    if (in_min_samples % denominator != 0) in_min_samples += denominator;
+                    std::size_t       in_min_wo_reminder = static_cast<std::size_t>(in_min_samples / denominator) * denominator;
+
+                    const std::size_t in_max_samples     = static_cast<std::size_t>(static_cast<double>(out_max_limit) / ratio);
+                    std::size_t       in_max_wo_reminder = static_cast<std::size_t>(in_max_samples / denominator) * denominator;
+
+                    if (ports_status.in_samples < in_min_wo_reminder) return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_INPUT_ITEMS };
+                    ports_status.in_samples  = std::clamp(ports_status.in_samples, in_min_wo_reminder, in_max_wo_reminder);
+                    ports_status.out_samples = numerator * (ports_status.in_samples / denominator);
                 }
-
-                ports_status.in_samples          = static_cast<std::size_t>(ports_status.in_samples / denominator) * denominator; // remove reminder
-
-                const std::size_t out_min_limit  = ports_status.out_min_samples;
-                const std::size_t out_max_limit  = std::min(ports_status.out_available, ports_status.out_max_samples);
-
-                std::size_t       in_min_samples = static_cast<std::size_t>(static_cast<double>(out_min_limit) / ratio);
-                if (in_min_samples % denominator != 0) in_min_samples += denominator;
-                std::size_t       in_min_wo_reminder = static_cast<std::size_t>(in_min_samples / denominator) * denominator;
-
-                const std::size_t in_max_samples     = static_cast<std::size_t>(static_cast<double>(out_max_limit) / ratio);
-                std::size_t       in_max_wo_reminder = static_cast<std::size_t>(in_max_samples / denominator) * denominator;
-
-                if (ports_status.in_samples < in_min_wo_reminder) return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_INPUT_ITEMS };
-                ports_status.in_samples  = std::clamp(ports_status.in_samples, in_min_wo_reminder, in_max_wo_reminder);
-                ports_status.out_samples = numerator * (ports_status.in_samples / denominator);
             }
 
             // TODO: special case for ports_status.in_samples == 0 ?
@@ -710,6 +722,38 @@ protected:
         // case sources: HW triggered vs. generating data per invocation (generators via Port::MIN)
         // case sinks: HW triggered vs. fixed-size consumer (may block/never finish for insufficient input data and fixed Port::MIN>0)
 
+        std::size_t n_samples_to_consume = ports_status.in_samples; // default stride == 0
+        if constexpr (node_template_parameters::template contains<PerformStride>) {
+            if (stride != 0) {
+                const bool first_time_stride = stride_counter == 0;
+                if (first_time_stride) {
+                    // sample processing are done as usual, ports_status.in_samples samples will be processed
+                    if (stride.value > stride_counter + ports_status.in_available) { // stride can not be consumed at once -> start stride_counter
+                        stride_counter += ports_status.in_available;
+                        n_samples_to_consume = ports_status.in_available;
+                    } else { // if the stride can be consumed at once -> no stride_counter is needed
+                        stride_counter       = 0;
+                        n_samples_to_consume = stride.value;
+                    }
+                } else {
+                    // |====================|...|====================|==============----| -> ====== is the stride
+                    //   ^first                    ^we are here (1)  or ^here (2)
+                    // if it is not the "first time" stride -> just consume (1) all samples or (2) missing rest of the samples
+                    // forward tags but no additional sample processing are done ->return
+                    if (stride.value > stride_counter + ports_status.in_available) {
+                        stride_counter += ports_status.in_available;
+                        n_samples_to_consume = ports_status.in_available;
+                    } else { // stride is at the end -> reset stride_counter
+                        n_samples_to_consume = stride.value - stride_counter;
+                        stride_counter       = 0;
+                    }
+                    const bool success = consume_readers(self(), n_samples_to_consume);
+                    forward_tags();
+                    return { requested_work, n_samples_to_consume, success ? work_return_status_t::OK : work_return_status_t::ERROR };
+                }
+            }
+        }
+
         const auto input_spans   = meta::tuple_transform([in_samples = ports_status.in_samples](auto &input_port) noexcept { return input_port.streamReader().get(in_samples); }, input_ports(&self()));
         auto       writers_tuple = meta::tuple_transform([out_samples = ports_status.out_samples](auto &output_port) noexcept { return output_port.streamWriter().reserve_output_range(out_samples); },
                                                    output_ports(&self()));
@@ -721,7 +765,7 @@ protected:
             }(std::make_index_sequence<traits::node::input_ports<Derived>::size>(), std::make_index_sequence<traits::node::output_ports<Derived>::size>());
 
             write_to_outputs(ports_status.out_samples, writers_tuple);
-            const bool success = consume_readers(self(), ports_status.in_samples);
+            const bool success = consume_readers(self(), n_samples_to_consume);
             forward_tags();
             return { requested_work, ports_status.in_samples, success ? ret : work_return_status_t::ERROR };
         } else if constexpr (HasProcessOneFunction<Derived>) {
@@ -761,7 +805,7 @@ protected:
 
             write_to_outputs(ports_status.out_samples, writers_tuple);
 
-            const bool success = consume_readers(self(), ports_status.in_samples);
+            const bool success = consume_readers(self(), n_samples_to_consume);
 
 #ifdef _DEBUG
             if (!success) {

--- a/test/grc/test.grc.expected
+++ b/test/grc/test.grc.expected
@@ -6,10 +6,10 @@ blocks:
       event_count: 100
       name: main_source
       numerator: 1
-      stride: 1
+      stride: 0
       unique_name: good::fixed_source<double>#0
       denominator::description: denominator
-      denominator::documentation: decimation/interpolation settings
+      denominator::documentation: "The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
       denominator::unit: ""
       denominator::visible: 0
       description: ""
@@ -22,11 +22,11 @@ blocks:
       name::unit: ""
       name::visible: 0
       numerator::description: numerator
-      numerator::documentation: decimation/interpolation settings
+      numerator::documentation: "The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
       numerator::unit: ""
       numerator::visible: 0
       stride::description: stride
-      stride::documentation: stride doc
+      stride::documentation: "Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)"
       stride::unit: ""
       stride::visible: 0
       unknown_property: 42
@@ -36,10 +36,10 @@ blocks:
       denominator: 1
       name: multiplier
       numerator: 1
-      stride: 1
+      stride: 0
       unique_name: good::multiply<double>#0
       denominator::description: denominator
-      denominator::documentation: decimation/interpolation settings
+      denominator::documentation: "The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
       denominator::unit: ""
       denominator::visible: 0
       description: ""
@@ -52,11 +52,11 @@ blocks:
       name::unit: ""
       name::visible: 0
       numerator::description: numerator
-      numerator::documentation: decimation/interpolation settings
+      numerator::documentation: "The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
       numerator::unit: ""
       numerator::visible: 0
       stride::description: stride
-      stride::documentation: stride doc
+      stride::documentation: "Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)"
       stride::unit: ""
       stride::visible: 0
   - name: counter
@@ -65,10 +65,10 @@ blocks:
       denominator: 1
       name: counter
       numerator: 1
-      stride: 1
+      stride: 0
       unique_name: builtin_counter<double>#0
       denominator::description: denominator
-      denominator::documentation: decimation/interpolation settings
+      denominator::documentation: "The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
       denominator::unit: ""
       denominator::visible: 0
       description: ""
@@ -81,11 +81,11 @@ blocks:
       name::unit: ""
       name::visible: 0
       numerator::description: numerator
-      numerator::documentation: decimation/interpolation settings
+      numerator::documentation: "The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
       numerator::unit: ""
       numerator::visible: 0
       stride::description: stride
-      stride::documentation: stride doc
+      stride::documentation: "Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)"
       stride::unit: ""
       stride::visible: 0
   - name: sink
@@ -94,11 +94,11 @@ blocks:
       denominator: 1
       name: sink
       numerator: 1
-      stride: 1
+      stride: 0
       total_count: 100
       unique_name: good::cout_sink<double>#0
       denominator::description: denominator
-      denominator::documentation: decimation/interpolation settings
+      denominator::documentation: "The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
       denominator::unit: ""
       denominator::visible: 0
       description: ""
@@ -111,11 +111,11 @@ blocks:
       name::unit: ""
       name::visible: 0
       numerator::description: numerator
-      numerator::documentation: decimation/interpolation settings
+      numerator::documentation: "The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
       numerator::unit: ""
       numerator::visible: 0
       stride::description: stride
-      stride::documentation: stride doc
+      stride::documentation: "Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)"
       stride::unit: ""
       stride::visible: 0
       unknown_property: 42

--- a/test/qa_node.cpp
+++ b/test/qa_node.cpp
@@ -107,7 +107,7 @@ const boost::ut::suite _fft_tests = [] {
         interpolation_decimation_test({ .n_samples{ 549 }, .numerator{ 1 }, .denominator{ 50 }, .expected_in{ 500 }, .expected_out{ 10 }, .expected_counter{ 1 } }, thread_pool);
         interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 3 }, .denominator{ 7 }, .expected_in{ 98 }, .expected_out{ 42 }, .expected_counter{ 1 } }, thread_pool);
         interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 100 }, .denominator{ 100 }, .expected_in{ 100 }, .expected_out{ 100 }, .expected_counter{ 1 } }, thread_pool);
-        
+
         interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 10 }, .denominator{ 1100 }, .expected_in{ 0 }, .expected_out{ 0 }, .expected_counter{ 0 } }, thread_pool);
         interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 1 }, .denominator{ 1001 }, .expected_in{ 0 }, .expected_out{ 0 }, .expected_counter{ 0 } }, thread_pool);
         interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 100000 }, .denominator{ 1 }, .expected_in{ 0 }, .expected_out{ 0 }, .expected_counter{ 0 } }, thread_pool);

--- a/test/qa_node.cpp
+++ b/test/qa_node.cpp
@@ -1,4 +1,5 @@
 #include <boost/ut.hpp>
+#include <vector>
 
 #if defined(__clang__) && __clang_major__ >= 16
 // clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
@@ -15,20 +16,50 @@ auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter
 namespace fg = fair::graph;
 
 struct ProcessStatus {
-    std::size_t n_inputs{ 0 };
-    std::size_t n_outputs{ 0 };
-    std::size_t process_counter{ 0 };
+    std::size_t      n_inputs{ 0 };
+    std::size_t      n_outputs{ 0 };
+    std::size_t      process_counter{ 0 };
+    std::size_t      total_in{ 0 };
+    std::size_t      total_out{ 0 };
+    std::vector<int> in_vector{};
 };
 
-struct TestData {
+struct IntDecTestData {
     std::size_t n_samples{};
     std::size_t numerator{};
     std::size_t denominator{};
-    int         out_port_min_samples{ -1 }; // -1 for not used
-    int         out_port_max_samples{ -1 }; // -1 for not used
-    std::size_t expected_in{};
-    std::size_t expected_out{};
-    std::size_t expected_counter{};
+    int         out_port_min{ -1 }; // -1 for not used
+    int         out_port_max{ -1 }; // -1 for not used
+    std::size_t exp_in{};
+    std::size_t exp_out{};
+    std::size_t exp_counter{};
+
+    std::string
+    to_string() const {
+        return fmt::format("n_samples: {}, numerator: {}, denominator: {}, out_port_min: {}, out_port_max: {}, exp_in: {}, exp_out: {}, exp_counter: {}", n_samples, numerator, denominator,
+                           out_port_min, out_port_max, exp_in, exp_out, exp_counter);
+    }
+};
+
+struct StrideTestData {
+    std::size_t      n_samples{};
+    std::size_t      numerator{ 1 };
+    std::size_t      denominator{ 1 };
+    std::size_t      stride{};
+    int              in_port_min{ -1 }; // -1 for not used
+    int              in_port_max{ -1 }; // -1 for not used
+    std::size_t      exp_in{};
+    std::size_t      exp_out{};
+    std::size_t      exp_counter{};
+    std::size_t      exp_total_in{ 0 };
+    std::size_t      exp_total_out{ 0 };
+    std::vector<int> exp_in_vector{};
+
+    std::string
+    to_string() const {
+        return fmt::format("n_samples: {}, numerator: {}, denominator: {}, stride: {}, in_port_min: {}, in_port_max: {}, exp_in: {}, exp_out: {}, exp_counter: {}, exp_total_in: {}, exp_total_out: {}",
+                           n_samples, numerator, denominator, stride, in_port_min, in_port_max, exp_in, exp_out, exp_counter, exp_total_in, exp_total_out);
+    }
 };
 
 template<typename T>
@@ -50,17 +81,21 @@ struct CountSource : public fg::node<CountSource<T>> {
 };
 
 template<typename T>
-struct IntDecBlock : public fg::node<IntDecBlock<T>, fg::PerformDecimationInterpolation> {
+struct IntDecBlock : public fg::node<IntDecBlock<T>, fg::PerformDecimationInterpolation, fg::PerformStride> {
     fg::IN<T>     in{};
     fg::OUT<T>    out{};
 
-    ProcessStatus status;
+    ProcessStatus status{};
+    bool          write_to_vector{ false };
 
     fg::work_return_status_t
     process_bulk(std::span<const T> input, std::span<T> output) noexcept {
         status.n_inputs  = input.size();
         status.n_outputs = output.size();
         status.process_counter++;
+        status.total_in += input.size();
+        status.total_out += output.size();
+        if (write_to_vector) status.in_vector.insert(status.in_vector.end(), input.begin(), input.end());
 
         return fg::work_return_status_t::OK;
     }
@@ -70,7 +105,7 @@ ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (CountSource<T>), out, count, 
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (IntDecBlock<T>), in, out);
 
 void
-interpolation_decimation_test(const TestData &data, std::shared_ptr<fair::thread_pool::BasicThreadPool> thread_pool) {
+interpolation_decimation_test(const IntDecTestData &data, std::shared_ptr<fair::thread_pool::BasicThreadPool> thread_pool) {
     using namespace boost::ut;
     using scheduler = fair::graph::scheduler::simple<>;
 
@@ -81,16 +116,49 @@ interpolation_decimation_test(const TestData &data, std::shared_ptr<fair::thread
     auto &int_dec_block       = flow.make_node<IntDecBlock<int>>();
     int_dec_block.numerator   = data.numerator;
     int_dec_block.denominator = data.denominator;
-    if (data.out_port_max_samples >= 0) int_dec_block.out.max_samples = static_cast<int>(data.out_port_max_samples);
-    if (data.out_port_min_samples >= 0) int_dec_block.out.min_samples = static_cast<int>(data.out_port_min_samples);
+    if (data.out_port_max >= 0) int_dec_block.out.max_samples = static_cast<int>(data.out_port_max);
+    if (data.out_port_min >= 0) int_dec_block.out.min_samples = static_cast<int>(data.out_port_min);
 
     std::ignore = flow.connect<"out">(source).to<"in">(int_dec_block);
     auto sched  = scheduler(std::move(flow), thread_pool);
     sched.run_and_wait();
 
-    expect(eq(int_dec_block.status.process_counter, data.expected_counter)) << "process_bulk invokes counter";
-    expect(eq(int_dec_block.status.n_inputs, data.expected_in)) << "number of input samples";
-    expect(eq(int_dec_block.status.n_outputs, data.expected_out)) << "number of output samples";
+    expect(eq(int_dec_block.status.process_counter, data.exp_counter)) << "process_bulk invokes counter, parameters = " << data.to_string();
+    expect(eq(int_dec_block.status.n_inputs, data.exp_in)) << "last number of input samples, parameters = " << data.to_string();
+    expect(eq(int_dec_block.status.n_outputs, data.exp_out)) << "last number of output samples, parameters = " << data.to_string();
+}
+
+void
+stride_test(const StrideTestData &data, std::shared_ptr<fair::thread_pool::BasicThreadPool> thread_pool) {
+    using namespace boost::ut;
+    using scheduler = fair::graph::scheduler::simple<>;
+
+    const bool write_to_vector{ data.exp_in_vector.size() != 0 };
+
+    fg::graph  flow;
+    auto      &source             = flow.make_node<CountSource<int>>();
+    source.n_samples              = static_cast<int>(data.n_samples);
+
+    auto &int_dec_block           = flow.make_node<IntDecBlock<int>>();
+    int_dec_block.write_to_vector = write_to_vector;
+    int_dec_block.numerator       = data.numerator;
+    int_dec_block.denominator     = data.denominator;
+    int_dec_block.stride          = data.stride;
+    if (data.in_port_max >= 0) int_dec_block.in.max_samples = static_cast<int>(data.in_port_max);
+    if (data.in_port_min >= 0) int_dec_block.in.min_samples = static_cast<int>(data.in_port_min);
+
+    std::ignore = flow.connect<"out">(source).to<"in">(int_dec_block);
+    auto sched  = scheduler(std::move(flow), thread_pool);
+    sched.run_and_wait();
+
+    expect(eq(int_dec_block.status.process_counter, data.exp_counter)) << "process_bulk invokes counter, parameters = " << data.to_string();
+    expect(eq(int_dec_block.status.n_inputs, data.exp_in)) << "last number of input samples, parameters = " << data.to_string();
+    expect(eq(int_dec_block.status.n_outputs, data.exp_out)) << "last number of output samples, parameters = " << data.to_string();
+    expect(eq(int_dec_block.status.total_in, data.exp_total_in)) << "total number of input samples, parameters = " << data.to_string();
+    expect(eq(int_dec_block.status.total_out, data.exp_total_out)) << "total number of output samples, parameters = " << data.to_string();
+    if (write_to_vector) {
+        expect(eq(int_dec_block.status.in_vector, data.exp_in_vector)) << "in vector of samples, parameters = " << data.to_string();
+    }
 }
 
 const boost::ut::suite _fft_tests = [] {
@@ -100,31 +168,51 @@ const boost::ut::suite _fft_tests = [] {
     auto thread_pool                      = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
 
     "Interpolation/Decimation tests"_test = [&thread_pool] {
-        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 1 }, .denominator{ 1 }, .expected_in{ 1024 }, .expected_out{ 1024 }, .expected_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 1 }, .denominator{ 2 }, .expected_in{ 1024 }, .expected_out{ 512 }, .expected_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 2 }, .denominator{ 1 }, .expected_in{ 1024 }, .expected_out{ 2048 }, .expected_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 5 }, .denominator{ 6 }, .expected_in{ 996 }, .expected_out{ 830 }, .expected_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 549 }, .numerator{ 1 }, .denominator{ 50 }, .expected_in{ 500 }, .expected_out{ 10 }, .expected_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 3 }, .denominator{ 7 }, .expected_in{ 98 }, .expected_out{ 42 }, .expected_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 100 }, .denominator{ 100 }, .expected_in{ 100 }, .expected_out{ 100 }, .expected_counter{ 1 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 1 }, .denominator{ 1 }, .exp_in{ 1024 }, .exp_out{ 1024 }, .exp_counter{ 1 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 1 }, .denominator{ 2 }, .exp_in{ 1024 }, .exp_out{ 512 }, .exp_counter{ 1 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 2 }, .denominator{ 1 }, .exp_in{ 1024 }, .exp_out{ 2048 }, .exp_counter{ 1 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 5 }, .denominator{ 6 }, .exp_in{ 996 }, .exp_out{ 830 }, .exp_counter{ 1 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 549 }, .numerator{ 1 }, .denominator{ 50 }, .exp_in{ 500 }, .exp_out{ 10 }, .exp_counter{ 1 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 3 }, .denominator{ 7 }, .exp_in{ 98 }, .exp_out{ 42 }, .exp_counter{ 1 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 100 }, .denominator{ 100 }, .exp_in{ 100 }, .exp_out{ 100 }, .exp_counter{ 1 } }, thread_pool);
 
-        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 10 }, .denominator{ 1100 }, .expected_in{ 0 }, .expected_out{ 0 }, .expected_counter{ 0 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 1 }, .denominator{ 1001 }, .expected_in{ 0 }, .expected_out{ 0 }, .expected_counter{ 0 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 100000 }, .denominator{ 1 }, .expected_in{ 0 }, .expected_out{ 0 }, .expected_counter{ 0 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 101 }, .denominator{ 101 }, .expected_in{ 0 }, .expected_out{ 0 }, .expected_counter{ 0 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 10 }, .denominator{ 1100 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 1 }, .denominator{ 1001 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 100000 }, .denominator{ 1 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 101 }, .denominator{ 101 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
 
-        interpolation_decimation_test(
-                { .n_samples{ 100 }, .numerator{ 5 }, .denominator{ 11 }, .out_port_min_samples{ 10 }, .out_port_max_samples{ 41 }, .expected_in{ 88 }, .expected_out{ 40 }, .expected_counter{ 1 } },
-                thread_pool);
-        interpolation_decimation_test(
-                { .n_samples{ 100 }, .numerator{ 7 }, .denominator{ 3 }, .out_port_min_samples{ 10 }, .out_port_max_samples{ 10 }, .expected_in{ 0 }, .expected_out{ 0 }, .expected_counter{ 0 } },
-                thread_pool);
-        interpolation_decimation_test(
-                { .n_samples{ 80 }, .numerator{ 2 }, .denominator{ 4 }, .out_port_min_samples{ 20 }, .out_port_max_samples{ 20 }, .expected_in{ 40 }, .expected_out{ 20 }, .expected_counter{ 2 } },
-                thread_pool);
-        interpolation_decimation_test(
-                { .n_samples{ 100 }, .numerator{ 7 }, .denominator{ 3 }, .out_port_min_samples{ 10 }, .out_port_max_samples{ 20 }, .expected_in{ 6 }, .expected_out{ 14 }, .expected_counter{ 16 } },
-                thread_pool);
+        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 5 }, .denominator{ 11 }, .out_port_min{ 10 }, .out_port_max{ 41 }, .exp_in{ 88 }, .exp_out{ 40 }, .exp_counter{ 1 } },
+                                      thread_pool);
+        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 7 }, .denominator{ 3 }, .out_port_min{ 10 }, .out_port_max{ 10 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 80 }, .numerator{ 2 }, .denominator{ 4 }, .out_port_min{ 20 }, .out_port_max{ 20 }, .exp_in{ 40 }, .exp_out{ 20 }, .exp_counter{ 2 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 7 }, .denominator{ 3 }, .out_port_min{ 10 }, .out_port_max{ 20 }, .exp_in{ 6 }, .exp_out{ 14 }, .exp_counter{ 16 } },
+                                      thread_pool);
+    };
+
+    "Stride tests"_test = [&thread_pool] {
+        stride_test({ .n_samples{ 1024 }, .stride{ 0 }, .in_port_max{ 1024 }, .exp_in{ 1024 }, .exp_out{ 1024 }, .exp_counter{ 1 }, .exp_total_in{ 1024 }, .exp_total_out{ 1024 } }, thread_pool);
+        stride_test({ .n_samples{ 1000 }, .stride{ 100 }, .in_port_max{ 50 }, .exp_in{ 50 }, .exp_out{ 50 }, .exp_counter{ 10 }, .exp_total_in{ 500 }, .exp_total_out{ 500 } }, thread_pool);
+        stride_test({ .n_samples{ 1000 }, .stride{ 133 }, .in_port_max{ 50 }, .exp_in{ 50 }, .exp_out{ 50 }, .exp_counter{ 8 }, .exp_total_in{ 400 }, .exp_total_out{ 400 } }, thread_pool);
+        stride_test({ .n_samples{ 1000 }, .stride{ 50 }, .in_port_max{ 100 }, .exp_in{ 50 }, .exp_out{ 50 }, .exp_counter{ 20 }, .exp_total_in{ 1950 }, .exp_total_out{ 1950 } }, thread_pool);
+        stride_test({ .n_samples{ 1000 }, .stride{ 33 }, .in_port_max{ 100 }, .exp_in{ 10 }, .exp_out{ 10 }, .exp_counter{ 31 }, .exp_total_in{ 2929 }, .exp_total_out{ 2929 } }, thread_pool);
+        // clang-format off
+        stride_test({ .n_samples{ 1000 }, .numerator{ 2 }, .denominator{ 4 }, .stride{ 50 }, .in_port_max{ 100 }, .exp_in{ 48 }, .exp_out{ 24 }, .exp_counter{ 20 }, .exp_total_in{ 1948 }, .exp_total_out{ 974 } },
+                    thread_pool);
+        stride_test({ .n_samples{ 1000 }, .numerator{ 2 }, .denominator{ 4 }, .stride{ 50 }, .in_port_max{ 50 }, .exp_in{ 48 }, .exp_out{ 24 }, .exp_counter{ 20 }, .exp_total_in{ 960 }, .exp_total_out{ 480 } },
+                    thread_pool);
+        // clang-format on
+
+        std::vector<int> exp_v1 = { 0, 1, 2, 3, 4, 3, 4, 5, 6, 7, 6, 7, 8, 9, 10, 9, 10, 11, 12, 13, 12, 13, 14 };
+        stride_test({ .n_samples{ 15 }, .stride{ 3 }, .in_port_max{ 5 }, .exp_in{ 3 }, .exp_out{ 3 }, .exp_counter{ 5 }, .exp_total_in{ 23 }, .exp_total_out{ 23 }, .exp_in_vector{ exp_v1 } },
+                    thread_pool);
+
+        std::vector<int> exp_v2 = { 0, 1, 2, 5, 6, 7, 10, 11, 12 };
+        stride_test({ .n_samples{ 15 }, .stride{ 5 }, .in_port_max{ 3 }, .exp_in{ 3 }, .exp_out{ 3 }, .exp_counter{ 3 }, .exp_total_in{ 9 }, .exp_total_out{ 9 }, .exp_in_vector{ exp_v2 } },
+                    thread_pool);
+
+        // assuming buffer size is approx 65k
+        stride_test({ .n_samples{ 1000000 }, .stride{ 250000 }, .in_port_max{ 100 }, .exp_in{ 100 }, .exp_out{ 100 }, .exp_counter{ 4 }, .exp_total_in{ 400 }, .exp_total_out{ 400 } }, thread_pool);
+        stride_test({ .n_samples{ 1000000 }, .stride{ 249900 }, .in_port_max{ 100 }, .exp_in{ 100 }, .exp_out{ 100 }, .exp_counter{ 5 }, .exp_total_in{ 500 }, .exp_total_out{ 500 } }, thread_pool);
     };
 };
 


### PR DESCRIPTION
Few details on implementation:
1) If `stride == 0` then it is not used and `n_samples_to_consume == n_samples_to_process`. 
2) If `stride != 0 and stride < in_available_samples` then `n_samples_to_consume == stride`. 
3) If `stride != 0 and stride > in_available_samples` then samples are consumed till `stride_consumed_counter == stride`. 

Depending on the parameters like `numerator`, `denominator` and available samples. `n_samples_to_process` can change for each `work` function execution, but `stride` is always the same. It can lead to different sample rates over time. In many cases this is normal behavior. If it is not the case then it is  user responsibility to set proper parameters .

It also can happen that `n_required_samples >= stride` but actual `n_samples_to_process < stride` because of input-output port limitations, interpolation, decimation requirements etc. This is the user responsibility to set block parameters according to the needs.


### Performance tests

### stride
```text
┌──────────────────────────────benchmark:───────────────────────────────┬──────┬─#N──┬─CTX-SW─┬───CPU cache misses────┬───CPU branch misses───┬─<CPU-I>─┬──min───┬──mean──┬─stddev─┬─median─┬──max───┬─total time─┬─ops/s─┐
│ merged src->sink work                                                 │ PASS │ 10  │     0  │ 2.22k / 3.86k = 57.4% │   390  / 212k =  0.2% │   10.4  │  17 us │  19 us │   1 us │  18 us │  21 us │     185 us │  552M │
│ merged src->copy->sink                                                │ PASS │ 10  │     0  │  649  / 1.33k = 48.8% │  199  / 11.4k =  1.8% │    1.1  │   4 us │   5 us │ 489 ns │   5 us │   6 us │      46 us │  2.2G │
│ merged src->copy->sink work                                           │ PASS │ 10  │     0  │   272  / 817  = 33.3% │   150  / 210k =  0.1% │   10.3  │  11 us │  12 us │ 388 ns │  12 us │  12 us │     117 us │  876M │
│ merged src->copy^10->sink                                             │ PASS │ 10  │     0  │  684  / 1.37k = 50.1% │   231  / 110k =  0.2% │    7.7  │  10 us │  11 us │ 433 ns │  11 us │  12 us │     109 us │  941M │
│ merged src(N=1024)->b1(N≤128)->b2(N=1024)->b3(N=32...128)->sink       │ PASS │ 10  │     0  │  715  / 1.41k = 50.7% │  205  / 11.3k =  1.8% │    1.1  │   4 us │   5 us │ 434 ns │   5 us │   5 us │      46 us │  2.2G │
│ merged src->mult(2.0)->divide(2.0)->add(-1)->sink - float             │ PASS │ 10  │     0  │  660  / 1.46k = 45.4% │   217  / 111k =  0.2% │   10.7  │  11 us │  12 us │ 451 ns │  12 us │  13 us │     120 us │  852M │
│ merged src->mult(2.0)->divide(2.0)->add(-1)->sink - int               │ PASS │ 10  │     0  │  650  / 1.31k = 49.6% │   220  / 110k =  0.2% │   11.7  │  16 us │  17 us │ 502 ns │  17 us │  18 us │     169 us │  604M │
│ merged src->(mult(2.0)->div(2.0)->add(-1))^10->sink - float           │ PASS │ 10  │     0  │  706  / 1.36k = 52.0% │  3.39k / 114k =  3.0% │   38.7  │ 104 us │ 118 us │  21 us │ 109 us │ 177 us │       1 ms │ 87.0M │
│ merged src->(mult(2.0)->div(2.0)->add(-1))^10->sink - int             │ PASS │ 10  │     0  │  818  / 1.60k = 51.2% │  3.39k / 114k =  3.0% │   48.8  │ 156 us │ 169 us │  31 us │ 161 us │ 260 us │       2 ms │ 60.6M │
│ runtime   src->sink overhead                                          │ PASS │ 10  │     0  │  13.5k / 179k =  7.5% │  2.58k / 435k =  0.6% │   21.6  │  12 us │  50 us │ 109 us │  13 us │ 378 us │     497 us │  206M │
│ runtime   src->copy->sink                                             │ PASS │ 10  │     0  │  30.5k / 354k =  8.6% │  4.09k / 734k =  0.6% │   34.2  │  13 us │  70 us │ 168 us │  14 us │ 575 us │     704 us │  145M │
│ runtime   src->copy^10->sink                                          │ PASS │ 10  │     0  │  119k / 1.92M =  6.2% │ 18.4k / 3.47M =  0.5% │    150  │  27 us │ 345 us │ 935 us │  35 us │   3 ms │       3 ms │ 29.7M │
│ runtime   src(N=1024)->b1(N≤128)->b2(N=1024)->b3(N=32...128)->sink    │ PASS │ 10  │     0  │  41.3k / 670k =  6.2% │ 6.67k / 1.43M =  0.5% │   65.6  │  21 us │ 157 us │ 382 us │  32 us │   1 ms │       2 ms │ 65.3M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - float             │ PASS │ 10  │     0  │  52.1k / 716k =  7.3% │ 7.79k / 1.37M =  0.6% │   61.6  │  14 us │ 130 us │ 339 us │  18 us │   1 ms │       1 ms │ 78.6M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - int               │ PASS │ 10  │     0  │  43.2k / 719k =  6.0% │ 7.88k / 1.37M =  0.6% │   62.6  │  17 us │ 134 us │ 344 us │  19 us │   1 ms │       1 ms │ 76.4M │
│ runtime   src->(mult(2.0)->div(2.0)->add(-1))^10->sink - float        │ PASS │ 10  │     0  │  372k / 5.77M =  6.4% │ 49.5k / 10.1M =  0.5% │    443  │ 139 us │   1 ms │   3 ms │ 149 us │  11 ms │      12 ms │  8.4M │
│ runtime   src->(mult(2.0)->div(2.0)->add(-1))^10->sink - int          │ PASS │ 10  │     0  │  323k / 5.64M =  5.7% │ 47.3k / 10.0M =  0.5% │    451  │ 132 us │   1 ms │   3 ms │ 137 us │   9 ms │      10 ms │ 10.2M │
│ runtime   src->mult(2.0)->mult(0.5)->add(-1)->sink (SIMD)             │ PASS │ 10  │     0  │  37.2k / 701k =  5.3% │ 7.20k / 1.36M =  0.5% │   60.2  │  13 us │ 130 us │ 344 us │  16 us │   1 ms │       1 ms │ 78.7M │
│ runtime   src->(mult(2.0)->mult(0.5)->add(-1))^10->sink (SIMD)        │ PASS │ 10  │     0  │  260k / 5.39M =  4.8% │ 47.0k / 9.80M =  0.5% │    412  │  79 us │ 918 us │   3 ms │  85 us │   8 ms │       9 ms │ 11.2M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - float single      │ PASS │ 10  │   115  │  907k / 5.88M = 15.4% │  184k / 10.5M =  1.7% │    544  │   2 ms │   3 ms │   1 ms │   2 ms │   6 ms │      26 ms │  4.0M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - int single        │ PASS │ 10  │    94  │  893k / 5.83M = 15.3% │  184k / 10.4M =  1.8% │    539  │   2 ms │   4 ms │   4 ms │   2 ms │  14 ms │      39 ms │  2.6M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - float bulk        │ PASS │ 10  │     0  │  47.4k / 723k =  6.5% │ 7.74k / 1.40M =  0.6% │   62.1  │  16 us │ 172 us │ 462 us │  19 us │   2 ms │       2 ms │ 59.4M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - int bulk          │ PASS │ 10  │     0  │  40.3k / 719k =  5.6% │ 7.26k / 1.48M =  0.5% │   68.2  │  32 us │ 153 us │ 353 us │  35 us │   1 ms │       2 ms │ 67.1M │
└───────────────────────────────────────────────────────────────────────┴──────┴─────┴────────┴───────────────────────┴───────────────────────┴─────────┴────────┴────────┴────────┴────────┴────────┴────────────┴───────┘
```

### main

```text
┌──────────────────────────────benchmark:───────────────────────────────┬──────┬─#N──┬─CTX-SW─┬───CPU cache misses────┬───CPU branch misses───┬─<CPU-I>─┬──min───┬──mean──┬─stddev─┬─median─┬──max───┬─total time─┬─ops/s─┐
│ merged src->sink work                                                 │ PASS │ 10  │     0  │ 2.00k / 3.68k = 54.2% │   388  / 212k =  0.2% │   10.4  │  23 us │  24 us │ 734 ns │  24 us │  25 us │     240 us │  426M │
│ merged src->copy->sink                                                │ PASS │ 10  │     0  │  646  / 1.36k = 47.7% │  200  / 11.1k =  1.8% │    1.1  │   4 us │   5 us │ 581 ns │   5 us │   5 us │      46 us │  2.2G │
│ merged src->copy->sink work                                           │ PASS │ 10  │     0  │   273  / 778  = 35.1% │   140  / 210k =  0.1% │   10.3  │  10 us │  12 us │ 792 ns │  12 us │  14 us │     118 us │  870M │
│ merged src->copy^10->sink                                             │ PASS │ 10  │     0  │  668  / 1.39k = 48.1% │   219  / 110k =  0.2% │    7.7  │  10 us │  11 us │ 511 ns │  11 us │  12 us │     111 us │  925M │
│ merged src(N=1024)->b1(N≤128)->b2(N=1024)->b3(N=32...128)->sink       │ PASS │ 10  │     0  │  683  / 1.37k = 50.0% │  195  / 11.0k =  1.8% │    1.1  │   4 us │   5 us │ 461 ns │   5 us │   5 us │      46 us │  2.2G │
│ merged src->mult(2.0)->divide(2.0)->add(-1)->sink - float             │ PASS │ 10  │     0  │  648  / 1.26k = 51.3% │   226  / 110k =  0.2% │   10.7  │  11 us │  12 us │ 459 ns │  12 us │  13 us │     121 us │  848M │
│ merged src->mult(2.0)->divide(2.0)->add(-1)->sink - int               │ PASS │ 10  │     0  │  676  / 1.37k = 49.4% │   217  / 110k =  0.2% │   11.7  │  16 us │  17 us │ 278 ns │  17 us │  17 us │     168 us │  610M │
│ merged src->(mult(2.0)->div(2.0)->add(-1))^10->sink - float           │ PASS │ 10  │     0  │  738  / 1.41k = 52.2% │  3.40k / 114k =  3.0% │   38.8  │ 107 us │ 136 us │  50 us │ 108 us │ 235 us │       1 ms │ 75.1M │
│ merged src->(mult(2.0)->div(2.0)->add(-1))^10->sink - int             │ PASS │ 10  │     0  │  709  / 1.44k = 49.2% │  3.40k / 113k =  3.0% │   48.7  │ 156 us │ 206 us │  75 us │ 161 us │ 349 us │       2 ms │ 49.8M │
│ runtime   src->sink overhead                                          │ PASS │ 10  │     0  │  13.4k / 185k =  7.2% │  2.61k / 434k =  0.6% │   21.5  │  13 us │  49 us │ 101 us │  15 us │ 352 us │     485 us │  211M │
│ runtime   src->copy->sink                                             │ PASS │ 10  │     0  │  29.4k / 360k =  8.2% │  4.12k / 732k =  0.6% │   34.1  │  14 us │  62 us │ 142 us │  15 us │ 486 us │     617 us │  166M │
│ runtime   src->copy^10->sink                                          │ PASS │ 10  │     0  │  118k / 1.91M =  6.2% │ 17.5k / 3.45M =  0.5% │    149  │  29 us │ 334 us │ 899 us │  36 us │   3 ms │       3 ms │ 30.7M │
│ runtime   src(N=1024)->b1(N≤128)->b2(N=1024)->b3(N=32...128)->sink    │ PASS │ 10  │     0  │  47.4k / 687k =  6.9% │ 6.65k / 1.43M =  0.5% │   65.9  │  22 us │ 154 us │ 380 us │  28 us │   1 ms │       2 ms │ 66.4M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - float             │ PASS │ 10  │     0  │  43.9k / 724k =  6.1% │ 7.59k / 1.38M =  0.5% │   62.0  │  18 us │ 146 us │ 369 us │  23 us │   1 ms │       1 ms │ 70.2M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - int               │ PASS │ 10  │     0  │  57.5k / 732k =  7.9% │ 7.42k / 1.37M =  0.5% │   62.5  │  21 us │ 138 us │ 342 us │  23 us │   1 ms │       1 ms │ 74.4M │
│ runtime   src->(mult(2.0)->div(2.0)->add(-1))^10->sink - float        │ PASS │ 10  │     0  │  308k / 5.62M =  5.5% │ 47.2k / 10.0M =  0.5% │    440  │ 117 us │ 935 us │   2 ms │ 122 us │   8 ms │       9 ms │ 10.9M │
│ runtime   src->(mult(2.0)->div(2.0)->add(-1))^10->sink - int          │ PASS │ 10  │     0  │  306k / 5.64M =  5.4% │ 46.8k / 10.0M =  0.5% │    451  │ 131 us │ 925 us │   2 ms │ 138 us │   8 ms │       9 ms │ 11.1M │
│ runtime   src->mult(2.0)->mult(0.5)->add(-1)->sink (SIMD)             │ PASS │ 10  │     0  │  50.4k / 718k =  7.0% │ 6.92k / 1.37M =  0.5% │   60.5  │  18 us │ 152 us │ 396 us │  21 us │   1 ms │       2 ms │ 67.5M │
│ runtime   src->(mult(2.0)->mult(0.5)->add(-1))^10->sink (SIMD)        │ PASS │ 10  │     0  │  315k / 5.41M =  5.8% │ 46.8k / 9.82M =  0.5% │    413  │  74 us │ 908 us │   2 ms │  78 us │   8 ms │       9 ms │ 11.3M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - float single      │ PASS │ 10  │    97  │  870k / 5.85M = 14.9% │  201k / 10.4M =  1.9% │    536  │   2 ms │   3 ms │   2 ms │   2 ms │   9 ms │      30 ms │  3.4M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - int single        │ PASS │ 10  │    89  │  888k / 5.84M = 15.2% │  197k / 10.4M =  1.9% │    535  │   2 ms │   5 ms │   5 ms │   4 ms │  20 ms │      52 ms │  2.0M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - float bulk        │ PASS │ 10  │     0  │  45.7k / 725k =  6.3% │ 7.71k / 1.39M =  0.6% │   62.0  │  19 us │ 141 us │ 355 us │  22 us │   1 ms │       1 ms │ 72.7M │
│ runtime   src->mult(2.0)->div(2.0)->add(-1)->sink - int bulk          │ PASS │ 10  │     0  │  54.0k / 723k =  7.5% │ 7.74k / 1.49M =  0.5% │   68.3  │  35 us │ 151 us │ 343 us │  36 us │   1 ms │       2 ms │ 67.7M │
└───────────────────────────────────────────────────────────────────────┴──────┴─────┴────────┴───────────────────────┴───────────────────────┴─────────┴────────┴────────┴────────┴────────┴────────┴────────────┴───────┘
```

