### PR TITLE
Add DataSet<float> and Dataset<double> to port suppurted types.

### DIFF
--- a/include/dataset.hpp
+++ b/include/dataset.hpp
@@ -4,7 +4,6 @@
 #include <chrono>
 #include <cstdint>
 #include <map>
-#include <node.hpp>
 #include <pmtv/pmt.hpp>
 #include <reflection.hpp>
 #include <tag.hpp>
@@ -22,27 +21,27 @@ struct layout_left {};
  */
 template<typename T>
 concept packet = requires(T t, const std::size_t n_items) {
-                     typename T::value_type;
-                     typename T::pmt_map;
-                     std::is_same_v<decltype(t.timestamp), int64_t>;
-                     std::is_same_v<decltype(t.signal_values), std::vector<typename T::value_type>>;
-                     std::is_same_v<decltype(t.meta_information), std::vector<typename T::pmt_map>>;
-                 };
+    typename T::value_type;
+    typename T::pmt_map;
+    std::is_same_v<decltype(t.timestamp), int64_t>;
+    std::is_same_v<decltype(t.signal_values), std::vector<typename T::value_type>>;
+    std::is_same_v<decltype(t.meta_information), std::vector<typename T::pmt_map>>;
+};
 
 /**
  * @brief A concept that describes a tensor, which is a subset of the DataSet struct.
  */
 template<typename T>
 concept tensor = packet<T> && requires(T t, const std::size_t n_items) {
-                                  typename T::value_type;
-                                  typename T::pmt_map;
-                                  typename T::tensor_layout_type;
-                                  std::is_same_v<decltype(t.extents), std::vector<std::int32_t>>;
-                                  std::is_same_v<decltype(t.layout), std::vector<typename T::tensor_layout_type>>;
-                                  std::is_same_v<decltype(t.signal_values), std::vector<typename T::value_type>>;
-                                  std::is_same_v<decltype(t.signal_errors), std::vector<typename T::value_type>>;
-                                  std::is_same_v<decltype(t.meta_information), std::vector<typename T::pmt_map>>;
-                              };
+    typename T::value_type;
+    typename T::pmt_map;
+    typename T::tensor_layout_type;
+    std::is_same_v<decltype(t.extents), std::vector<std::int32_t>>;
+    std::is_same_v<decltype(t.layout), std::vector<typename T::tensor_layout_type>>;
+    std::is_same_v<decltype(t.signal_values), std::vector<typename T::value_type>>;
+    std::is_same_v<decltype(t.signal_errors), std::vector<typename T::value_type>>;
+    std::is_same_v<decltype(t.meta_information), std::vector<typename T::pmt_map>>;
+};
 
 /**
  * @brief: a dataset consists of signal data, metadata, and associated axis information.
@@ -54,27 +53,27 @@ concept tensor = packet<T> && requires(T t, const std::size_t n_items) {
  */
 template<typename T>
 concept dataset = tensor<T> && requires(T t, const std::size_t n_items) {
-                                   typename T::value_type;
-                                   typename T::pmt_map;
-                                   typename T::tensor_layout_type;
-                                   std::is_same_v<decltype(t.timestamp), int64_t>;
+    typename T::value_type;
+    typename T::pmt_map;
+    typename T::tensor_layout_type;
+    std::is_same_v<decltype(t.timestamp), int64_t>;
 
-                                   // axis layout:
-                                   std::is_same_v<decltype(t.axis_names), std::vector<std::string>>;
-                                   std::is_same_v<decltype(t.axis_units), std::vector<std::string>>;
-                                   std::is_same_v<decltype(t.axis_values), std::vector<typename T::value_type>>;
+    // axis layout:
+    std::is_same_v<decltype(t.axis_names), std::vector<std::string>>;
+    std::is_same_v<decltype(t.axis_units), std::vector<std::string>>;
+    std::is_same_v<decltype(t.axis_values), std::vector<typename T::value_type>>;
 
-                                   // signal data storage
-                                   std::is_same_v<decltype(t.signal_names), std::vector<std::string>>;
-                                   std::is_same_v<decltype(t.signal_units), std::vector<std::string>>;
-                                   std::is_same_v<decltype(t.signal_values), std::vector<typename T::value_type>>;
-                                   std::is_same_v<decltype(t.signal_errors), std::vector<typename T::value_type>>;
-                                   std::is_same_v<decltype(t.signal_ranges), std::vector<std::vector<typename T::value_type>>>;
+    // signal data storage
+    std::is_same_v<decltype(t.signal_names), std::vector<std::string>>;
+    std::is_same_v<decltype(t.signal_units), std::vector<std::string>>;
+    std::is_same_v<decltype(t.signal_values), std::vector<typename T::value_type>>;
+    std::is_same_v<decltype(t.signal_errors), std::vector<typename T::value_type>>;
+    std::is_same_v<decltype(t.signal_ranges), std::vector<std::vector<typename T::value_type>>>;
 
-                                   // meta data
-                                   std::is_same_v<decltype(t.meta_information), std::vector<typename T::pmt_map>>;
-                                   std::is_same_v<decltype(t.timing_events), std::vector<std::vector<tag_t>>>;
-                               };
+    // meta data
+    std::is_same_v<decltype(t.meta_information), std::vector<typename T::pmt_map>>;
+    std::is_same_v<decltype(t.timing_events), std::vector<std::vector<tag_t>>>;
+};
 
 template<typename T>
 struct DataSet {
@@ -119,8 +118,8 @@ struct Tensor {
     using pmt_map                       = std::map<std::string, pmtv::pmt>;
     std::int64_t              timestamp = 0; // UTC timestamp [ns]
 
-    std::vector<std::int32_t> extents; // extents[dim0_size, dim1_size, …]
-    tensor_layout_type        layout;  // row-major, column-major, “special”
+    std::vector<std::int32_t> extents;       // extents[dim0_size, dim1_size, …]
+    tensor_layout_type        layout;        // row-major, column-major, “special”
 
     std::vector<T>            signal_values; // size = \PI_i extents[i]
     std::vector<T>            signal_errors; // size = \PI_i extents[i] or '0' if not applicable
@@ -147,7 +146,7 @@ static_assert(packet<Packet<std::byte>>, "Packet<std::byte> concept conformity")
 static_assert(packet<Packet<float>>, "Packet<std::byte> concept conformity");
 static_assert(packet<Packet<double>>, "Packet<std::byte> concept conformity");
 
-} // namespace graph::dataset
+} // namespace fair::graph
 
 ENABLE_REFLECTION(fair::graph::DataSet_double, timestamp, axis_names, axis_units, axis_values, extents, layout, signal_names, signal_units, signal_values, signal_errors, signal_ranges,
                   meta_information, timing_events)

--- a/include/port.hpp
+++ b/include/port.hpp
@@ -202,7 +202,12 @@ public:
         return PortName;
     }
 
+    // TODO revisit: constexpr was removed because emscripten does not support constexpr function for non literal type, like DataSet<T>
+#if defined(__EMSCRIPTEN__)
+    [[nodiscard]] supported_type
+#else
     [[nodiscard]] constexpr supported_type
+#endif
     pmt_type() const noexcept {
         return T();
     }
@@ -484,8 +489,13 @@ private:
         }
 
         ~wrapper() override = default;
-
+        
+        // TODO revisit: constexpr was removed because emscripten does not support constexpr function for non literal type, like DataSet<T>
+#if defined(__EMSCRIPTEN__)
+        [[nodiscard]] supported_type
+#else
         [[nodiscard]] constexpr supported_type
+#endif
         pmt_type() const noexcept override {
             return _value.pmt_type();
         }

--- a/include/port.hpp
+++ b/include/port.hpp
@@ -1,13 +1,14 @@
 #ifndef GNURADIO_PORT_HPP
 #define GNURADIO_PORT_HPP
 
-#include <complex>
-#include <span>
-#include <variant>
-
 #include "circular_buffer.hpp"
 #include "tag.hpp"
 #include "utils.hpp"
+#include <complex>
+#include <dataset.hpp>
+#include <node.hpp>
+#include <span>
+#include <variant>
 
 namespace fair::graph {
 
@@ -15,7 +16,8 @@ using fair::meta::fixed_string;
 using namespace fair::literals;
 
 // #### default supported types -- TODO: to be replaced by pmt::pmtv declaration
-using supported_type = std::variant<uint8_t, uint32_t, int8_t, int16_t, int32_t, float, double, std::complex<float>, std::complex<double> /*, ...*/>;
+// Only DataSet<double> and DataSet<float> are added => consider to support more Dataset<T>
+using supported_type = std::variant<uint8_t, uint32_t, int8_t, int16_t, int32_t, float, double, std::complex<float>, std::complex<double>, DataSet<double>, DataSet<float> /*, ...*/>;
 
 enum class port_direction_t { INPUT, OUTPUT, ANY }; // 'ANY' only for query and not to be used for port declarations
 enum class connection_result_t { SUCCESS, FAILED };


### PR DESCRIPTION
This PR includes following changes:
- Add DataSet<float> and Dataset<double> to port suppurted types.
- Add FFT test with flow graph.
- Remove constexpr for port::pmt_type() and dynamic_port::pmt_type() functions when using emscripten. 

**Note!** Last item has to be revisited later! `constexpr` was removed because `emscripten` does not support `constexpr` function for non literal type, like `DataSet<T>`. For the moment after the discussion with @wirew0rm, this solution was considered as a best/easiest which should not even harm the performance. We still need to discuss this problem later especially considering performance issues if any, and the fact that `DataSet` will be used more and more in many other blocks.