### PR TITLE
added store/reset default block setting functionality

### DIFF
--- a/include/node.hpp
+++ b/include/node.hpp
@@ -442,9 +442,8 @@ public:
             _output_tags_changed = true;
         }
 
-        // TODO: expand on this init function:
-        //  * store initial setting -> needed for `reset()` call
-        //  * ...
+        // store default settings -> can be recovered with 'reset_defaults()'
+        settings().store_defaults();
     }
 
     void

--- a/include/tag.hpp
+++ b/include/tag.hpp
@@ -50,17 +50,16 @@ using property_map = pmtv::map_t;
  */
 struct alignas(hardware_constructive_interference_size) tag_t {
     using signed_index_type = std::make_signed_t<std::size_t>;
-    signed_index_type index{0};
-    property_map map{};
+    signed_index_type index{ 0 };
+    property_map      map{};
 
     tag_t() = default; // TODO: remove -- needed only for Clang <=15
 
-    tag_t(signed_index_type index_, property_map map_) noexcept: index(index_), map(std::move(
-            map_)) {} // TODO: remove -- needed only for Clang <=15
+    tag_t(signed_index_type index_, property_map map_) noexcept : index(index_), map(std::move(map_)) {} // TODO: remove -- needed only for Clang <=15
 
     bool
     operator==(const tag_t &other) const
-    = default;
+            = default;
 
     // TODO: do we need the convenience methods below?
     void
@@ -190,8 +189,10 @@ inline EM_CONSTEXPR_STATIC default_tag<"trigger_name", std::string> TRIGGER_NAME
 inline EM_CONSTEXPR_STATIC default_tag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp"> TRIGGER_TIME;
 inline EM_CONSTEXPR_STATIC default_tag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;
 inline EM_CONSTEXPR_STATIC default_tag<"context", std::string, "", "multiplexing key to orchestrate node settings/behavioural changes"> CONTEXT;
+inline EM_CONSTEXPR_STATIC default_tag<"reset_default", bool, "", "reset block state to stored default"> RESET_DEFAULTS;
+inline EM_CONSTEXPR_STATIC default_tag<"store_default", bool, "", "store block settings as default"> STORE_DEFAULTS;
 
-inline constexpr std::tuple DEFAULT_TAGS = { SAMPLE_RATE, SIGNAL_NAME, SIGNAL_UNIT, SIGNAL_MIN, SIGNAL_MAX, TRIGGER_NAME, TRIGGER_TIME, TRIGGER_OFFSET, CONTEXT };
+inline constexpr std::tuple DEFAULT_TAGS = { SAMPLE_RATE, SIGNAL_NAME, SIGNAL_UNIT, SIGNAL_MIN, SIGNAL_MAX, TRIGGER_NAME, TRIGGER_TIME, TRIGGER_OFFSET, CONTEXT, RESET_DEFAULTS, STORE_DEFAULTS };
 } // namespace tag
 
 } // namespace fair::graph


### PR DESCRIPTION
Based on a suggestion/request by @Jsallay added functionality to reset to and store default block parameter. 

The initial defaults are those settings during block initialisation, including the (optional) parameters that have been passed as constructor arguments, e.g. 
```cpp 
auto &block = flow_graph.make_node<TestBlock<float>>({ { "name", "TestName" }, { "scaling_factor", 2.f } });
```

The reset and store can be triggered via streaming tags `gr:reset_default` and ``gr:store_default` (N.B. naming open for change), or explicitly via the setting accessor methods:
```cpp
 block.settings().store_defaults();
 // ...
 block.settings().reset_defaults();
 // reverting to old settings
 // block.reset() is optionally called
```

Refactored, introduced some concepts for the optional `settings_changed()` and `reset()` block call back functions, and tried to simplify the code where possible (<-> low hanging fruits). 

The function signature for these optional block functions are checked using `static_assert(...)`s in the settings implementation that -- if violated -- yield something like:

![image](https://github.com/fair-acc/graph-prototype/assets/46007894/8e709240-c8fe-4d19-8edf-947529598ae8)
or
![image](https://github.com/fair-acc/graph-prototype/assets/46007894/892b336d-29e0-4419-97c9-4a334893db71)


Next on the list would be the parameter range checks...