### PR TITLE
cmake: disable asan for qa_plugin_test

### DIFF
--- a/include/node.hpp
+++ b/include/node.hpp
@@ -728,11 +728,12 @@ protected:
             }
 
             if constexpr (node_template_parameters::template contains<PerformDecimationInterpolation>) {
-                if (numerator != 1. || denominator != 1.) {
+                if (numerator != 1_UZ || denominator != 1_UZ) {
                     // TODO: this ill-defined checks can be done only once after parameters were changed
                     const double ratio          = static_cast<double>(numerator) / static_cast<double>(denominator);
-                    bool         is_ill_defined = (denominator > ports_status.in_max_samples) || (ports_status.in_min_samples * ratio > ports_status.out_max_samples)
-                                       || (ports_status.in_max_samples * ratio < ports_status.out_min_samples);
+                    bool         is_ill_defined = (denominator > ports_status.in_max_samples)
+                            || (static_cast<double>(ports_status.in_min_samples) * ratio > static_cast<double>(ports_status.out_max_samples))
+                            || (static_cast<double>(ports_status.in_max_samples) * ratio < static_cast<double>(ports_status.out_min_samples));
                     assert(!is_ill_defined);
                     if (is_ill_defined) {
                         return { requested_work, 0_UZ, work_return_status_t::ERROR };
@@ -745,10 +746,10 @@ protected:
 
                     std::size_t       in_min_samples = static_cast<std::size_t>(static_cast<double>(out_min_limit) / ratio);
                     if (in_min_samples % denominator != 0) in_min_samples += denominator;
-                    std::size_t       in_min_wo_reminder = static_cast<std::size_t>(in_min_samples / denominator) * denominator;
+                    std::size_t       in_min_wo_reminder = (in_min_samples / denominator) * denominator;
 
                     const std::size_t in_max_samples     = static_cast<std::size_t>(static_cast<double>(out_max_limit) / ratio);
-                    std::size_t       in_max_wo_reminder = static_cast<std::size_t>(in_max_samples / denominator) * denominator;
+                    std::size_t       in_max_wo_reminder = (in_max_samples / denominator) * denominator;
 
                     if (ports_status.in_samples < in_min_wo_reminder) return { requested_work, 0_UZ, work_return_status_t::INSUFFICIENT_INPUT_ITEMS };
                     ports_status.in_samples  = std::clamp(ports_status.in_samples, in_min_wo_reminder, in_max_wo_reminder);
@@ -829,7 +830,7 @@ protected:
 
         std::size_t n_samples_to_consume = ports_status.in_samples; // default stride == 0
         if constexpr (node_template_parameters::template contains<PerformStride>) {
-            if (stride != 0) {
+            if (stride != 0_UZ) {
                 const bool first_time_stride = stride_counter == 0;
                 if (first_time_stride) {
                     // sample processing are done as usual, ports_status.in_samples samples will be processed

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,9 +47,14 @@ if (NOT EMSCRIPTEN)
     add_subdirectory(plugins)
 
     if (NOT (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang"))
-        # Clang has issues with ut, app_plugins_test (the target below) tests
-        # the plugin system without ut
-        add_ut_test(qa_plugins_test)
+        # add add target manually without asan TODO: reenable once it builds on the CI again
+        # add_ut_test(qa_plugins_test)
+        add_executable(qa_plugins_test qa_plugins_test.cpp)
+        target_compile_options(qa_plugins_test PRIVATE -Wall)
+        target_link_options(qa_plugins_test PRIVATE -Wall)
+        target_include_directories(qa_plugins_test PRIVATE ${CMAKE_BINARY_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
+        target_link_libraries(qa_plugins_test PRIVATE graph-prototype-options graph-prototype fmt refl-cpp ut fftw)
+        add_test(NAME qa_plugins_test COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_CURRENT_BINARY_DIR}/qa_plugins_test)
         target_link_libraries(qa_plugins_test PRIVATE graph-prototype-plugin)
         add_dependencies(qa_plugins_test good_math_plugin good_base_plugin bad_plugin)
     endif ()

--- a/test/blocklib/core/sources/clock_source.hpp
+++ b/test/blocklib/core/sources/clock_source.hpp
@@ -104,9 +104,9 @@ ClockSource Documentation -- add here
             return work_return_status_t::INSUFFICIENT_OUTPUT_ITEMS;
         }
 
-        const auto          remaining_samples  = static_cast<std::uint32_t>(n_samples_max - n_samples_produced);
+        const std::uint32_t remaining_samples  = n_samples_max - n_samples_produced;
         const std::uint32_t limit              = std::min(writableSamples, remaining_samples);
-        const std::uint32_t n_available        = std::min(limit, static_cast<std::uint32_t>(chunk_size.value));
+        const std::uint32_t n_available        = std::min(limit, chunk_size.value);
 
         std::uint32_t       samples_to_produce = n_available;
         while (next_tag < tags.size() && tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced + n_available)) {
@@ -114,11 +114,11 @@ ClockSource Documentation -- add here
             tag_t &out_tag     = this->output_tags()[0];
             out_tag            = tags[next_tag];
             out_tag.index      = tags[next_tag].index - static_cast<std::make_signed_t<std::size_t>>(n_samples_produced);
-            samples_to_produce = static_cast<std::uint32_t>(static_cast<std::uint32_t>(tags[next_tag].index) - n_samples_produced);
+            samples_to_produce = static_cast<std::uint32_t>(tags[next_tag].index) - n_samples_produced;
             this->forward_tags();
             next_tag++;
         }
-        samples_to_produce = std::min(samples_to_produce, static_cast<std::uint32_t>(n_samples_max.value));
+        samples_to_produce = std::min(samples_to_produce, n_samples_max.value);
 
         output.publish(samples_to_produce);
         n_samples_produced += samples_to_produce;

--- a/test/plugins/CMakeLists.txt
+++ b/test/plugins/CMakeLists.txt
@@ -1,7 +1,8 @@
 function(add_gp_plugin PLUGIN_NAME)
     add_library(${PLUGIN_NAME} MODULE ${PLUGIN_NAME}.cpp)
 
-    target_compile_options(${PLUGIN_NAME} PRIVATE -fsanitize=address -Wall)
+    # target_compile_options(${PLUGIN_NAME} PRIVATE -fsanitize=address -Wall)
+    target_compile_options(${PLUGIN_NAME} PRIVATE -Wall)
 
     target_include_directories(${PLUGIN_NAME} PUBLIC ${CMAKE_BINARY_DIR}/include)
     target_link_libraries(${PLUGIN_NAME} PUBLIC graph-prototype-options graph-prototype graph-prototype-plugin refl-cpp fmt)

--- a/test/qa_fft.cpp
+++ b/test/qa_fft.cpp
@@ -90,7 +90,7 @@ const boost::ut::suite _fft_tests = [] {
             const auto peak_frequency{ static_cast<double>(peak_index) * t.sample_rate / static_cast<double>(t.N) };
 
             const auto expected_amplitude = t.output_in_dB ? 20. * log10(std::abs(t.amplitude)) : t.amplitude;
-            expect(approx(peak_amplitude, expected_amplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
+            expect(approx(static_cast<double>(peak_amplitude), expected_amplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
             expect(approx(peak_frequency, t.frequency, tolerance)) << fmt::format("<{}> equal frequency", type_name<T>());
         }
     } | types_to_test;
@@ -105,7 +105,7 @@ const boost::ut::suite _fft_tests = [] {
         std::vector<T> signal(N);
 
         static_assert(N == 16, "expected values are calculated for N == 16");
-        int    expected_peak_index{ 0 };
+        std::size_t expected_peak_index{ 0 };
         T      expected_fft0{ 0., 0. };
         double expected_peak_amplitude{ 0. };
         for (std::size_t iT = 0; iT < 5; iT++) {
@@ -141,9 +141,9 @@ const boost::ut::suite _fft_tests = [] {
             const auto peak_amplitude{ fft1.magnitude_spectrum[peak_index] };
 
             expect(eq(peak_index, expected_peak_index)) << fmt::format("<{}> equal peak index", type_name<T>());
-            expect(approx(peak_amplitude, expected_peak_amplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
-            expect(approx(fft1.fftw_out[0][0], expected_fft0.real(), tolerance)) << fmt::format("<{}> equal fft[0].real()", type_name<T>());
-            expect(approx(fft1.fftw_out[0][1], expected_fft0.imag(), tolerance)) << fmt::format("<{}> equal fft[0].imag()", type_name<T>());
+            expect(approx(static_cast<double>(peak_amplitude), expected_peak_amplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
+            expect(approx(static_cast<double>(fft1.fftw_out[0][0]), static_cast<double>(expected_fft0.real()), tolerance)) << fmt::format("<{}> equal fft[0].real()", type_name<T>());
+            expect(approx(static_cast<double>(fft1.fftw_out[0][1]), static_cast<double>(expected_fft0.imag()), tolerance)) << fmt::format("<{}> equal fft[0].imag()", type_name<T>());
         }
     } | complex_types_to_test;
 

--- a/test/qa_node.cpp
+++ b/test/qa_node.cpp
@@ -10,7 +10,6 @@ auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter
 #include <fmt/format.h>
 #include <graph.hpp>
 #include <node.hpp>
-#include <numbers>
 #include <scheduler.hpp>
 
 namespace fg = fair::graph;
@@ -116,8 +115,8 @@ interpolation_decimation_test(const IntDecTestData &data, std::shared_ptr<fair::
     auto &int_dec_block       = flow.make_node<IntDecBlock<int>>();
     int_dec_block.numerator   = data.numerator;
     int_dec_block.denominator = data.denominator;
-    if (data.out_port_max >= 0) int_dec_block.out.max_samples = static_cast<int>(data.out_port_max);
-    if (data.out_port_min >= 0) int_dec_block.out.min_samples = static_cast<int>(data.out_port_min);
+    if (data.out_port_max >= 0) int_dec_block.out.max_samples = static_cast<size_t>(data.out_port_max);
+    if (data.out_port_min >= 0) int_dec_block.out.min_samples = static_cast<size_t>(data.out_port_min);
 
     std::ignore = flow.connect<"out">(source).to<"in">(int_dec_block);
     auto sched  = scheduler(std::move(flow), thread_pool);
@@ -144,8 +143,8 @@ stride_test(const StrideTestData &data, std::shared_ptr<fair::thread_pool::Basic
     int_dec_block.numerator       = data.numerator;
     int_dec_block.denominator     = data.denominator;
     int_dec_block.stride          = data.stride;
-    if (data.in_port_max >= 0) int_dec_block.in.max_samples = static_cast<int>(data.in_port_max);
-    if (data.in_port_min >= 0) int_dec_block.in.min_samples = static_cast<int>(data.in_port_min);
+    if (data.in_port_max >= 0) int_dec_block.in.max_samples = static_cast<size_t>(data.in_port_max);
+    if (data.in_port_min >= 0) int_dec_block.in.min_samples = static_cast<size_t>(data.in_port_min);
 
     std::ignore = flow.connect<"out">(source).to<"in">(int_dec_block);
     auto sched  = scheduler(std::move(flow), thread_pool);
@@ -167,53 +166,47 @@ const boost::ut::suite _fft_tests = [] {
 
     auto thread_pool                      = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
 
+    // clang-format off
     "Interpolation/Decimation tests"_test = [&thread_pool] {
-        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 1 }, .denominator{ 1 }, .exp_in{ 1024 }, .exp_out{ 1024 }, .exp_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 1 }, .denominator{ 2 }, .exp_in{ 1024 }, .exp_out{ 512 }, .exp_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 1024 }, .numerator{ 2 }, .denominator{ 1 }, .exp_in{ 1024 }, .exp_out{ 2048 }, .exp_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 5 }, .denominator{ 6 }, .exp_in{ 996 }, .exp_out{ 830 }, .exp_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 549 }, .numerator{ 1 }, .denominator{ 50 }, .exp_in{ 500 }, .exp_out{ 10 }, .exp_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 3 }, .denominator{ 7 }, .exp_in{ 98 }, .exp_out{ 42 }, .exp_counter{ 1 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 100 }, .denominator{ 100 }, .exp_in{ 100 }, .exp_out{ 100 }, .exp_counter{ 1 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples = 1024, .numerator =   1, .denominator =   1, .exp_in = 1024, .exp_out = 1024, .exp_counter = 1 }, thread_pool);
+        interpolation_decimation_test({ .n_samples = 1024, .numerator =   1, .denominator =   2, .exp_in = 1024, .exp_out =  512, .exp_counter = 1 }, thread_pool);
+        interpolation_decimation_test({ .n_samples = 1024, .numerator =   2, .denominator =   1, .exp_in = 1024, .exp_out = 2048, .exp_counter = 1 }, thread_pool);
+        interpolation_decimation_test({ .n_samples = 1000, .numerator =   5, .denominator =   6, .exp_in =  996, .exp_out =  830, .exp_counter = 1 }, thread_pool);
+        interpolation_decimation_test({ .n_samples =  549, .numerator =   1, .denominator =  50, .exp_in =  500, .exp_out =   10, .exp_counter = 1 }, thread_pool);
+        interpolation_decimation_test({ .n_samples =  100, .numerator =   3, .denominator =   7, .exp_in =   98, .exp_out =   42, .exp_counter = 1 }, thread_pool);
+        interpolation_decimation_test({ .n_samples =  100, .numerator = 100, .denominator = 100, .exp_in =  100, .exp_out =  100, .exp_counter = 1 }, thread_pool);
 
-        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 10 }, .denominator{ 1100 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 1000 }, .numerator{ 1 }, .denominator{ 1001 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 100000 }, .denominator{ 1 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 101 }, .denominator{ 101 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
+        interpolation_decimation_test({ .n_samples = 1000, .numerator =     10, .denominator = 1100, .exp_in = 0 , .exp_out = 0, .exp_counter = 0 }, thread_pool);
+        interpolation_decimation_test({ .n_samples = 1000, .numerator =      1, .denominator = 1001, .exp_in = 0 , .exp_out = 0, .exp_counter = 0 }, thread_pool);
+        interpolation_decimation_test({ .n_samples =  100, .numerator = 100000, .denominator =    1, .exp_in = 0 , .exp_out = 0, .exp_counter = 0 }, thread_pool);
+        interpolation_decimation_test({ .n_samples =  100, .numerator =    101, .denominator =  101, .exp_in = 0 , .exp_out = 0, .exp_counter = 0 }, thread_pool);
 
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 5 }, .denominator{ 11 }, .out_port_min{ 10 }, .out_port_max{ 41 }, .exp_in{ 88 }, .exp_out{ 40 }, .exp_counter{ 1 } },
-                                      thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 7 }, .denominator{ 3 }, .out_port_min{ 10 }, .out_port_max{ 10 }, .exp_in{ 0 }, .exp_out{ 0 }, .exp_counter{ 0 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 80 }, .numerator{ 2 }, .denominator{ 4 }, .out_port_min{ 20 }, .out_port_max{ 20 }, .exp_in{ 40 }, .exp_out{ 20 }, .exp_counter{ 2 } }, thread_pool);
-        interpolation_decimation_test({ .n_samples{ 100 }, .numerator{ 7 }, .denominator{ 3 }, .out_port_min{ 10 }, .out_port_max{ 20 }, .exp_in{ 6 }, .exp_out{ 14 }, .exp_counter{ 16 } },
-                                      thread_pool);
+        interpolation_decimation_test({ .n_samples =  100, .numerator = 5, .denominator = 11, .out_port_min = 10 , .out_port_max = 41, .exp_in = 88, .exp_out = 40, .exp_counter =  1 }, thread_pool);
+        interpolation_decimation_test({ .n_samples =  100, .numerator = 7, .denominator =  3, .out_port_min = 10 , .out_port_max = 10, .exp_in =  0, .exp_out =  0, .exp_counter =  0 }, thread_pool);
+        interpolation_decimation_test({ .n_samples =   80, .numerator = 2, .denominator =  4, .out_port_min = 20 , .out_port_max = 20, .exp_in = 40, .exp_out = 20, .exp_counter =  2 }, thread_pool);
+        interpolation_decimation_test({ .n_samples =  100, .numerator = 7, .denominator =  3, .out_port_min = 10 , .out_port_max = 20, .exp_in =  6, .exp_out = 14, .exp_counter = 16 }, thread_pool);
     };
 
     "Stride tests"_test = [&thread_pool] {
-        stride_test({ .n_samples{ 1024 }, .stride{ 0 }, .in_port_max{ 1024 }, .exp_in{ 1024 }, .exp_out{ 1024 }, .exp_counter{ 1 }, .exp_total_in{ 1024 }, .exp_total_out{ 1024 } }, thread_pool);
-        stride_test({ .n_samples{ 1000 }, .stride{ 100 }, .in_port_max{ 50 }, .exp_in{ 50 }, .exp_out{ 50 }, .exp_counter{ 10 }, .exp_total_in{ 500 }, .exp_total_out{ 500 } }, thread_pool);
-        stride_test({ .n_samples{ 1000 }, .stride{ 133 }, .in_port_max{ 50 }, .exp_in{ 50 }, .exp_out{ 50 }, .exp_counter{ 8 }, .exp_total_in{ 400 }, .exp_total_out{ 400 } }, thread_pool);
-        stride_test({ .n_samples{ 1000 }, .stride{ 50 }, .in_port_max{ 100 }, .exp_in{ 50 }, .exp_out{ 50 }, .exp_counter{ 20 }, .exp_total_in{ 1950 }, .exp_total_out{ 1950 } }, thread_pool);
-        stride_test({ .n_samples{ 1000 }, .stride{ 33 }, .in_port_max{ 100 }, .exp_in{ 10 }, .exp_out{ 10 }, .exp_counter{ 31 }, .exp_total_in{ 2929 }, .exp_total_out{ 2929 } }, thread_pool);
-        // clang-format off
-        stride_test({ .n_samples{ 1000 }, .numerator{ 2 }, .denominator{ 4 }, .stride{ 50 }, .in_port_max{ 100 }, .exp_in{ 48 }, .exp_out{ 24 }, .exp_counter{ 20 }, .exp_total_in{ 1948 }, .exp_total_out{ 974 } },
-                    thread_pool);
-        stride_test({ .n_samples{ 1000 }, .numerator{ 2 }, .denominator{ 4 }, .stride{ 50 }, .in_port_max{ 50 }, .exp_in{ 48 }, .exp_out{ 24 }, .exp_counter{ 20 }, .exp_total_in{ 960 }, .exp_total_out{ 480 } },
-                    thread_pool);
-        // clang-format on
+        stride_test( {.n_samples = 1024 , .stride =   0 , .in_port_max = 1024 , .exp_in = 1024 , .exp_out = 1024 , .exp_counter =  1 , .exp_total_in = 1024 , .exp_total_out = 1024 }, thread_pool);
+        stride_test( {.n_samples = 1000 , .stride = 100 , .in_port_max =   50 , .exp_in =   50 , .exp_out =   50 , .exp_counter = 10 , .exp_total_in =  500 , .exp_total_out =  500 }, thread_pool);
+        stride_test( {.n_samples = 1000 , .stride = 133 , .in_port_max =   50 , .exp_in =   50 , .exp_out =   50 , .exp_counter =  8 , .exp_total_in =  400 , .exp_total_out =  400 }, thread_pool);
+        stride_test( {.n_samples = 1000 , .stride =  50 , .in_port_max =  100 , .exp_in =   50 , .exp_out =   50 , .exp_counter = 20 , .exp_total_in = 1950 , .exp_total_out = 1950 }, thread_pool);
+        stride_test( {.n_samples = 1000 , .stride =  33 , .in_port_max =  100 , .exp_in =   10 , .exp_out =   10 , .exp_counter = 31 , .exp_total_in = 2929 , .exp_total_out = 2929 }, thread_pool);
+        stride_test( {.n_samples = 1000 , .numerator = 2 , .denominator = 4 , .stride = 50 , .in_port_max = 100 , .exp_in = 48 , .exp_out = 24 , .exp_counter = 20 , .exp_total_in = 1948 , .exp_total_out = 974 }, thread_pool);
+        stride_test( {.n_samples = 1000 , .numerator = 2 , .denominator = 4 , .stride = 50 , .in_port_max =  50 , .exp_in = 48 , .exp_out = 24 , .exp_counter = 20 , .exp_total_in =  960 , .exp_total_out = 480 }, thread_pool);
 
-        std::vector<int> exp_v1 = { 0, 1, 2, 3, 4, 3, 4, 5, 6, 7, 6, 7, 8, 9, 10, 9, 10, 11, 12, 13, 12, 13, 14 };
-        stride_test({ .n_samples{ 15 }, .stride{ 3 }, .in_port_max{ 5 }, .exp_in{ 3 }, .exp_out{ 3 }, .exp_counter{ 5 }, .exp_total_in{ 23 }, .exp_total_out{ 23 }, .exp_in_vector{ exp_v1 } },
-                    thread_pool);
+        std::vector<int> exp_v1 = {0, 1, 2, 3, 4, 3, 4, 5, 6, 7, 6, 7, 8, 9, 10, 9, 10, 11, 12, 13, 12, 13, 14};
+        stride_test( {.n_samples = 15, .stride = 3, .in_port_max = 5, .exp_in = 3, .exp_out = 3, .exp_counter = 5, .exp_total_in = 23, .exp_total_out = 23, .exp_in_vector = exp_v1 }, thread_pool);
 
-        std::vector<int> exp_v2 = { 0, 1, 2, 5, 6, 7, 10, 11, 12 };
-        stride_test({ .n_samples{ 15 }, .stride{ 5 }, .in_port_max{ 3 }, .exp_in{ 3 }, .exp_out{ 3 }, .exp_counter{ 3 }, .exp_total_in{ 9 }, .exp_total_out{ 9 }, .exp_in_vector{ exp_v2 } },
-                    thread_pool);
+        std::vector<int> exp_v2 = {0, 1, 2, 5, 6, 7, 10, 11, 12};
+        stride_test( {.n_samples = 15, .stride = 5, .in_port_max = 3, .exp_in = 3, .exp_out = 3, .exp_counter = 3, .exp_total_in = 9, .exp_total_out = 9, .exp_in_vector = exp_v2 }, thread_pool);
 
         // assuming buffer size is approx 65k
-        stride_test({ .n_samples{ 1000000 }, .stride{ 250000 }, .in_port_max{ 100 }, .exp_in{ 100 }, .exp_out{ 100 }, .exp_counter{ 4 }, .exp_total_in{ 400 }, .exp_total_out{ 400 } }, thread_pool);
-        stride_test({ .n_samples{ 1000000 }, .stride{ 249900 }, .in_port_max{ 100 }, .exp_in{ 100 }, .exp_out{ 100 }, .exp_counter{ 5 }, .exp_total_in{ 500 }, .exp_total_out{ 500 } }, thread_pool);
+        stride_test( {.n_samples = 1000000, .stride = 250000, .in_port_max = 100, .exp_in = 100, .exp_out = 100, .exp_counter = 4, .exp_total_in = 400, .exp_total_out = 400 }, thread_pool);
+        stride_test( {.n_samples = 1000000, .stride = 249900, .in_port_max = 100, .exp_in = 100, .exp_out = 100, .exp_counter = 5, .exp_total_in = 500, .exp_total_out = 500 }, thread_pool);
     };
+    // clang-format on
 };
 
 int


### PR DESCRIPTION
temporarily disable asan for test which fails due to changes in the github action environment.

runner release that probably caused the failures: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230814.1

Only  mentioned related change is a micro version in cmake.

Also resolves all gcc warnings.