### PR TITLE
Several changes in FFT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,13 +17,13 @@ if (EMSCRIPTEN)
     target_compile_options(graph-prototype-options INTERFACE
             -fwasm-exceptions
             -pthread
-            )
+    )
     target_link_options(graph-prototype-options INTERFACE
             "SHELL:-s ALLOW_MEMORY_GROWTH=1"
             -fwasm-exceptions
             -pthread
             "SHELL:-s PTHREAD_POOL_SIZE=30"
-            )
+    )
 endif ()
 
 
@@ -92,7 +92,7 @@ ExternalProject_Add(fftw_ext
         BUILD_COMMAND ""
         INSTALL_COMMAND ""
         LOG_DOWNLOAD ON
-        )
+)
 
 include_directories(${FFTW_PREFIX}/install/include)
 

--- a/bench/bm_fft.cpp
+++ b/bench/bm_fft.cpp
@@ -5,7 +5,7 @@
 #include <fmt/format.h>
 #include <numbers>
 
-/// This custom implementation of FFT ("compute_fft_v1" and "compute_fft_v1") is done only for performance comparison with default FFTW implementation.
+/// This custom implementation of FFT ("compute_fft_v1" and "computeFftV1") is done only for performance comparison with default FFTW implementation.
 
 /**
  * Real-valued fast fourier transform algorithms
@@ -16,7 +16,7 @@
 template<typename T>
     requires gr::blocks::fft::ComplexType<T>
 void
-compute_fft_v1(std::vector<T> &signal) {
+computeFftV1(std::vector<T> &signal) {
     const std::size_t N{ signal.size() };
     for (std::size_t j = 0, rev = 0; j < N; j++) {
         if (j < rev) std::swap(signal[j], signal[rev]);
@@ -47,7 +47,7 @@ compute_fft_v1(std::vector<T> &signal) {
 template<typename T>
     requires gr::blocks::fft::ComplexType<T>
 void
-compute_fft_v2(std::vector<T> &signal) {
+computeFftV2(std::vector<T> &signal) {
     const std::size_t N{ signal.size() };
 
     if (N == 1) return;
@@ -59,8 +59,8 @@ compute_fft_v2(std::vector<T> &signal) {
         odd[i]  = signal[2 * i + 1];
     }
 
-    compute_fft_v2(even);
-    compute_fft_v2(odd);
+    computeFftV2(even);
+    computeFftV2(odd);
 
     const typename T::value_type wn{ static_cast<typename T::value_type>(2. * std::numbers::pi) / static_cast<typename T::value_type>(N) };
     for (std::size_t i = 0; i < N / 2; i++) {
@@ -73,24 +73,24 @@ compute_fft_v2(std::vector<T> &signal) {
 template<typename T>
     requires gr::blocks::fft::ComplexType<T>
 std::vector<typename T::value_type>
-compute_magnitude_spectrum(std::vector<T> &fft_signal) {
-    const std::size_t                   N{ fft_signal.size() };
-    std::vector<typename T::value_type> magnitude_spectrum(N / 2);
+computeMagnitudeSpectrum(std::vector<T> &fftSignal) {
+    const std::size_t                   N{ fftSignal.size() };
+    std::vector<typename T::value_type> magnitudeSpectrum(N / 2);
     for (std::size_t i = 0; i < N / 2; i++) {
-        magnitude_spectrum[i] = std::hypot(fft_signal[i].real(), fft_signal[i].imag()) * static_cast<typename T::value_type>(2.) / static_cast<typename T::value_type>(N);
+        magnitudeSpectrum[i] = std::hypot(fftSignal[i].real(), fftSignal[i].imag()) * static_cast<typename T::value_type>(2.) / static_cast<typename T::value_type>(N);
     }
-    return magnitude_spectrum;
+    return magnitudeSpectrum;
 }
 
 template<typename T>
 std::vector<T>
-generate_sin_sample(std::size_t N, double sample_rate, double frequency, double amplitude) {
+generateSinSample(std::size_t N, double sampleRate, double frequency, double amplitude) {
     std::vector<T> signal(N);
     for (std::size_t i = 0; i < N; i++) {
         if constexpr (gr::blocks::fft::ComplexType<T>) {
-            signal[i] = { static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sample_rate)), 0. };
+            signal[i] = { static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate)), 0. };
         } else {
-            signal[i] = static_cast<T>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sample_rate));
+            signal[i] = static_cast<T>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate));
         }
     }
     return signal;
@@ -98,62 +98,62 @@ generate_sin_sample(std::size_t N, double sample_rate, double frequency, double 
 
 template<typename T>
 void
-test_fft(bool with_mag_spectrum) {
+testFft(bool withMagSpectrum) {
     using namespace benchmark;
     using namespace boost::ut::reflection;
 
     constexpr std::size_t N{ 1024 }; // must be power of 2
-    constexpr double      sample_rate{ 256. };
+    constexpr double      sampleRate{ 256. };
     constexpr double      frequency{ 100. };
     constexpr double      amplitude{ 1. };
-    constexpr int         n_repetitions{ 100 };
+    constexpr int         nRepetitions{ 100 };
 
     static_assert(std::has_single_bit(N));
 
-    std::vector<T> signal   = generate_sin_sample<T>(N, sample_rate, frequency, amplitude);
-    std::string    name_opt = with_mag_spectrum ? "fft+mag" : "fft";
+    std::vector<T> signal  = generateSinSample<T>(N, sampleRate, frequency, amplitude);
+    std::string    nameOpt = withMagSpectrum ? "fft+mag" : "fft";
 
     {
         gr::blocks::fft::fft<T> fft1{};
-        std::ignore = fft1.settings().set({ { "fft_size", N } });
+        std::ignore = fft1.settings().set({ { "fftSize", N } });
         std::ignore = fft1.settings().apply_staged_parameters();
         fft1.inputHistory.push_back_bulk(signal.begin(), signal.end());
 
-        ::benchmark::benchmark<n_repetitions>(fmt::format("{} - {} fftw", name_opt, type_name<T>())) = [&fft1, &with_mag_spectrum] {
-            fft1.prepare_input();
-            fft1.compute_fft();
-            if (with_mag_spectrum) fft1.compute_magnitude_spectrum();
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - {} fftw", nameOpt, type_name<T>())) = [&fft1, &withMagSpectrum] {
+            fft1.prepareInput();
+            fft1.computeFft();
+            if (withMagSpectrum) fft1.computeMagnitudeSpectrum();
         };
     }
 
     if constexpr (gr::blocks::fft::ComplexType<T>) {
-        ::benchmark::benchmark<n_repetitions>(fmt::format("{} - {} fft_v1", name_opt, type_name<T>())) = [&signal, &with_mag_spectrum] {
-            auto signal_copy = signal;
-            compute_fft_v1<T>(signal_copy);
-            if (with_mag_spectrum) [[maybe_unused]]
-                auto magnitude_spectrum = compute_magnitude_spectrum<T>(signal_copy);
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - {} fft_v1", nameOpt, type_name<T>())) = [&signal, &withMagSpectrum] {
+            auto signalCopy = signal;
+            computeFftV1<T>(signalCopy);
+            if (withMagSpectrum) [[maybe_unused]]
+                auto magnitudeSpectrum = computeMagnitudeSpectrum<T>(signalCopy);
         };
 
-        ::benchmark::benchmark<n_repetitions>(fmt::format("{} - {} fft_v2", name_opt, type_name<T>())) = [&signal, &with_mag_spectrum] {
-            auto signal_copy = signal;
-            compute_fft_v2<T>(signal_copy);
-            if (with_mag_spectrum) [[maybe_unused]]
-                auto magnitude_spectrum = compute_magnitude_spectrum<T>(signal_copy);
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - {} fft_v2", nameOpt, type_name<T>())) = [&signal, &withMagSpectrum] {
+            auto signalCopy = signal;
+            computeFftV2<T>(signalCopy);
+            if (withMagSpectrum) [[maybe_unused]]
+                auto magnitudeSpectrum = computeMagnitudeSpectrum<T>(signalCopy);
         };
     }
 }
 
 inline const boost::ut::suite _fft_bm_tests = [] {
-    std::tuple<std::complex<float>, std::complex<double>> complex_types_to_test{};
-    std::tuple<float, double>                             real_types_to_test{};
+    std::tuple<std::complex<float>, std::complex<double>> complexTypesToTest{};
+    std::tuple<float, double>                             realTypesToTest{};
 
-    std::apply([]<class... TArgs>(TArgs... /*args*/) { (test_fft<TArgs>(false), ...); }, complex_types_to_test);
+    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFft<TArgs>(false), ...); }, complexTypesToTest);
     benchmark::results::add_separator();
-    std::apply([]<class... TArgs>(TArgs... /*args*/) { (test_fft<TArgs>(true), ...); }, complex_types_to_test);
+    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFft<TArgs>(true), ...); }, complexTypesToTest);
     benchmark::results::add_separator();
-    std::apply([]<class... TArgs>(TArgs... /*args*/) { (test_fft<TArgs>(false), ...); }, real_types_to_test);
+    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFft<TArgs>(false), ...); }, realTypesToTest);
     benchmark::results::add_separator();
-    std::apply([]<class... TArgs>(TArgs... /*args*/) { (test_fft<TArgs>(true), ...); }, real_types_to_test);
+    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFft<TArgs>(true), ...); }, realTypesToTest);
 };
 
 int

--- a/test/blocklib/core/fft/fft.hpp
+++ b/test/blocklib/core/fft/fft.hpp
@@ -1,6 +1,7 @@
 #ifndef GRAPH_PROTOTYPE_FFT_HPP
 #define GRAPH_PROTOTYPE_FFT_HPP
 
+#include "window.hpp"
 #include <dataset.hpp>
 #include <fftw3.h>
 #include <history_buffer.hpp>
@@ -32,81 +33,105 @@ public:
     // clang-format off
     template<typename FftwT>
     struct fftw {
-        using plan_type     = fftwf_plan;
-        using in_data_type  = std::conditional_t<ComplexType<FftwT>, fftwf_complex, float>;
-        using out_data_type = fftwf_complex;
-        using precision_type = float;
-        using in_history_type  = std::conditional_t<ComplexType<FftwT>, std::complex<float>, float>; // history_buffer can not store c-arrays -> use std::complex
+        using PlanType       = fftwf_plan;
+        using InDataType    = std::conditional_t<ComplexType<FftwT>, fftwf_complex, float>;
+        using OutDataType   = fftwf_complex;
+        using PrecisionType  = float;
+        using InHistoryType = std::conditional_t<ComplexType<FftwT>, std::complex<float>, float>; // history_buffer can not store c-arrays -> use std::complex
+        using InUniquePtr   = std::unique_ptr<InDataType [], decltype([](InDataType *ptr) { fftwf_free(ptr); })>;
+        using OutUniquePtr  = std::unique_ptr<OutDataType [], decltype([](OutDataType *ptr) { fftwf_free(ptr); })>;
+        using PlanUniquePtr = std::unique_ptr<std::remove_pointer_t<PlanType>, decltype([](PlanType ptr) { fftwf_destroy_plan(ptr); })>;
 
-        static void execute(const plan_type p) { fftwf_execute(p); }
-        static void destroy_plan(plan_type p) { fftwf_destroy_plan(p); }
-        static void free(void *p) { fftwf_free(p); }
+        static void execute(const PlanType p) { fftwf_execute(p); }
         static void cleanup() { fftwf_cleanup(); }
         static void * malloc(std::size_t n) { return fftwf_malloc(n);}
-        static plan_type plan(int p_n, in_data_type *p_in, out_data_type *p_out, int p_sign, unsigned int p_flags) {
-            if constexpr (std::is_same_v<in_data_type, float>) {
+        static PlanType plan(int p_n, InDataType *p_in, OutDataType *p_out, int p_sign, unsigned int p_flags) {
+            if constexpr (std::is_same_v<InDataType, float>) {
                 return fftwf_plan_dft_r2c_1d(p_n, p_in, p_out, p_flags);
             } else {
                 return fftwf_plan_dft_1d(p_n, p_in, p_out, p_sign, p_flags);
             }
         }
-        static int import_wisdom_from_filename(const std::string& path) {return fftwf_import_wisdom_from_filename(path.c_str());}
-        static int export_wisdom_to_filename(const std::string& path) {return fftwf_export_wisdom_to_filename(path.c_str());}
+        static int importWisdomFromFilename(const std::string& path) {return fftwf_import_wisdom_from_filename(path.c_str());}
+        static int exportWisdomToFilename(const std::string& path) {return fftwf_export_wisdom_to_filename(path.c_str());}
+        static int importWisdomFromString(const std::string& str) {return fftwf_import_wisdom_from_string(str.c_str());}
+        static std::string exportWisdomToString() {
+            char* cstr = fftwf_export_wisdom_to_string();
+            if (cstr == nullptr) return "";
+            std::string str(cstr);
+            fftwf_free(cstr);
+            return str;
+        }
+        static void forgetWisdom() {fftwf_forget_wisdom();}
     };
 
     template<DoubleType FftwDoubleT>
     struct fftw<FftwDoubleT> {
-        using plan_type     = fftw_plan;
-        using in_data_type  = std::conditional_t<ComplexType<FftwDoubleT>, fftw_complex, double>;
-        using out_data_type = fftw_complex;
-        using precision_type = double;
-        using in_history_type  = std::conditional_t<ComplexType<FftwDoubleT>, std::complex<double>, double>; // history_buffer can not store c-arrays -> use std::complex
+        using PlanType       = fftw_plan;
+        using InDataType    = std::conditional_t<ComplexType<FftwDoubleT>, fftw_complex, double>;
+        using OutDataType   = fftw_complex;
+        using PrecisionType  = double;
+        using InHistoryType = std::conditional_t<ComplexType<FftwDoubleT>, std::complex<double>, double>; // history_buffer can not store c-arrays -> use std::complex
+        using InUniquePtr   = std::unique_ptr<InDataType [], decltype([](InDataType *ptr) { fftwf_free(ptr); })>;
+        using OutUniquePtr  = std::unique_ptr<OutDataType [], decltype([](OutDataType *ptr) { fftwf_free(ptr); })>;
+        using PlanUniquePtr = std::unique_ptr<std::remove_pointer_t<PlanType>, decltype([](PlanType ptr) { fftw_destroy_plan(ptr); })>;
 
-        static void execute(const plan_type p) { fftw_execute(p); }
-        static void destroy_plan(plan_type p) { fftw_destroy_plan(p); }
-        static void free(void *p) { fftw_free(p); }
+        static void execute(const PlanType p) { fftw_execute(p); }
         static void cleanup() { fftw_cleanup(); }
         static void * malloc(std::size_t n) { return fftw_malloc(n);}
-        static plan_type plan(int p_n, in_data_type *p_in, out_data_type *p_out, int p_sign, unsigned int p_flags) {
-            if constexpr (std::is_same_v<in_data_type, double>) {
+        static PlanType plan(int p_n, InDataType *p_in, OutDataType *p_out, int p_sign, unsigned int p_flags) {
+            if constexpr (std::is_same_v<InDataType, double>) {
                 return fftw_plan_dft_r2c_1d(p_n, p_in, p_out, p_flags);
             } else {
                 return fftw_plan_dft_1d(p_n, p_in, p_out, p_sign, p_flags);
             }
         }
-        static int import_wisdom_from_filename(const std::string& path) {return fftw_import_wisdom_from_filename(path.c_str());}
-        static int export_wisdom_to_filename(const std::string& path) {return fftw_export_wisdom_to_filename(path.c_str());}
+        static int importWisdomFromFilename(const std::string& path) {return fftw_import_wisdom_from_filename(path.c_str());}
+        static int exportWisdomToFilename(const std::string& path) {return fftw_export_wisdom_to_filename(path.c_str());}
+        static int importWisdomFromString(const std::string& str) {return fftw_import_wisdom_from_string(str.c_str());}
+        static std::string exportWisdomToString() {
+            char* cstr = fftw_export_wisdom_to_string();
+            if (cstr == nullptr) return "";
+            std::string str(cstr);
+            fftw_free(cstr);
+            return str;
+        }
+        static void forgetWisdom() {fftw_forget_wisdom();}
     };
 
-    template <typename signedT> struct make_signed { using type = signedT;};
-    template <std::integral signedT> struct make_signed<signedT> { using type = std::make_signed_t<signedT>; };
-    template<typename evalU> struct eval_output_type { using type1 = evalU; using type2 = typename make_signed<T>::type;};
-    template<ComplexType evalU> struct eval_output_type<evalU> { using type1 = typename evalU::value_type; using type2 = evalU;};
-    using U = std::conditional_t<ComplexType<T>, typename eval_output_type<T>::type1, typename eval_output_type<T>::type2>;
+    template <typename signedT> struct MakeSigned { using type = signedT;};
+    template <std::integral signedT> struct MakeSigned<signedT> { using type = std::make_signed_t<signedT>; };
+    template<typename evalU> struct EvalOutputType { using type1 = evalU; using type2 = typename MakeSigned<T>::type;};
+    template<ComplexType evalU> struct EvalOutputType<evalU> { using type1 = typename evalU::value_type; using type2 = evalU;};
+    using U = std::conditional_t<ComplexType<T>, typename EvalOutputType<T>::type1, typename EvalOutputType<T>::type2>;
     // clang-format on
 
-    using plan_type       = typename fftw<T>::plan_type;
-    using in_data_type    = typename fftw<T>::in_data_type;
-    using out_data_type   = typename fftw<T>::out_data_type;
-    using precision_type  = typename fftw<T>::precision_type;
-    using in_history_type = typename fftw<T>::in_history_type;
+    using InDataType    = typename fftw<T>::InDataType;
+    using OutDataType   = typename fftw<T>::OutDataType;
+    using PrecisionType = typename fftw<T>::PrecisionType;
+    using InHistoryType = typename fftw<T>::InHistoryType;
+    using InUniquePtr   = typename fftw<T>::InUniquePtr;
+    using OutUniquePtr  = typename fftw<T>::OutUniquePtr;
+    using PlanUniquePtr = typename fftw<T>::PlanUniquePtr;
 
-    IN<T>                           in;
-    OUT<DataSet<U>>                 out;
+    IN<T>                         in;
+    OUT<DataSet<U>>               out;
 
-    std::size_t                     fft_size{ 1024 };
-    bool                            output_in_dB{ false };
-    std::string                     wisdom_path{ ".gr_fftw_wisdom" };
-    int                             sign{ FFTW_FORWARD };
-    unsigned int                    flags{ FFTW_ESTIMATE }; // FFTW_EXHAUSTIVE, FFTW_MEASURE, FFTW_ESTIMATE
-    history_buffer<in_history_type> inputHistory{ fft_size };
-    in_data_type                   *fftw_in{ nullptr };
-    out_data_type                  *fftw_out{ nullptr };
-    plan_type                       fftw_p{ nullptr };
-    std::vector<U>                  magnitude_spectrum{};
-    std::vector<U>                  phase_spectrum{};
+    std::size_t                   fftSize{ 1024 };
+    int                           window{ static_cast<int>(WindowFunction::None) };
+    std::vector<PrecisionType>    windowVector;
+    bool                          outputInDb{ false };
+    std::string                   wisdomPath{ ".gr_fftw_wisdom" };
+    int                           sign{ FFTW_FORWARD };
+    unsigned int                  flags{ FFTW_ESTIMATE }; // FFTW_EXHAUSTIVE, FFTW_MEASURE, FFTW_ESTIMATE
+    history_buffer<InHistoryType> inputHistory{ fftSize };
+    InUniquePtr                   fftwIn{};
+    OutUniquePtr                  fftwOut{};
+    PlanUniquePtr                 fftwPlan{};
+    std::vector<U>                magnitudeSpectrum{};
+    std::vector<U>                phaseSpectrum{};
 
-    fft() { init_all(); }
+    fft() { initAll(); }
 
     fft(const fft &rhs)     = delete;
     fft(fft &&rhs) noexcept = delete;
@@ -117,153 +142,197 @@ public:
     operator=(fft &&rhs) noexcept
             = delete;
 
-    ~fft() { clear_fftw(); }
+    ~fft() { clearFftw(); }
 
     void
-    settings_changed(const property_map & /*old_settings*/, const property_map &new_settings) noexcept {
-        if (new_settings.contains("fft_size") && fft_size != inputHistory.capacity()) {
-            inputHistory = history_buffer<in_history_type>(fft_size);
-            init_all();
+    settings_changed(const property_map & /*old_settings*/, const property_map &newSettings) noexcept {
+        if (newSettings.contains("fftSize") && fftSize != inputHistory.capacity()) {
+            inputHistory = history_buffer<InHistoryType>(fftSize);
+            initAll();
+        } else if (newSettings.contains("window")) { // no need to create window twice if fftSize was changed
+            initWindowFunction();
         }
     }
 
     constexpr DataSet<U>
     process_one(T input) noexcept {
-        if constexpr (std::is_same_v<T, in_history_type>) {
+        if constexpr (std::is_same_v<T, InHistoryType>) {
             inputHistory.push_back(input);
         } else {
-            inputHistory.push_back(static_cast<in_history_type>(input));
+            inputHistory.push_back(static_cast<InHistoryType>(input));
         }
 
-        if (inputHistory.size() >= fft_size) {
-            prepare_input();
-            compute_fft();
-            compute_magnitude_spectrum();
-            return create_dataset();
+        if (inputHistory.size() >= fftSize) {
+            prepareInput();
+            computeFft();
+            computeMagnitudeSpectrum();
+            computePhaseSpectrum();
+            return createDataset();
         } else {
             return DataSet<U>();
         }
     }
 
     constexpr DataSet<U>
-    create_dataset() {
+    createDataset() {
         DataSet<U> ds{};
         ds.timestamp = 0;
-        const std::size_t N{ magnitude_spectrum.size() };
+        const std::size_t N{ magnitudeSpectrum.size() };
 
         ds.axis_names   = { "time", "fft.real", "fft.imag", "magnitude", "phase" };
-        ds.axis_units   = { "u.a.", "u.a.", "u.a.", "u.a.", "u.a." };
+        ds.axis_units   = { "u.a.", "u.a.", "u.a.", "u.a.", "rad" };
         ds.extents      = { 4, static_cast<int32_t>(N) };
         ds.layout       = fair::graph::layout_right{};
         ds.signal_names = { "fft.real", "fft.imag", "magnitude", "phase" };
-        ds.signal_units = { "u.a.", "u.a.", "u.a.", "u.a." };
+        ds.signal_units = { "u.a.", "u.a.", "u.a.", "rad" };
 
         ds.signal_values.resize(4 * N);
+        ds.signal_ranges = { { std::numeric_limits<U>::max(), std::numeric_limits<U>::lowest() },
+                             { std::numeric_limits<U>::max(), std::numeric_limits<U>::lowest() },
+                             { std::numeric_limits<U>::max(), std::numeric_limits<U>::lowest() },
+                             { std::numeric_limits<U>::max(), std::numeric_limits<U>::lowest() } };
         for (std::size_t i = 0; i < N; i++) {
-            if constexpr (std::is_same_v<U, precision_type>) {
-                ds.signal_values[i]     = fftw_out[i][0];
-                ds.signal_values[i + N] = fftw_out[i][1];
+            if constexpr (std::is_same_v<U, PrecisionType>) {
+                ds.signal_values[i]     = fftwOut[i][0];
+                ds.signal_values[i + N] = fftwOut[i][1];
             } else {
-                ds.signal_values[i]     = static_cast<U>(fftw_out[i][0]);
-                ds.signal_values[i + N] = static_cast<U>(fftw_out[i][1]);
+                ds.signal_values[i]     = static_cast<U>(fftwOut[i][0]);
+                ds.signal_values[i + N] = static_cast<U>(fftwOut[i][1]);
             }
-            ds.signal_values[i + 2 * N] = magnitude_spectrum[i];
-            ds.signal_values[i + 3 * N] = phase_spectrum[i];
+            ds.signal_ranges[0][0]      = std::min(ds.signal_ranges[0][0], ds.signal_values[i]);
+            ds.signal_ranges[0][1]      = std::max(ds.signal_ranges[0][1], ds.signal_values[i]);
+            ds.signal_ranges[1][0]      = std::min(ds.signal_ranges[1][0], ds.signal_values[i + N]);
+            ds.signal_ranges[1][1]      = std::max(ds.signal_ranges[1][1], ds.signal_values[i + N]);
+
+            ds.signal_values[i + 2 * N] = magnitudeSpectrum[i];
+            ds.signal_ranges[2][0]      = std::min(ds.signal_ranges[2][0], magnitudeSpectrum[i]);
+            ds.signal_ranges[2][1]      = std::max(ds.signal_ranges[2][1], magnitudeSpectrum[i]);
+
+            ds.signal_values[i + 3 * N] = phaseSpectrum[i];
+            ds.signal_ranges[3][0]      = std::min(ds.signal_ranges[3][0], phaseSpectrum[i]);
+            ds.signal_ranges[3][1]      = std::max(ds.signal_ranges[3][1], phaseSpectrum[i]);
         }
 
-        ds.signal_errors = {};
-
-        for (std::size_t i = 0; i < 4; i++) {
-            const auto mm = std::minmax_element(std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(i * N)), std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>((i + 1) * N)));
-            ds.signal_ranges.push_back({ *mm.first, *mm.second });
-        }
+        ds.signal_errors    = {};
+        ds.meta_information = {
+            { { "fftSize", fftSize }, { "window", window }, { "outputInDb", outputInDb }, { "numerator", this->numerator }, { "denominator", this->denominator }, { "stride", this->stride } }
+        };
 
         return ds;
     }
 
     void
-    prepare_input() {
-        static_assert(sizeof(in_data_type) == sizeof(in_history_type), "std::complex<T> and T[2] must have the same size");
-        std::memcpy(fftw_in, &(*inputHistory.begin()), sizeof(in_data_type) * fft_size);
-    }
-
-    void
-    compute_fft() {
-        fftw<T>::execute(fftw_p);
-    }
-
-    void
-    compute_magnitude_spectrum() {
-        for (std::size_t i = 0; i < magnitude_spectrum.size(); i++) {
-            const precision_type mag{ std::hypot(fftw_out[i][0], fftw_out[i][1]) * static_cast<precision_type>(2.0) / static_cast<precision_type>(fft_size) };
-            magnitude_spectrum[i] = static_cast<U>(output_in_dB ? static_cast<precision_type>(20.) * std::log10(std::abs(mag)) : mag);
+    prepareInput() {
+        static_assert(sizeof(InDataType) == sizeof(InHistoryType), "std::complex<T> and T[2] must have the same size");
+        std::memcpy(fftwIn.get(), &(*inputHistory.begin()), sizeof(InDataType) * fftSize);
+        // apply window function if needed
+        if (window != static_cast<int>(WindowFunction::None)) {
+            if (fftSize != windowVector.size()) throw std::runtime_error(fmt::format("fftSize({}) and windowVector.size({}) are not equal.", fftSize, windowVector.size()));
+            for (std::size_t i = 0; i < fftSize; i++) {
+                if constexpr (ComplexType<T>) {
+                    fftwIn[i][0] *= windowVector[i];
+                    fftwIn[i][1] *= windowVector[i];
+                } else {
+                    fftwIn[i] *= windowVector[i];
+                }
+            }
         }
     }
 
     void
-    compute_phase_spectrum() {
-        for (std::size_t i = 0; i < phase_spectrum.size(); i++) {
-            const auto phase{ std::atan2(fftw_out[i][1], fftw_out[i][0]) };
-            phase_spectrum[i] = static_cast<U>(output_in_dB ? 20. * log10(abs(phase)) : phase);
+    computeFft() {
+        fftw<T>::execute(fftwPlan.get());
+    }
+
+    void
+    computeMagnitudeSpectrum() {
+        for (std::size_t i = 0; i < magnitudeSpectrum.size(); i++) {
+            const PrecisionType mag{ std::hypot(fftwOut[i][0], fftwOut[i][1]) * static_cast<PrecisionType>(2.0) / static_cast<PrecisionType>(fftSize) };
+            magnitudeSpectrum[i] = static_cast<U>(outputInDb ? static_cast<PrecisionType>(20.) * std::log10(std::abs(mag)) : mag);
         }
     }
 
     void
-    init_all() {
-        clear_fftw();
-        fftw_in = static_cast<in_data_type *>(fftw<T>::malloc(sizeof(in_data_type) * fft_size));
+    computePhaseSpectrum() {
+        for (std::size_t i = 0; i < phaseSpectrum.size(); i++) {
+            const auto phase{ std::atan2(fftwOut[i][1], fftwOut[i][0]) };
+            phaseSpectrum[i] = outputInDb ? static_cast<U>(20.) * std::log10(std::abs(phase)) : phase;
+        }
+    }
+
+    void
+    initAll() {
+        clearFftw();
+        fftwIn = InUniquePtr(static_cast<InDataType *>(fftw<T>::malloc(sizeof(InDataType) * fftSize)));
         if constexpr (ComplexType<T>) {
-            fftw_out = static_cast<out_data_type *>(fftw<T>::malloc(sizeof(out_data_type) * fft_size));
-            magnitude_spectrum.resize(fft_size);
-            phase_spectrum.resize(fft_size);
+            fftwOut = OutUniquePtr(static_cast<OutDataType *>(fftw<T>::malloc(sizeof(OutDataType) * fftSize)));
+            magnitudeSpectrum.resize(fftSize);
+            phaseSpectrum.resize(fftSize);
         } else {
-            fftw_out = static_cast<out_data_type *>(fftw<T>::malloc(sizeof(out_data_type) * (1 + fft_size / 2)));
-            magnitude_spectrum.resize(fft_size / 2);
-            phase_spectrum.resize(fft_size / 2);
+            fftwOut = OutUniquePtr(static_cast<OutDataType *>(fftw<T>::malloc(sizeof(OutDataType) * (1 + fftSize / 2))));
+            magnitudeSpectrum.resize(fftSize / 2);
+            phaseSpectrum.resize(fftSize / 2);
         }
         {
             std::lock_guard lg{ fftw_plan_mutex };
-            import_wisdom();
-            fftw_p = fftw<T>::plan(static_cast<int>(fft_size), fftw_in, fftw_out, sign, flags);
-            export_wisdom();
+            importWisdom();
+            fftwPlan = PlanUniquePtr(fftw<T>::plan(static_cast<int>(fftSize), fftwIn.get(), fftwOut.get(), sign, flags));
+            exportWisdom();
         }
+
+        initWindowFunction();
     }
 
     void
-    clear_fftw() {
-        if (fftw_p != nullptr) {
+    initWindowFunction() {
+        windowVector = createWindowFunction<PrecisionType>(static_cast<WindowFunction>(window), fftSize);
+    }
+
+    void
+    clearFftw() {
+        {
             std::lock_guard lg{ fftw_plan_mutex };
-            fftw<T>::destroy_plan(fftw_p);
-            fftw_p = nullptr;
+            fftwPlan.reset();
         }
-        if (fftw_in != nullptr) {
-            fftw<T>::free(fftw_in);
-            fftw_in = nullptr;
-        }
-        if (fftw_out != nullptr) {
-            fftw<T>::free(fftw_out);
-            fftw_out = nullptr;
-        }
+
+        fftwIn.reset();
+        fftwOut.reset();
+
         // fftw<T>::cleanup(); // No need for fftw_cleanup -> After calling it, all existing plans become undefined
-        magnitude_spectrum.clear();
-        phase_spectrum.clear();
+        magnitudeSpectrum.clear();
+        phaseSpectrum.clear();
     }
 
-    void
-    import_wisdom() {
+    int
+    importWisdom() {
         // TODO: lock file while importing wisdom?
-        fftw<T>::import_wisdom_from_filename(wisdom_path);
+        return fftw<T>::importWisdomFromFilename(wisdomPath);
+    }
+
+    int
+    exportWisdom() {
+        // TODO: lock file while exporting wisdom?
+        return fftw<T>::exportWisdomToFilename(wisdomPath);
+    }
+
+    int
+    importWisdomFromString(const std::string wisdomString) {
+        return fftw<T>::importWisdomFromString(wisdomString);
+    }
+
+    std::string
+    exportWisdomToString() {
+        return fftw<T>::exportWisdomToString();
     }
 
     void
-    export_wisdom() {
-        // TODO: lock file while exporting wisdom?
-        fftw<T>::export_wisdom_to_filename(wisdom_path);
+    forgetWisdom() {
+        return fftw<T>::forgetWisdom();
     }
 };
 
 } // namespace gr::blocks::fft
 
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (gr::blocks::fft::fft<T>), in, out, fft_size, output_in_dB);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (gr::blocks::fft::fft<T>), in, out, fftSize, outputInDb, window);
 
 #endif // GRAPH_PROTOTYPE_FFT_HPP

--- a/test/blocklib/core/fft/window.hpp
+++ b/test/blocklib/core/fft/window.hpp
@@ -1,0 +1,106 @@
+
+#ifndef GRAPH_PROTOTYPE_WINDOW_HPP
+#define GRAPH_PROTOTYPE_WINDOW_HPP
+
+#include <cmath>
+#include <numbers>
+#include <vector>
+
+namespace gr::blocks::fft {
+
+template<typename T>
+concept FloatOrDoubleType = std::is_same_v<T, float> || std::is_same_v<T, double>;
+
+// Implementation of window function (also known as an apodization function or tapering function).
+// See Wikipedia for more info: https://en.wikipedia.org/wiki/Window_function
+
+enum class WindowFunction : int { None, Rectangular, Hamming, Hann, HannExp, Blackman, Nuttall, BlackmanHarris, BlackmanNuttall, FlatTop, Exponential };
+
+// Only float or double are allowed because FFT supports only float or double precisions.
+template<FloatOrDoubleType T>
+std::vector<T>
+createWindowFunction(WindowFunction func, const std::size_t n) {
+    constexpr T    pi   = std::numbers::pi_v<T>;
+    constexpr T    pi2  = static_cast<T>(2.) * pi;
+    const T        exp0 = std::exp(static_cast<T>(0.));
+    constexpr T    c1   = 1.;
+    constexpr T    c2   = 2.;
+    constexpr T    c3   = 3.;
+    constexpr T    c4   = 4.;
+    std::vector<T> res(n);
+    switch (func) {
+    case WindowFunction::None: {
+        return {};
+    }
+    case WindowFunction::Rectangular: {
+        for (std::size_t i = 0; i < n; i++) res[i] = 1.;
+        return res;
+    }
+    case WindowFunction::Hamming: {
+        const T a = pi2 / static_cast<T>(n);
+        for (std::size_t i = 0; i < n; i++) res[i] = static_cast<T>(0.53836) - static_cast<T>(0.46164) * std::cos(a * static_cast<T>(i));
+        return res;
+    }
+    case WindowFunction::Hann: {
+        const T a = pi2 / static_cast<T>(n - 1);
+        for (std::size_t i = 0; i < n; i++) res[i] = static_cast<T>(0.5) - static_cast<T>(0.5) * std::cos(a * static_cast<T>(i));
+        return res;
+    }
+    case WindowFunction::HannExp: {
+        const T a = pi2 / static_cast<T>(n - 1);
+        for (std::size_t i = 0; i < n; i++) res[i] = std::pow(std::sin(a * static_cast<T>(i)), c2);
+        return res;
+    }
+    case WindowFunction::Blackman: {
+        const T a = pi2 / static_cast<T>(n - 1);
+        for (std::size_t i = 0; i < n; i++) {
+            const T ai = a * static_cast<T>(i);
+            res[i]     = static_cast<T>(0.42) - static_cast<T>(0.5) * std::cos(ai) + static_cast<T>(0.08) * std::cos(c2 * ai);
+        }
+        return res;
+    }
+    case WindowFunction::Nuttall: {
+        const T a = pi2 / static_cast<T>(n - 1);
+        for (std::size_t i = 0; i < n; i++) {
+            const T ai = a * static_cast<T>(i);
+            res[i]     = static_cast<T>(0.355768) - static_cast<T>(0.487396) * std::cos(ai) + static_cast<T>(0.144232) * std::cos(c2 * ai) - static_cast<T>(0.012604) * std::cos(c3 * ai);
+        }
+        return res;
+    }
+    case WindowFunction::BlackmanHarris: {
+        const T a = pi2 / static_cast<T>(n - 1);
+        for (std::size_t i = 0; i < n; i++) {
+            const T ai = a * static_cast<T>(i);
+            res[i]     = static_cast<T>(0.35875) - static_cast<T>(0.48829) * std::cos(ai) + static_cast<T>(0.14128) * std::cos(c2 * ai) - static_cast<T>(0.01168) * std::cos(c3 * ai);
+        }
+        return res;
+    }
+    case WindowFunction::BlackmanNuttall: {
+        const T a = pi2 / static_cast<T>(n - 1);
+        for (std::size_t i = 0; i < n; i++) {
+            const T ai = a * static_cast<T>(i);
+            res[i]     = static_cast<T>(0.3635819) - static_cast<T>(0.4891775) * std::cos(ai) + static_cast<T>(0.1365995) * std::cos(c2 * ai) - static_cast<T>(0.0106411) * std::cos(c3 * ai);
+        }
+        return res;
+    }
+    case WindowFunction::FlatTop: {
+        const T a = pi2 / static_cast<T>(n - 1);
+        for (std::size_t i = 0; i < n; i++) {
+            const T ai = a * static_cast<T>(i);
+            res[i]     = c1 - static_cast<T>(1.93) * std::cos(ai) + static_cast<T>(1.29) * std::cos(c2 * ai) - static_cast<T>(0.388) * std::cos(c3 * ai) + static_cast<T>(0.032) * std::cos(c4 * ai);
+        }
+        return res;
+    }
+    case WindowFunction::Exponential: {
+        const T a = c3 * static_cast<T>(n);
+        for (std::size_t i = 0; i < n; i++) res[i] = std::exp(static_cast<T>(i) / a) / exp0;
+        return res;
+    }
+    default: {
+        return {};
+    }
+    }
+}
+} // namespace gr::blocks::fft
+
+#endif // GRAPH_PROTOTYPE_WINDOW_HPP

--- a/test/qa_fft.cpp
+++ b/test/qa_fft.cpp
@@ -19,11 +19,11 @@ template<typename T>
 struct CountSource : public fg::node<CountSource<T>> {
     fg::OUT<T> out{};
     int        count{ 0 };
-    int        n_samples{ 1024 };
+    int        nSamples{ 1024 };
 
     constexpr std::make_signed_t<std::size_t>
     available_samples(const CountSource & /*d*/) noexcept {
-        const auto ret = n_samples - count;
+        const auto ret = nSamples - count;
         return ret > 0 ? ret : -1; // '-1' -> DONE, produced enough samples
     }
 
@@ -33,164 +33,178 @@ struct CountSource : public fg::node<CountSource<T>> {
     }
 };
 
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (CountSource<T>), out, count, n_samples);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (CountSource<T>), out, count, nSamples);
 
 template<typename T>
 std::vector<T>
-generate_sin_sample(std::size_t N, double sample_rate, double frequency, double amplitude) {
+generateSinSample(std::size_t N, double sampleRate, double frequency, double amplitude) {
     std::vector<T> signal(N);
     for (std::size_t i = 0; i < N; i++) {
         if constexpr (gr::blocks::fft::ComplexType<T>) {
-            signal[i] = { static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sample_rate)), 0. };
+            signal[i] = { static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate)), 0. };
         } else {
-            signal[i] = static_cast<T>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sample_rate));
+            signal[i] = static_cast<T>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate));
         }
     }
     return signal;
 }
 
-template<typename T>
+template<typename T, typename U>
 bool
-equal_vectors(const std::vector<T> &v1, const std::vector<T> &v2, double tolerance = 1.e-6) {
+equalVectors(const std::vector<T> &v1, const std::vector<U> &v2, double tolerance = 1.e-6) {
     if constexpr (gr::blocks::fft::ComplexType<T>) {
         return std::equal(v1.begin(), v1.end(), v2.begin(), [&tolerance](const auto &l, const auto &r) {
             return std::abs(l.real() - r.real()) < static_cast<typename T::value_type>(tolerance) && std::abs(l.imag() - r.imag()) < static_cast<typename T::value_type>(tolerance);
         });
     } else {
-        return std::equal(v1.begin(), v1.end(), v2.begin(), [&tolerance](const auto &l, const auto &r) { return std::abs(l - r) < static_cast<T>(tolerance); });
+        return std::equal(v1.begin(), v1.end(), v2.begin(), [&tolerance](const auto &l, const auto &r) { return std::abs(static_cast<double>(l) - static_cast<double>(r)) < tolerance; });
     }
 }
 
 template<typename T, typename inT, typename outT, typename pT>
 void
-test_fftw_types() {
+testFftwTypes() {
     using namespace boost::ut;
     gr::blocks::fft::fft<T> fft1;
-    expect(std::is_same_v<typename std::remove_pointer_t<decltype(fft1.fftw_in)>, inT>) << "";
-    expect(std::is_same_v<typename std::remove_pointer_t<decltype(fft1.fftw_out)>, outT>) << "";
-    expect(std::is_same_v<decltype(fft1.fftw_p), pT>) << "";
+    expect(std::is_same_v<typename std::remove_pointer_t<decltype(fft1.fftwIn.get())>, inT>) << "";
+    expect(std::is_same_v<typename std::remove_pointer_t<decltype(fft1.fftwOut.get())>, outT>) << "";
+    expect(std::is_same_v<decltype(fft1.fftwPlan.get()), pT>) << "";
 }
 
-const boost::ut::suite _fft_tests = [] {
+const boost::ut::suite fftTests = [] {
     using namespace boost::ut;
     using namespace gr::blocks::fft;
     using namespace boost::ut::reflection;
-    std::tuple<std::complex<float>, std::complex<double>>                complex_types_to_test{};
-    std::tuple<std::complex<float>, std::complex<double>, float, double> types_to_test{};
+    std::tuple<std::complex<float>, std::complex<double>>                     complexTypesToTest{};
+    std::tuple<std::complex<float>, std::complex<double>, float, double, int> typesToTest{};
+    std::tuple<float, double>                                                 floatingTypesToTest{};
 
     "FFT sin tests"_test = []<typename T>() {
         fft<T>           fft1{};
         constexpr double tolerance{ 1.e-6 };
         struct TestParams {
-            std::size_t N{ 1024 };           // must be power of 2
-            double      sample_rate{ 128. }; // must be power of 2 (only for the unit test for easy comparison with true result)
+            std::size_t N{ 1024 };          // must be power of 2
+            double      sampleRate{ 128. }; // must be power of 2 (only for the unit test for easy comparison with true result)
             double      frequency{ 1. };
             double      amplitude{ 1. };
-            bool        output_in_dB{ false };
+            bool        outputInDb{ false };
         };
 
         std::vector<TestParams> testCases = { { 256, 128., 10., 5., false }, { 512, 4., 1., 1., false }, { 512, 32., 1., 0.1, false }, { 256, 128., 10., 5., true } };
         for (const auto &t : testCases) {
             assert(std::has_single_bit(t.N));
-            assert(std::has_single_bit(static_cast<std::size_t>(t.sample_rate)));
+            assert(std::has_single_bit(static_cast<std::size_t>(t.sampleRate)));
 
-            std::ignore = fft1.settings().set({ { "fft_size", t.N } });
-            std::ignore = fft1.settings().set({ { "output_in_dB", t.output_in_dB } });
+            std::ignore = fft1.settings().set({ { "fftSize", t.N } });
+            std::ignore = fft1.settings().set({ { "outputInDb", t.outputInDb } });
             std::ignore = fft1.settings().apply_staged_parameters();
-            const auto signal{ generate_sin_sample<T>(t.N, t.sample_rate, t.frequency, t.amplitude) };
+            const auto signal{ generateSinSample<T>(t.N, t.sampleRate, t.frequency, t.amplitude) };
 
             fft1.inputHistory.push_back_bulk(signal.begin(), signal.end());
-            fft1.prepare_input();
-            fft1.compute_fft();
-            fft1.compute_magnitude_spectrum();
+            fft1.prepareInput();
+            fft1.computeFft();
+            fft1.computeMagnitudeSpectrum();
 
-            const auto peak_index{
-                static_cast<std::size_t>(std::distance(fft1.magnitude_spectrum.begin(),
-                                                       std::max_element(fft1.magnitude_spectrum.begin(), std::next(fft1.magnitude_spectrum.begin(), static_cast<std::ptrdiff_t>(t.N / 2u)))))
+            const auto peakIndex{
+                static_cast<std::size_t>(std::distance(fft1.magnitudeSpectrum.begin(),
+                                                       std::max_element(fft1.magnitudeSpectrum.begin(), std::next(fft1.magnitudeSpectrum.begin(), static_cast<std::ptrdiff_t>(t.N / 2u)))))
             }; // only positive frequencies from FFT
-            const auto peak_amplitude = fft1.magnitude_spectrum[peak_index];
-            const auto peak_frequency{ static_cast<double>(peak_index) * t.sample_rate / static_cast<double>(t.N) };
+            const auto peakAmplitude = fft1.magnitudeSpectrum[peakIndex];
+            const auto peakFrequency{ static_cast<double>(peakIndex) * t.sampleRate / static_cast<double>(t.N) };
 
-            const auto expected_amplitude = t.output_in_dB ? 20. * log10(std::abs(t.amplitude)) : t.amplitude;
-            expect(approx(static_cast<double>(peak_amplitude), expected_amplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
-            expect(approx(peak_frequency, t.frequency, tolerance)) << fmt::format("<{}> equal frequency", type_name<T>());
+            const auto expectedAmplitude = t.outputInDb ? 20. * log10(std::abs(t.amplitude)) : t.amplitude;
+            if constexpr (!std::is_same_v<int, T>) {
+                expect(approx(static_cast<double>(peakAmplitude), expectedAmplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
+                expect(approx(peakFrequency, t.frequency, tolerance)) << fmt::format("<{}> equal frequency", type_name<T>());
+            }
         }
-    } | types_to_test;
+    } | typesToTest;
 
     "FFT pattern tests"_test = []<typename T>() {
         fft<T>                fft1{};
         constexpr double      tolerance{ 1.e-6 };
-        constexpr std::size_t N = 16;
-        std::ignore             = fft1.settings().set({ { "fft_size", N } });
-        std::ignore             = fft1.settings().apply_staged_parameters();
+        constexpr std::size_t N{ 16 };
+        std::ignore = fft1.settings().set({ { "fftSize", N } });
+        std::ignore = fft1.settings().apply_staged_parameters();
 
         std::vector<T> signal(N);
 
         static_assert(N == 16, "expected values are calculated for N == 16");
-        std::size_t expected_peak_index{ 0 };
-        T      expected_fft0{ 0., 0. };
-        double expected_peak_amplitude{ 0. };
+        std::size_t expectedPeakIndex{ 0 };
+        T           expectedFft0{ 0., 0. };
+        double      expectedPeakAmplitude{ 0. };
         for (std::size_t iT = 0; iT < 5; iT++) {
             if (iT == 0) {
                 std::fill(signal.begin(), signal.end(), T(0., 0.));
-                expected_fft0           = { 0., 0. };
-                expected_peak_amplitude = 0.;
+                expectedFft0          = { 0., 0. };
+                expectedPeakAmplitude = 0.;
             } else if (iT == 1) {
                 std::fill(signal.begin(), signal.end(), T(1., 0.));
-                expected_fft0           = { 16., 0. };
-                expected_peak_amplitude = 2.;
+                expectedFft0          = { 16., 0. };
+                expectedPeakAmplitude = 2.;
             } else if (iT == 2) {
                 std::fill(signal.begin(), signal.end(), T(1., 1.));
-                expected_fft0           = { 16., 16. };
-                expected_peak_amplitude = std::sqrt(8.);
+                expectedFft0          = { 16., 16. };
+                expectedPeakAmplitude = std::sqrt(8.);
             } else if (iT == 3) {
                 std::iota(signal.begin(), signal.end(), 1);
-                expected_fft0           = { 136., 0. };
-                expected_peak_amplitude = 17.;
+                expectedFft0          = { 136., 0. };
+                expectedPeakAmplitude = 17.;
             } else if (iT == 4) {
                 int i = 0;
                 std::generate(signal.begin(), signal.end(), [&i] { return T(static_cast<typename T::value_type>(i++ % 2), 0.); });
-                expected_fft0           = { 8., 0. };
-                expected_peak_amplitude = 1.;
+                expectedFft0          = { 8., 0. };
+                expectedPeakAmplitude = 1.;
             }
 
             fft1.inputHistory.push_back_bulk(signal.begin(), signal.end());
-            fft1.prepare_input();
-            fft1.compute_fft();
-            fft1.compute_magnitude_spectrum();
+            fft1.prepareInput();
+            fft1.computeFft();
+            fft1.computeMagnitudeSpectrum();
 
-            const auto peak_index{ static_cast<std::size_t>(std::distance(fft1.magnitude_spectrum.begin(), std::max_element(fft1.magnitude_spectrum.begin(), fft1.magnitude_spectrum.end()))) };
-            const auto peak_amplitude{ fft1.magnitude_spectrum[peak_index] };
+            const auto peakIndex{ static_cast<std::size_t>(std::distance(fft1.magnitudeSpectrum.begin(), std::max_element(fft1.magnitudeSpectrum.begin(), fft1.magnitudeSpectrum.end()))) };
+            const auto peakAmplitude{ fft1.magnitudeSpectrum[peakIndex] };
 
-            expect(eq(peak_index, expected_peak_index)) << fmt::format("<{}> equal peak index", type_name<T>());
-            expect(approx(static_cast<double>(peak_amplitude), expected_peak_amplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
-            expect(approx(static_cast<double>(fft1.fftw_out[0][0]), static_cast<double>(expected_fft0.real()), tolerance)) << fmt::format("<{}> equal fft[0].real()", type_name<T>());
-            expect(approx(static_cast<double>(fft1.fftw_out[0][1]), static_cast<double>(expected_fft0.imag()), tolerance)) << fmt::format("<{}> equal fft[0].imag()", type_name<T>());
+            expect(eq(peakIndex, expectedPeakIndex)) << fmt::format("<{}> equal peak index", type_name<T>());
+            expect(approx(static_cast<double>(peakAmplitude), expectedPeakAmplitude, tolerance)) << fmt::format("<{}> equal amplitude", type_name<T>());
+            expect(approx(static_cast<double>(fft1.fftwOut[0][0]), static_cast<double>(expectedFft0.real()), tolerance)) << fmt::format("<{}> equal fft[0].real()", type_name<T>());
+            expect(approx(static_cast<double>(fft1.fftwOut[0][1]), static_cast<double>(expectedFft0.imag()), tolerance)) << fmt::format("<{}> equal fft[0].imag()", type_name<T>());
         }
-    } | complex_types_to_test;
+    } | complexTypesToTest;
 
     "FFT process_one tests"_test = []<typename T>() {
         fft<T>                fft1{};
-        constexpr std::size_t N = 16;
-        std::ignore             = fft1.settings().set({ { "fft_size", N } });
-        std::ignore             = fft1.settings().apply_staged_parameters();
-        using dataset_type      = typename fft<T>::U;
+        constexpr std::size_t N{ 16 };
+        constexpr double      tolerance{ 1.e-6 };
+        std::ignore         = fft1.settings().set({ { "fftSize", N } });
+        std::ignore         = fft1.settings().apply_staged_parameters();
+        using DatasetType   = typename fft<T>::U;
+        using InHistoryType = typename fft<T>::InHistoryType;
 
         std::vector<T> signal(N);
         std::iota(signal.begin(), signal.end(), 1);
-        DataSet<dataset_type> ds1{};
+        DataSet<DatasetType> ds1{};
         for (std::size_t i = 0; i < N; i++) ds1 = fft1.process_one(signal[i]);
-        expect(equal_vectors<T>(std::vector(fft1.inputHistory.begin(), fft1.inputHistory.end()), signal)) << fmt::format("<{}> equal history buffer", type_name<T>());
-        const auto N2 = static_cast<int>(fft1.magnitude_spectrum.size());
-        expect(equal_vectors<dataset_type>(std::vector(ds1.signal_values.begin() + 2 * N2, ds1.signal_values.begin() + 3 * N2), fft1.magnitude_spectrum))
+        expect(equalVectors<InHistoryType, T>(std::vector(fft1.inputHistory.begin(), fft1.inputHistory.end()), signal)) << fmt::format("<{}> equal history buffer", type_name<T>());
+        const auto N2 = fft1.magnitudeSpectrum.size();
+        expect(equalVectors<DatasetType, DatasetType>(std::vector(ds1.signal_values.begin() + static_cast<std::ptrdiff_t>(2U * N2), ds1.signal_values.begin() + static_cast<std::ptrdiff_t>(3U * N2)),
+                                                      fft1.magnitudeSpectrum))
                 << fmt::format("<{}> equal DataSet magnitude", type_name<T>());
+
+        for (std::size_t i = 0; i < 4; i++) {
+            const auto mm = std::minmax_element(std::next(ds1.signal_values.begin(), static_cast<std::ptrdiff_t>(i * N2)),
+                                                std::next(ds1.signal_values.begin(), static_cast<std::ptrdiff_t>((i + 1U) * N2)));
+            expect(approx(*mm.first, ds1.signal_ranges[i][0], tolerance));
+            expect(approx(*mm.second, ds1.signal_ranges[i][1], tolerance));
+        }
 
         std::iota(signal.begin(), signal.end(), N + 1);
         for (std::size_t i = 0; i < N; i++) ds1 = fft1.process_one(signal[i]);
-        expect(equal_vectors<T>(std::vector(fft1.inputHistory.begin(), fft1.inputHistory.end()), signal)) << fmt::format("<{}> equal history buffer", type_name<T>());
-        expect(equal_vectors<dataset_type>(std::vector(ds1.signal_values.begin() + 2 * N2, ds1.signal_values.begin() + 3 * N2), fft1.magnitude_spectrum))
+        expect(equalVectors<InHistoryType, T>(std::vector(fft1.inputHistory.begin(), fft1.inputHistory.end()), signal)) << fmt::format("<{}> equal history buffer", type_name<T>());
+        expect(equalVectors<DatasetType, DatasetType>(std::vector(ds1.signal_values.begin() + static_cast<std::ptrdiff_t>(2U * N2), ds1.signal_values.begin() + static_cast<std::ptrdiff_t>(3U * N2)),
+                                                      fft1.magnitudeSpectrum))
                 << fmt::format("<{}> equal DataSet magnitude", type_name<T>());
-    } | types_to_test;
+    } | typesToTest;
 
     "FFT types tests"_test = [] {
         expect(std::is_same_v<fft<std::complex<float>>::U, float>) << "output type must be float";
@@ -204,39 +218,147 @@ const boost::ut::suite _fft_tests = [] {
     };
 
     "FFT fftw types tests"_test = [] {
-        test_fftw_types<std::complex<float>, fftwf_complex, fftwf_complex, fftwf_plan>();
-        test_fftw_types<std::complex<double>, fftw_complex, fftw_complex, fftw_plan>();
-        test_fftw_types<float, float, fftwf_complex, fftwf_plan>();
-        test_fftw_types<double, double, fftw_complex, fftw_plan>();
-        test_fftw_types<int, float, fftwf_complex, fftwf_plan>();
-        test_fftw_types<unsigned int, float, fftwf_complex, fftwf_plan>();
+        testFftwTypes<std::complex<float>, fftwf_complex, fftwf_complex, fftwf_plan>();
+        testFftwTypes<std::complex<double>, fftw_complex, fftw_complex, fftw_plan>();
+        testFftwTypes<float, float, fftwf_complex, fftwf_plan>();
+        testFftwTypes<double, double, fftw_complex, fftw_plan>();
+        testFftwTypes<int, float, fftwf_complex, fftwf_plan>();
+        testFftwTypes<unsigned int, float, fftwf_complex, fftwf_plan>();
     };
 
     "FFT flow graph example"_test = [] {
         // This test checks how fftw works if one creates and destroys several fft blocks in different graph flows
         using namespace boost::ut;
-        using scheduler       = fair::graph::scheduler::simple<>;
-        auto      thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
+        using Scheduler      = fair::graph::scheduler::simple<>;
+        auto      threadPool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
 
         fg::graph flow1;
         auto     &source1 = flow1.make_node<CountSource<double>>();
-        auto     &fft1    = flow1.make_node<fft<double>>({ { "fft_size", 16 } });
+        auto     &fft1    = flow1.make_node<fft<double>>({ { "fftSize", 16 } });
         std::ignore       = flow1.connect<"out">(source1).to<"in">(fft1);
-        auto sched1       = scheduler(std::move(flow1), thread_pool);
+        auto sched1       = Scheduler(std::move(flow1), threadPool);
 
         // run 2 times to check potential memory problems
         for (int i = 0; i < 2; i++) {
             fg::graph flow2;
             auto     &source2 = flow2.make_node<CountSource<double>>();
-            auto     &fft2    = flow2.make_node<fft<double>>({ { "fft_size", 16 } });
+            auto     &fft2    = flow2.make_node<fft<double>>({ { "fftSize", 16 } });
             std::ignore       = flow2.connect<"out">(source2).to<"in">(fft2);
-            auto sched2       = scheduler(std::move(flow2), thread_pool);
+            auto sched2       = Scheduler(std::move(flow2), threadPool);
             sched2.run_and_wait();
-            expect(approx(source2.count, source2.n_samples, 1e-4));
+            expect(approx(source2.count, source2.nSamples, 1e-4));
         }
 
         sched1.run_and_wait();
-        expect(approx(source1.count, source1.n_samples, 1e-4));
+        expect(approx(source1.count, source1.nSamples, 1e-4));
+    };
+
+    "FFT window function tests"_test = []<typename T>() {
+        fft<T> fft1{};
+        using PrecisionType = typename fft<T>::PrecisionType;
+        using InHistoryType = typename fft<T>::InHistoryType;
+        constexpr double            tolerance{ 1.e-5 };
+        constexpr std::size_t       N{ 8 };
+
+        std::vector<WindowFunction> testCases = { WindowFunction::None,    WindowFunction::Rectangular,    WindowFunction::Hamming,
+                                                  WindowFunction::Hann,    WindowFunction::HannExp,        WindowFunction::Blackman,
+                                                  WindowFunction::Nuttall, WindowFunction::BlackmanHarris, WindowFunction::BlackmanNuttall,
+                                                  WindowFunction::FlatTop, WindowFunction::Exponential };
+
+        for (const auto &t : testCases) {
+            std::ignore = fft1.settings().set({ { "fftSize", N } });
+            std::ignore = fft1.settings().set({ { "window", static_cast<int>(t) } });
+            std::ignore = fft1.settings().apply_staged_parameters();
+
+            std::vector<T> signal(N);
+            if constexpr (ComplexType<T>) {
+                typename T::value_type i = 0.;
+                std::generate(signal.begin(), signal.end(), [&i] {
+                    i = i + static_cast<typename T::value_type>(1.);
+                    return T(i, i);
+                });
+            } else {
+                std::iota(signal.begin(), signal.end(), 1.);
+            }
+            for (const auto s : signal) fft1.inputHistory.push_back(static_cast<InHistoryType>(s));
+            fft1.prepareInput();
+
+            expect(eq(fft1.fftSize, N)) << fmt::format("<{}> equal fft size", type_name<T>());
+            expect(eq(fft1.windowVector.size(), (t == WindowFunction::None) ? 0 : N)) << fmt::format("<{}> equal window vector size", type_name<T>());
+            expect(eq(fft1.window, static_cast<int>(t))) << fmt::format("<{}> equal window function", type_name<T>());
+
+            std::vector<double> windowFunc = createWindowFunction<double>(t, N);
+            for (std::size_t i = 0; i < N; i++) {
+                if constexpr (ComplexType<T>) {
+                    const typename T::value_type expValue = (t == WindowFunction::None) ? signal[i].real() : signal[i].real() * static_cast<typename T::value_type>(windowFunc[i]);
+                    expect(approx(fft1.fftwIn.get()[i][0], expValue, tolerance)) << fmt::format("<{}> equal fftwIn complex.real", type_name<T>());
+                    expect(approx(fft1.fftwIn.get()[i][1], expValue, tolerance)) << fmt::format("<{}> equal fftwIn complex.imag", type_name<T>());
+                } else {
+                    const PrecisionType expValue = (t == WindowFunction::None) ? static_cast<PrecisionType>(signal[i])
+                                                                               : static_cast<PrecisionType>(signal[i]) * static_cast<PrecisionType>(windowFunc[i]);
+                    expect(approx(fft1.fftwIn.get()[i], expValue, tolerance)) << fmt::format("<{}> equal fftwIn", type_name<T>());
+                }
+            }
+        }
+    } | typesToTest;
+
+    "FFT window tests"_test = []<typename T>() {
+        // Expected value for size 8
+        std::vector<double> None8{};
+        std::vector<double> Rectangular8{ 1., 1., 1., 1., 1., 1., 1., 1. };
+        std::vector<double> Hamming8{ 0.07671999999999995, 0.2119312255330421, 0.53836, 0.8647887744669578, 1.0, 0.8647887744669578, 0.5383600000000001, 0.21193122553304222 };
+        std::vector<double> Hann8{ 0., 0.1882550990706332, 0.6112604669781572, 0.9504844339512095, 0.9504844339512095, 0.6112604669781573, 0.1882550990706333, 0. };
+        std::vector<double> Blackman8{ -1.3877787807814457E-17, 0.09045342435412804, 0.45918295754596355, 0.9203636180999081,
+                                       0.9203636180999083,      0.45918295754596383, 0.09045342435412812, -1.3877787807814457E-17 };
+        std::vector<double> BlackmanHarris8{ 6.0000000000001025E-5, 0.03339172347815117, 0.332833504298565,   0.8893697722232837,
+                                             0.8893697722232838,    0.3328335042985652,  0.03339172347815122, 6.0000000000001025E-5 };
+        std::vector<double> BlackmanNuttall8{ 3.628000000000381E-4, 0.03777576895352025, 0.34272761996881945, 0.8918518610776603,
+                                              0.8918518610776603,   0.3427276199688196,  0.0377757689535203,  3.628000000000381E-4 };
+        std::vector<double> Exponential8{ 1., 1.0425469051899914, 1.086904049521229, 1.1331484530668263, 1.1813604128656459, 1.2316236423470497, 1.2840254166877414, 1.338656724353094 };
+        std::vector<double> FlatTop8{ 0.004000000000000087, -0.16964240541774014, 0.04525319347985671,  3.622389211937882,
+                                      3.6223892119378833,   0.04525319347985735,  -0.16964240541774012, 0.004000000000000087 };
+        std::vector<double> HannExp8{ 0., 0.6112604669781572, 0.9504844339512096, 0.18825509907063334, 0.18825509907063315, 0.9504844339512096, 0.6112604669781574, 5.99903913064743E-32 };
+        std::vector<double> Nuttall8{ -2.42861286636753E-17, 0.031142736797915613, 0.3264168059086425,   0.8876284572934416,
+                                      0.8876284572934416,    0.32641680590864275,  0.031142736797915654, -2.42861286636753E-17 };
+
+        // check all windows for unwanted changes
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::None, 8), None8)) << fmt::format("<{}> equal None[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::Rectangular, 8), Rectangular8)) << fmt::format("<{}> equal Rectangular[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::Hamming, 8), Hamming8)) << fmt::format("<{}> equal Hamming[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::Hann, 8), Hann8)) << fmt::format("<{}> equal Hann[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::Blackman, 8), Blackman8)) << fmt::format("<{}> equal Blackman[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::BlackmanHarris, 8), BlackmanHarris8)) << fmt::format("<{}> equal BlackmanHarris[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::BlackmanNuttall, 8), BlackmanNuttall8)) << fmt::format("<{}> equal BlackmanNuttall[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::Exponential, 8), Exponential8)) << fmt::format("<{}> equal Exponential[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::FlatTop, 8), FlatTop8)) << fmt::format("<{}> equal FlatTop[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::HannExp, 8), HannExp8)) << fmt::format("<{}> equal HannExp[8] vectors", type_name<T>());
+        expect(equalVectors<T, double>(createWindowFunction<T>(WindowFunction::Nuttall, 8), Nuttall8)) << fmt::format("<{}> equal Nuttall[8] vectors", type_name<T>());
+
+        // test zero length
+        expect(eq(createWindowFunction<T>(WindowFunction::None, 0).size(), 0u)) << fmt::format("<{}> zero size None[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::Rectangular, 0).size(), 0u)) << fmt::format("<{}> zero size Rectangular[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::Hamming, 0).size(), 0u)) << fmt::format("<{}> zero size Hamming[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::Hann, 0).size(), 0u)) << fmt::format("<{}> zero size Hann[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::Blackman, 0).size(), 0u)) << fmt::format("<{}> zero size Blackman[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::BlackmanHarris, 0).size(), 0u)) << fmt::format("<{}> zero size BlackmanHarris[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::BlackmanNuttall, 0).size(), 0u)) << fmt::format("<{}> zero size BlackmanNuttall[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::Exponential, 0).size(), 0u)) << fmt::format("<{}> zero size Exponential[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::FlatTop, 0).size(), 0u)) << fmt::format("<{}> zero size FlatTop[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::HannExp, 0).size(), 0u)) << fmt::format("<{}> zero size HannExp[8] vectors", type_name<T>());
+        expect(eq(createWindowFunction<T>(WindowFunction::Nuttall, 0).size(), 0u)) << fmt::format("<{}> zero size Nuttall[8] vectors", type_name<T>());
+    } | floatingTypesToTest;
+
+    "FFT wisdom import/export tests"_test = []() {
+        fft<double> fft1{};
+
+        std::string wisdomString1 = fft1.exportWisdomToString();
+        fft1.forgetWisdom();
+        int importOk = fft1.importWisdomFromString(wisdomString1);
+        expect(eq(importOk, 1)) << "Wisdom import from string.";
+        std::string wisdomString2 = fft1.exportWisdomToString();
+
+        // lines are not always at the same order thus it is hard to compare
+        // expect(eq(wisdomString1, wisdomString2)) << "Wisdom strings are the same.";
     };
 };
 

--- a/test/qa_node.cpp
+++ b/test/qa_node.cpp
@@ -164,7 +164,7 @@ const boost::ut::suite _fft_tests = [] {
     using namespace boost::ut;
     using namespace boost::ut::reflection;
 
-    auto thread_pool                      = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
+    auto thread_pool = std::make_shared<fair::thread_pool::BasicThreadPool>("custom pool", fair::thread_pool::CPU_BOUND, 2, 2);
 
     // clang-format off
     "Interpolation/Decimation tests"_test = [&thread_pool] {


### PR DESCRIPTION
This PR includes the following changes:
* Implement window (apodization) function.
* Meta information for DataSet.
* unique_ptr for in_data, out_data and plan.
* Compute ranges as part of copying to DataSet.
* Add integral type to FFT tests.
* fftw wisdom import/export via string.
* Additional unit tests.
* General improvements and bug fixing.
* Change code style according to opendigitizer style guide.

#### Note for reviewer: 
- `enum class window_function : int {...}` includes all supported window types.
- `window` type is declared as `int` in `fft` class to make it available to change it via settings mechanism.
- where it is needed `static_cast` is used to convert between `int` and `window_function` and vice versa.
- @mattkretz suggested another possible solution:
```cpp
struct EnumLike
{
  int value;

  template <Enum T>
  EnumLike(T x) : value(int(x)) {}
  
  template <Enum T>
  operator T() const { return T(value); }
};
```
But it requires to add `EnumLike` as `pmt` supported type.
See example here: https://godbolt.org/z/h1xjjxGn4
