### PR TITLE
Enhance `Annotated<...>` with Range Limits and Generic Validation via `Limits<Min, Max, OptValidatorFunc>`

### DIFF
--- a/include/node.hpp
+++ b/include/node.hpp
@@ -316,11 +316,11 @@ struct node : protected std::tuple<Arguments...> {
             "node_thread_pool", fair::thread_pool::TaskType::IO_BOUND, 2_UZ, std::numeric_limits<uint32_t>::max());
 
     constexpr static tag_propagation_policy_t tag_policy = tag_propagation_policy_t::TPP_ALL_TO_ALL;
-    A<std::size_t, "numerator", Doc<"The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)">>      numerator   = 1_UZ;
-    A<std::size_t, "denominator", Doc<"The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)">> denominator = 1_UZ;
-    A<std::size_t, "stride", Doc<"Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)">>                          stride      = 0_UZ;
-    std::size_t                                                                                                    stride_counter                                                                = 0_UZ;
-    const std::size_t                                                                                              unique_id   = _unique_id_counter++;
+    A<std::size_t, "numerator", Doc<"top number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect">, Limits<1_UZ, std::size_t(-1)>>      numerator      = 1_UZ;
+    A<std::size_t, "denominator", Doc<"bottom number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect">, Limits<1_UZ, std::size_t(-1)>> denominator    = 1_UZ;
+    A<std::size_t, "stride", Doc<"samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.">>                                                stride         = 0_UZ;
+    std::size_t                                                                                                                                                        stride_counter = 0_UZ;
+    const std::size_t                                                                                                                                                  unique_id = _unique_id_counter++;
     const std::string                                                                                              unique_name = fmt::format("{}#{}", fair::meta::type_name<Derived>(), unique_id);
     A<std::string, "user-defined name", Doc<"N.B. may not be unique -> ::unique_name">>                            name{ std::string(fair::meta::type_name<Derived>()) };
     A<property_map, "meta-information", Doc<"store non-graph-processing information like UI block position etc.">> meta_information;
@@ -605,7 +605,7 @@ public:
 
     constexpr void
     forward_tags() noexcept {
-        if (!_output_tags_changed && !_input_tags_present) {
+        if (!(_output_tags_changed || _input_tags_present)) {
             return;
         }
         std::size_t port_id = 0; // TODO absorb this as optional tuple_for_each argument

--- a/test/grc/test.grc.expected
+++ b/test/grc/test.grc.expected
@@ -9,7 +9,7 @@ blocks:
       stride: 0
       unique_name: good::fixed_source<double>#0
       denominator::description: denominator
-      denominator::documentation: "The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
+      denominator::documentation: "bottom number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect"
       denominator::unit: ""
       denominator::visible: 0
       description: ""
@@ -22,11 +22,11 @@ blocks:
       name::unit: ""
       name::visible: 0
       numerator::description: numerator
-      numerator::documentation: "The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
+      numerator::documentation: "top number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect"
       numerator::unit: ""
       numerator::visible: 0
       stride::description: stride
-      stride::documentation: "Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)"
+      stride::documentation: samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.
       stride::unit: ""
       stride::visible: 0
       unknown_property: 42
@@ -39,7 +39,7 @@ blocks:
       stride: 0
       unique_name: good::multiply<double>#0
       denominator::description: denominator
-      denominator::documentation: "The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
+      denominator::documentation: "bottom number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect"
       denominator::unit: ""
       denominator::visible: 0
       description: ""
@@ -52,11 +52,11 @@ blocks:
       name::unit: ""
       name::visible: 0
       numerator::description: numerator
-      numerator::documentation: "The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
+      numerator::documentation: "top number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect"
       numerator::unit: ""
       numerator::visible: 0
       stride::description: stride
-      stride::documentation: "Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)"
+      stride::documentation: samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.
       stride::unit: ""
       stride::visible: 0
   - name: counter
@@ -68,7 +68,7 @@ blocks:
       stride: 0
       unique_name: builtin_counter<double>#0
       denominator::description: denominator
-      denominator::documentation: "The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
+      denominator::documentation: "bottom number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect"
       denominator::unit: ""
       denominator::visible: 0
       description: ""
@@ -81,11 +81,11 @@ blocks:
       name::unit: ""
       name::visible: 0
       numerator::description: numerator
-      numerator::documentation: "The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
+      numerator::documentation: "top number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect"
       numerator::unit: ""
       numerator::visible: 0
       stride::description: stride
-      stride::documentation: "Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)"
+      stride::documentation: samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.
       stride::unit: ""
       stride::visible: 0
   - name: sink
@@ -98,7 +98,7 @@ blocks:
       total_count: 100
       unique_name: good::cout_sink<double>#0
       denominator::description: denominator
-      denominator::documentation: "The bottom number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
+      denominator::documentation: "bottom number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect"
       denominator::unit: ""
       denominator::visible: 0
       description: ""
@@ -111,11 +111,11 @@ blocks:
       name::unit: ""
       name::visible: 0
       numerator::description: numerator
-      numerator::documentation: "The top number of a fraction = numerator/denominator: decimation (fraction < 1), interpolation (fraction > 1), no effect (fraction = 1)"
+      numerator::documentation: "top number of input-to-output sample ratio: < 1 decimation, >1 interpolation, 1_ no effect"
       numerator::unit: ""
       numerator::visible: 0
       stride::description: stride
-      stride::documentation: "Number of samples between two data processing: overlap (stride < N), skip (stride > N), undefined-default (stride = 0)"
+      stride::documentation: samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.
       stride::unit: ""
       stride::visible: 0
       unknown_property: 42


### PR DESCRIPTION
This PR enhances the functionality of the `Annotated<...>` type by introducing range limits and generic validation checks. These are made possible via the optional `Limits<Min, Max, OptValidatorFunc>` type, where the minimum, maximum, and validator are specified as Non-Type Template Parameters (NTTPs).

### Examples

Here's how you can utilize the new feature:

1. **Basic Limit Specification**:
```cpp
Annotated<float, "sample rate", Limits<int64_t(0), std::numeric_limits<int64_t>::max()>> sample_rate = 1000.0f;
```

2. **Using a Separate Validator Function**:
```cpp
constexpr auto isPowerOfTwo = [](const int &val) { return val > 0 && (val & (val - 1)) == 0; };
Annotated<int, "power of two", Limits<0, 0, isPowerOfTwo>> needPowerOfTwo = 2;
```
  N.B. `MIN==MAX` disable the range check leaving the optional arbitrary validator function.

3. **Incorporating an Inline Lambda Validator**:
```cpp
Annotated<int, "power of two", Limits<0, 0, [](const int &val) { return val > 0 && (val & (val - 1)) == 0; }>> needPowerOfTwoAlt = 2;
expect(needPowerOfTwoAlt.validate(4));
expect(not needPowerOfTwoAlt.validate(5));
```

4. **Validation In Action**:
```cpp
block.settings().set({ { "sample_rate", -1.0f } });
block.settings().apply_staged_parameters(); // This currently prints a warning. TODO: Replace with a more informative PMT error message sent via the msgOut port.
// example error output:
// cannot set field fair::graph::setting_test::TestBlock<float>#24(fair::graph::setting_test::TestBlock<float>)::1 = -1 to sample_rate due to limit constraints [0, 9223372036854775807] validate func is not defined
```

### Future Work

The exact format of the PMT error message, which will be sent through the `MSG_OUT msgOut` port, is still under discussion. To be discussed during one of the upcoming GR Architecture WG meetings (@mormj et al.).
