### PR TITLE
refactored port<T> interface

### DIFF
--- a/bench/bm_scheduler.cpp
+++ b/bench/bm_scheduler.cpp
@@ -14,7 +14,7 @@ inline constexpr std::size_t N_SAMPLES = gr::util::round_up(10'000'000, 1024);
 inline constexpr std::size_t N_NODES   = 5;
 
 template<typename T, char op>
-class math_op : public fg::node<math_op<T, op>, fg::IN<T, 0, N_MAX, "in">, fg::OUT<T, 0, N_MAX, "out">> {
+class math_op : public fg::node<math_op<T, op>, fg::PortInNamed<T, "in">, fg::PortOutNamed<T, "out">> {
     T _factor = static_cast<T>(1.0f);
 
 public:

--- a/bench/bm_test_helper.hpp
+++ b/bench/bm_test_helper.hpp
@@ -18,9 +18,9 @@ inline static std::size_t n_samples_produced = 0_UZ;
 template<typename T, std::size_t min = 0_UZ, std::size_t count = N_MAX, bool use_bulk_operation = true>
 class source : public fg::node<source<T, min, count>> {
 public:
-    uint64_t    _n_samples_max;
-    std::size_t _n_tag_offset;
-    fg::OUT<T>  out;
+    uint64_t       _n_samples_max;
+    std::size_t    _n_tag_offset;
+    fg::PortOut<T> out;
 
     source() = delete;
 
@@ -87,11 +87,11 @@ public:
 
 inline static std::size_t n_samples_consumed = 0_UZ;
 
-template<typename T, std::size_t N_MIN = 0_UZ, std::size_t N_MAX = N_MAX>
+template<typename T, std::size_t N_MIN = 1_UZ, std::size_t N_MAX = N_MAX>
 struct sink : public fg::node<sink<T, N_MIN, N_MAX>> {
-    fg::IN<T, N_MIN, N_MAX> in;
-    std::size_t             should_receive_n_samples = 0;
-    int64_t                 _last_tag_position       = -1;
+    fg::PortIn<T, fg::RequiredSamples<N_MIN, N_MAX>> in;
+    std::size_t                                      should_receive_n_samples = 0;
+    int64_t                                          _last_tag_position       = -1;
 
     template<fair::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr auto

--- a/include/data_sink.hpp
+++ b/include/data_sink.hpp
@@ -144,7 +144,7 @@ public:
 
     template<typename T, TriggerMatcher M>
     std::shared_ptr<typename data_sink<T>::dataset_poller>
-    get_trigger_poller(const data_sink_query &query, M&& matcher, std::size_t pre_samples, std::size_t post_samples, blocking_mode block = blocking_mode::Blocking) {
+    get_trigger_poller(const data_sink_query &query, M &&matcher, std::size_t pre_samples, std::size_t post_samples, blocking_mode block = blocking_mode::Blocking) {
         std::lock_guard lg{ _mutex };
         auto            sink = find_sink<T>(query);
         return sink ? sink->get_trigger_poller(std::forward<M>(matcher), pre_samples, post_samples, block) : nullptr;
@@ -152,7 +152,7 @@ public:
 
     template<typename T, TriggerMatcher M>
     std::shared_ptr<typename data_sink<T>::dataset_poller>
-    get_multiplexed_poller(const data_sink_query &query, M&& matcher, std::size_t maximum_window_size, blocking_mode block = blocking_mode::Blocking) {
+    get_multiplexed_poller(const data_sink_query &query, M &&matcher, std::size_t maximum_window_size, blocking_mode block = blocking_mode::Blocking) {
         std::lock_guard lg{ _mutex };
         auto            sink = find_sink<T>(query);
         return sink ? sink->get_multiplexed_poller(std::forward<M>(matcher), maximum_window_size, block) : nullptr;
@@ -160,7 +160,7 @@ public:
 
     template<typename T, TriggerMatcher M>
     std::shared_ptr<typename data_sink<T>::dataset_poller>
-    get_snapshot_poller(const data_sink_query &query, M&& matcher, std::chrono::nanoseconds delay, blocking_mode block = blocking_mode::Blocking) {
+    get_snapshot_poller(const data_sink_query &query, M &&matcher, std::chrono::nanoseconds delay, blocking_mode block = blocking_mode::Blocking) {
         std::lock_guard lg{ _mutex };
         auto            sink = find_sink<T>(query);
         return sink ? sink->get_snapshot_poller(std::forward<M>(matcher), delay, block) : nullptr;
@@ -168,7 +168,7 @@ public:
 
     template<typename T, StreamCallback<T> Callback>
     bool
-    register_streaming_callback(const data_sink_query &query, std::size_t max_chunk_size, Callback&& callback) {
+    register_streaming_callback(const data_sink_query &query, std::size_t max_chunk_size, Callback &&callback) {
         std::lock_guard lg{ _mutex };
         auto            sink = find_sink<T>(query);
         if (!sink) {
@@ -181,7 +181,7 @@ public:
 
     template<typename T, DataSetCallback<T> Callback, TriggerMatcher M>
     bool
-    register_trigger_callback(const data_sink_query &query, M&& matcher, std::size_t pre_samples, std::size_t post_samples, Callback&& callback) {
+    register_trigger_callback(const data_sink_query &query, M &&matcher, std::size_t pre_samples, std::size_t post_samples, Callback &&callback) {
         std::lock_guard lg{ _mutex };
         auto            sink = find_sink<T>(query);
         if (!sink) {
@@ -194,7 +194,7 @@ public:
 
     template<typename T, DataSetCallback<T> Callback, TriggerMatcher M>
     bool
-    register_multiplexed_callback(const data_sink_query &query, M&& matcher, std::size_t maximum_window_size, Callback&& callback) {
+    register_multiplexed_callback(const data_sink_query &query, M &&matcher, std::size_t maximum_window_size, Callback &&callback) {
         std::lock_guard lg{ _mutex };
         auto            sink = find_sink<T>(query);
         if (!sink) {
@@ -207,7 +207,7 @@ public:
 
     template<typename T, DataSetCallback<T> Callback, TriggerMatcher M>
     bool
-    register_snapshot_callback(const data_sink_query &query, M&& matcher, std::chrono::nanoseconds delay, Callback&& callback) {
+    register_snapshot_callback(const data_sink_query &query, M &&matcher, std::chrono::nanoseconds delay, Callback &&callback) {
         std::lock_guard lg{ _mutex };
         auto            sink = find_sink<T>(query);
         if (!sink) {
@@ -319,7 +319,7 @@ public:
     Annotated<T, "signal min", Doc<"signal physical min. (e.g. DAQ) limit">>         signal_min  = std::numeric_limits<T>::lowest();
     Annotated<T, "signal max", Doc<"signal physical max. (e.g. DAQ) limit">>         signal_max  = std::numeric_limits<T>::max();
 
-    IN<T, std::dynamic_extent, _listener_buffer_size>                                in;
+    PortIn<T, RequiredSamples<std::dynamic_extent, _listener_buffer_size>>           in;
 
     struct poller {
         // TODO consider whether reusing port<T> here makes sense
@@ -409,7 +409,7 @@ public:
 
     template<TriggerMatcher M>
     std::shared_ptr<dataset_poller>
-    get_trigger_poller(M&& matcher, std::size_t pre_samples, std::size_t post_samples, blocking_mode block_mode = blocking_mode::Blocking) {
+    get_trigger_poller(M &&matcher, std::size_t pre_samples, std::size_t post_samples, blocking_mode block_mode = blocking_mode::Blocking) {
         const auto      block   = block_mode == blocking_mode::Blocking;
         auto            handler = std::make_shared<dataset_poller>();
         std::lock_guard lg(_listener_mutex);
@@ -420,7 +420,7 @@ public:
 
     template<TriggerMatcher M>
     std::shared_ptr<dataset_poller>
-    get_multiplexed_poller(M&& matcher, std::size_t maximum_window_size, blocking_mode block_mode = blocking_mode::Blocking) {
+    get_multiplexed_poller(M &&matcher, std::size_t maximum_window_size, blocking_mode block_mode = blocking_mode::Blocking) {
         std::lock_guard lg(_listener_mutex);
         const auto      block   = block_mode == blocking_mode::Blocking;
         auto            handler = std::make_shared<dataset_poller>();
@@ -430,7 +430,7 @@ public:
 
     template<TriggerMatcher M>
     std::shared_ptr<dataset_poller>
-    get_snapshot_poller(M&& matcher, std::chrono::nanoseconds delay, blocking_mode block_mode = blocking_mode::Blocking) {
+    get_snapshot_poller(M &&matcher, std::chrono::nanoseconds delay, blocking_mode block_mode = blocking_mode::Blocking) {
         const auto      block   = block_mode == blocking_mode::Blocking;
         auto            handler = std::make_shared<dataset_poller>();
         std::lock_guard lg(_listener_mutex);
@@ -440,27 +440,27 @@ public:
 
     template<StreamCallback<T> Callback>
     void
-    register_streaming_callback(std::size_t max_chunk_size, Callback&& callback) {
+    register_streaming_callback(std::size_t max_chunk_size, Callback &&callback) {
         add_listener(std::make_unique<continuous_listener<Callback>>(max_chunk_size, std::forward<Callback>(callback), *this), false);
     }
 
     template<TriggerMatcher M, DataSetCallback<T> Callback>
     void
-    register_trigger_callback(M&& matcher, std::size_t pre_samples, std::size_t post_samples, Callback&& callback) {
+    register_trigger_callback(M &&matcher, std::size_t pre_samples, std::size_t post_samples, Callback &&callback) {
         add_listener(std::make_unique<trigger_listener<Callback, M>>(std::forward<M>(matcher), pre_samples, post_samples, std::forward<Callback>(callback)), false);
         ensure_history_size(pre_samples);
     }
 
     template<TriggerMatcher M, DataSetCallback<T> Callback>
     void
-    register_multiplexed_callback(M&& matcher, std::size_t maximum_window_size, Callback&& callback) {
+    register_multiplexed_callback(M &&matcher, std::size_t maximum_window_size, Callback &&callback) {
         std::lock_guard lg(_listener_mutex);
         add_listener(std::make_unique<multiplexed_listener<Callback, M>>(std::forward<M>(matcher), maximum_window_size, std::forward<Callback>(callback)), false);
     }
 
     template<TriggerMatcher M, DataSetCallback<T> Callback>
     void
-    register_snapshot_callback(M&& matcher, std::chrono::nanoseconds delay, Callback&& callback) {
+    register_snapshot_callback(M &&matcher, std::chrono::nanoseconds delay, Callback &&callback) {
         std::lock_guard lg(_listener_mutex);
         add_listener(std::make_unique<snapshot_listener<Callback, M>>(std::forward<M>(matcher), delay, std::forward<Callback>(callback)), false);
     }
@@ -634,7 +634,7 @@ private:
         Callback              callback;
 
         template<typename CallbackFW>
-        explicit continuous_listener(std::size_t max_chunk_size, CallbackFW&& c, const data_sink<T> &parent) : parent_sink(parent), buffer(max_chunk_size), callback{ std::forward<CallbackFW>(c) } {}
+        explicit continuous_listener(std::size_t max_chunk_size, CallbackFW &&c, const data_sink<T> &parent) : parent_sink(parent), buffer(max_chunk_size), callback{ std::forward<CallbackFW>(c) } {}
 
         explicit continuous_listener(std::shared_ptr<poller> poller, bool do_block, const data_sink<T> &parent) : parent_sink(parent), block(do_block), polling_handler{ std::move(poller) } {}
 
@@ -760,11 +760,12 @@ private:
         Callback                      callback;
 
         template<TriggerMatcher Matcher>
-        explicit trigger_listener(Matcher&& matcher, std::shared_ptr<dataset_poller> handler, std::size_t pre, std::size_t post, bool do_block)
+        explicit trigger_listener(Matcher &&matcher, std::shared_ptr<dataset_poller> handler, std::size_t pre, std::size_t post, bool do_block)
             : block(do_block), pre_samples(pre), post_samples(post), trigger_matcher(std::forward<Matcher>(matcher)), polling_handler{ std::move(handler) } {}
 
         template<typename CallbackFW, TriggerMatcher Matcher>
-        explicit trigger_listener(Matcher&& matcher, std::size_t pre, std::size_t post, CallbackFW&& cb) : pre_samples(pre), post_samples(post), trigger_matcher(std::forward<Matcher>(matcher)), callback{ std::forward<CallbackFW>(cb) } {}
+        explicit trigger_listener(Matcher &&matcher, std::size_t pre, std::size_t post, CallbackFW &&cb)
+            : pre_samples(pre), post_samples(post), trigger_matcher(std::forward<Matcher>(matcher)), callback{ std::forward<CallbackFW>(cb) } {}
 
         void
         set_dataset_template(DataSet<T> dst) override {
@@ -850,11 +851,11 @@ private:
         Callback                      callback;
 
         template<typename CallbackFW, TriggerMatcher Matcher>
-        explicit multiplexed_listener(Matcher&& matcher_, std::size_t max_window_size, CallbackFW&& cb)
+        explicit multiplexed_listener(Matcher &&matcher_, std::size_t max_window_size, CallbackFW &&cb)
             : matcher(std::forward<Matcher>(matcher_)), maximum_window_size(max_window_size), callback(std::forward<CallbackFW>(cb)) {}
 
         template<TriggerMatcher Matcher>
-        explicit multiplexed_listener(Matcher&& matcher_, std::size_t max_window_size, std::shared_ptr<dataset_poller> handler, bool do_block)
+        explicit multiplexed_listener(Matcher &&matcher_, std::size_t max_window_size, std::shared_ptr<dataset_poller> handler, bool do_block)
             : block(do_block), matcher(std::forward<Matcher>(matcher_)), maximum_window_size(max_window_size), polling_handler{ std::move(handler) } {}
 
         void
@@ -949,11 +950,12 @@ private:
         Callback                      callback;
 
         template<TriggerMatcher Matcher>
-        explicit snapshot_listener(Matcher&& matcher, std::chrono::nanoseconds delay, std::shared_ptr<dataset_poller> poller, bool do_block)
+        explicit snapshot_listener(Matcher &&matcher, std::chrono::nanoseconds delay, std::shared_ptr<dataset_poller> poller, bool do_block)
             : block(do_block), time_delay(delay), trigger_matcher(std::forward<Matcher>(matcher)), polling_handler{ std::move(poller) } {}
 
         template<typename CallbackFW, TriggerMatcher Matcher>
-        explicit snapshot_listener(Matcher&& matcher, std::chrono::nanoseconds delay, CallbackFW&& cb) : time_delay(delay), trigger_matcher(std::forward<Matcher>(matcher)), callback(std::forward<CallbackFW>(cb)) {}
+        explicit snapshot_listener(Matcher &&matcher, std::chrono::nanoseconds delay, CallbackFW &&cb)
+            : time_delay(delay), trigger_matcher(std::forward<Matcher>(matcher)), callback(std::forward<CallbackFW>(cb)) {}
 
         void
         set_dataset_template(DataSet<T> dst) override {

--- a/include/graph.hpp
+++ b/include/graph.hpp
@@ -738,9 +738,10 @@ operator<<(std::ostream &os, const port_direction_t &value) {
     return os << static_cast<int>(value);
 }
 
+template<PortDomainType T>
 inline std::ostream &
-operator<<(std::ostream &os, const port_domain_t &value) {
-    return os << static_cast<int>(value);
+operator<<(std::ostream &os, const T &value) {
+    return os << value.Name;
 }
 
 #if HAVE_SOURCE_LOCATION

--- a/include/port.hpp
+++ b/include/port.hpp
@@ -1,44 +1,77 @@
 #ifndef GNURADIO_PORT_HPP
 #define GNURADIO_PORT_HPP
 
-#include "circular_buffer.hpp"
-#include "tag.hpp"
-#include "utils.hpp"
 #include <complex>
 #include <dataset.hpp>
 #include <node.hpp>
 #include <span>
 #include <variant>
 
+#include <annotated.hpp>
+#include <circular_buffer.hpp>
+#include <tag.hpp>
+#include <utils.hpp>
+
 namespace fair::graph {
 
 using fair::meta::fixed_string;
 using namespace fair::literals;
 
-// #### default supported types -- TODO: to be replaced by pmt::pmtv declaration
+#ifndef PMT_SUPPORTED_TYPE // // #### default supported types -- TODO: to be replaced by pmt::pmtv declaration
+#define PMT_SUPPORTED_TYPE
 // Only DataSet<double> and DataSet<float> are added => consider to support more Dataset<T>
-using supported_type = std::variant<uint8_t, uint32_t, int8_t, int16_t, int32_t, float, double, std::complex<float>, std::complex<double>, DataSet<double>, DataSet<float> /*, ...*/>;
+using supported_type = std::variant<uint8_t, uint32_t, int8_t, int16_t, int32_t, float, double, std::complex<float>, std::complex<double>, DataSet<float>, DataSet<double> /*, ...*/>;
+#endif
 
 enum class port_direction_t { INPUT, OUTPUT, ANY }; // 'ANY' only for query and not to be used for port declarations
+
 enum class connection_result_t { SUCCESS, FAILED };
+
 enum class port_type_t {
     STREAM, /*!< used for single-producer-only ond usually synchronous one-to-one or one-to-many communications */
     MESSAGE /*!< used for multiple-producer one-to-one, one-to-many, many-to-one, or many-to-many communications */
 };
-enum class port_domain_t { CPU, GPU, NET, FPGA, DSP, MLU };
+
+/**
+ * @brief optional port annotation argument to described whether the port can be handled within the same scheduling domain.
+ *
+ * @tparam PortDomainName the unique name of the domain, name shouldn't clash with other existing definitions (e.g. 'CPU' and 'GPU')
+ */
+template<fixed_string PortDomainName>
+struct PortDomain {
+    inline static constexpr fixed_string Name = PortDomainName;
+};
+
+template<typename T>
+concept PortDomainType = requires { T::Name; } && std::is_base_of_v<PortDomain<T::Name>, T>;
+
+template<typename T>
+using is_port_domain = std::bool_constant<PortDomainType<T>>;
+
+struct CPU : public PortDomain<"CPU"> {};
+
+struct GPU : public PortDomain<"GPU"> {};
+
+static_assert(is_port_domain<CPU>::value);
+static_assert(is_port_domain<GPU>::value);
+static_assert(!is_port_domain<int>::value);
 
 template<class T>
-concept Port = requires(T t, const std::size_t n_items) { // dynamic definitions
+concept PortType = requires(T t, const std::size_t n_items, const supported_type &newDefault) { // dynamic definitions
     typename T::value_type;
-    { t.pmt_type() } -> std::same_as<supported_type>;
+    { t.defaultValue() } -> std::same_as<supported_type>;
+    { t.setDefaultValue(newDefault) } -> std::same_as<bool>;
     { t.name } -> std::convertible_to<std::string_view>;
     { t.priority } -> std::convertible_to<std::int32_t>;
     { t.min_samples } -> std::convertible_to<std::size_t>;
     { t.max_samples } -> std::convertible_to<std::size_t>;
     { t.type() } -> std::same_as<port_type_t>;
     { t.direction() } -> std::same_as<port_direction_t>;
+    { t.domain() } -> std::same_as<std::string_view>;
     { t.resize_buffer(n_items) } -> std::same_as<connection_result_t>;
     { t.disconnect() } -> std::same_as<connection_result_t>;
+    { t.isSynchronous() } -> std::same_as<bool>;
+    { t.isOptional() } -> std::same_as<bool>;
 };
 
 /**
@@ -50,6 +83,95 @@ struct internal_port_buffers {
     void *streamHandler;
     void *tagHandler;
 };
+
+/**
+ * @brief optional port annotation argument to describe the min/max number of samples required from this port before invoking the blocks work function.
+ *
+ * @tparam MIN_SAMPLES (>0) specifies the minimum number of samples the port/block requires for processing in one scheduler iteration
+ * @tparam MAX_SAMPLES specifies the maximum number of samples the port/block can process in one scheduler iteration
+ */
+template<std::size_t MIN_SAMPLES = std::dynamic_extent, std::size_t MAX_SAMPLES = std::dynamic_extent>
+struct RequiredSamples {
+    static_assert(MIN_SAMPLES > 0, "Port<T, ..., RequiredSamples::MIN_SAMPLES, ...>, ..> must be >= 0");
+    static constexpr std::size_t MinSamples = MIN_SAMPLES;
+    static constexpr std::size_t MaxSamples = MAX_SAMPLES;
+};
+
+template<typename T>
+concept IsRequiredSamples = requires {
+    T::MinSamples;
+    T::MaxSamples;
+} && std::is_base_of_v<RequiredSamples<T::MinSamples, T::MaxSamples>, T>;
+
+template<typename T>
+using is_required_samples = std::bool_constant<IsRequiredSamples<T>>;
+
+static_assert(is_required_samples<RequiredSamples<1, 1024>>::value);
+static_assert(!is_required_samples<int>::value);
+
+/**
+ * @brief optional port annotation argument informing the graph/scheduler that a given port does not require to be connected
+ */
+struct Optional {};
+
+/**
+ * @brief optional port annotation argument to define the buffer implementation to be used for streaming data
+ *
+ * @tparam BufferType user-extendable buffer implementation for the streaming data
+ */
+template<gr::Buffer BufferType>
+struct StreamBufferType {
+    using type = BufferType;
+};
+
+/**
+ * @brief optional port annotation argument to define the buffer implementation to be used for tag data
+ *
+ * @tparam BufferType user-extendable buffer implementation for the tag data
+ */
+template<gr::Buffer BufferType>
+struct TagBufferType {
+    using type = BufferType;
+};
+
+template<typename T>
+concept IsStreamBufferAttribute = requires { typename T::type; } && gr::Buffer<typename T::type> && std::is_base_of_v<StreamBufferType<typename T::type>, T>;
+;
+
+template<typename T>
+concept IsTagBufferAttribute = requires { typename T::type; } && gr::Buffer<typename T::type> && std::is_base_of_v<TagBufferType<typename T::type>, T>;
+
+template<typename T>
+using is_stream_buffer_attribute = std::bool_constant<IsStreamBufferAttribute<T>>;
+
+template<typename T>
+using is_tag_buffer_attribute = std::bool_constant<IsTagBufferAttribute<T>>;
+
+template<typename T>
+struct DefaultStreamBuffer : StreamBufferType<gr::circular_buffer<T>> {};
+
+struct DefaultTagBuffer : TagBufferType<gr::circular_buffer<tag_t>> {};
+
+static_assert(is_stream_buffer_attribute<DefaultStreamBuffer<int>>::value);
+static_assert(!is_stream_buffer_attribute<DefaultTagBuffer>::value);
+static_assert(!is_tag_buffer_attribute<DefaultStreamBuffer<int>>::value);
+static_assert(is_tag_buffer_attribute<DefaultTagBuffer>::value);
+
+/**
+ * @brief Annotation for making a port asynchronous in a signal flow-graph block.
+ *
+ * In a standard block, the processing function is invoked based on the least common number of samples
+ * available across all input and output ports. When a port is annotated with `Async`, it is excluded from this
+ * least common number calculation.
+ *
+ * Applying `Async` as an optional template argument of the Port class essentially marks the port as "optional" for the
+ * synchronization mechanism. The block's processing function will be invoked regardless of the number of samples
+ * available at this specific port, relying solely on the state of other ports that are not marked as asynchronous.
+ *
+ * Use this annotation to create ports that do not constrain the block's ability to process data, making it
+ * asynchronous relative to the other ports in the block.
+ */
+struct Async {};
 
 /**
  * @brief 'ports' are interfaces that allows data to flow between blocks in a graph, similar to RF connectors.
@@ -73,38 +195,41 @@ struct internal_port_buffers {
  * @tparam PortName a string to identify the port, notably to be used in an UI- and hand-written explicit code context.
  * @tparam PortType STREAM  or MESSAGE
  * @tparam PortDirection either input or output
- * @tparam MIN_SAMPLES specifies the minimum number of samples the port/block requires for processing in one scheduler iteration
- * @tparam MAX_SAMPLES specifies the maximum number of samples the port/block can process in one scheduler iteration
- * @tparam BufferType user-extendable buffer implementation for the streaming data
- * @tparam TagBufferType user-extendable buffer implementation for the tag data
+ * @tparam Arguments optional: default to 'DefaultStreamBuffer' and DefaultTagBuffer' based on 'gr::circular_buffer', and CPU domain
  */
-template<typename T, fixed_string PortName, port_type_t PortType, port_direction_t PortDirection, // TODO: sort default arguments
-         std::size_t MIN_SAMPLES = std::dynamic_extent, std::size_t MAX_SAMPLES = std::dynamic_extent, gr::Buffer BufferType = gr::circular_buffer<T>,
-         gr::Buffer TagBufferType = gr::circular_buffer<tag_t>>
-class port {
-public:
+template<typename T, fixed_string PortName, port_type_t PortType, port_direction_t PortDirection, typename... Arguments>
+struct Port {
+    template<fixed_string NewName>
+    using with_name = Port<T, NewName, PortType, PortDirection, Arguments...>;
+
     static_assert(PortDirection != port_direction_t::ANY, "ANY reserved for queries and not port direction declarations");
 
-    using value_type                = T;
+    using value_type                            = T;
+    using ArgumentsTypeList                     = typename fair::meta::typelist<Arguments...>;
+    using Domain                                = ArgumentsTypeList::template find_or_default<is_port_domain, CPU>;
+    using Required                              = ArgumentsTypeList::template find_or_default<is_required_samples, RequiredSamples<std::dynamic_extent, std::dynamic_extent>>;
+    using BufferType                            = ArgumentsTypeList::template find_or_default<is_stream_buffer_attribute, DefaultStreamBuffer<T>>::type;
+    using TagBufferType                         = ArgumentsTypeList::template find_or_default<is_tag_buffer_attribute, DefaultTagBuffer>::type;
+    static constexpr port_direction_t Direction = PortDirection;
+    static constexpr bool             IS_INPUT  = PortDirection == port_direction_t::INPUT;
+    static constexpr bool             IS_OUTPUT = PortDirection == port_direction_t::OUTPUT;
+    static constexpr fixed_string     Name      = PortName;
 
-    static constexpr bool IS_INPUT  = PortDirection == port_direction_t::INPUT;
-    static constexpr bool IS_OUTPUT = PortDirection == port_direction_t::OUTPUT;
-
-    template<fixed_string NewName>
-    using with_name     = port<T, NewName, PortType, PortDirection, MIN_SAMPLES, MAX_SAMPLES, BufferType>;
-
-    using ReaderType    = decltype(std::declval<BufferType>().new_reader());
-    using WriterType    = decltype(std::declval<BufferType>().new_writer());
-    using IoType        = std::conditional_t<IS_INPUT, ReaderType, WriterType>;
-    using TagReaderType = decltype(std::declval<TagBufferType>().new_reader());
-    using TagWriterType = decltype(std::declval<TagBufferType>().new_writer());
-    using TagIoType     = std::conditional_t<IS_INPUT, TagReaderType, TagWriterType>;
+    using ReaderType                            = decltype(std::declval<BufferType>().new_reader());
+    using WriterType                            = decltype(std::declval<BufferType>().new_writer());
+    using IoType                                = std::conditional_t<IS_INPUT, ReaderType, WriterType>;
+    using TagReaderType                         = decltype(std::declval<TagBufferType>().new_reader());
+    using TagWriterType                         = decltype(std::declval<TagBufferType>().new_writer());
+    using TagIoType                             = std::conditional_t<IS_INPUT, TagReaderType, TagWriterType>;
 
     // public properties
-    const std::string name        = static_cast<std::string>(PortName);
-    std::int16_t      priority    = 0; // → dependents of a higher-prio port should be scheduled first (Q: make this by order of ports?)
-    std::size_t       min_samples = (MIN_SAMPLES == std::dynamic_extent ? 1 : MIN_SAMPLES);
-    std::size_t       max_samples = MAX_SAMPLES;
+    constexpr static bool synchronous   = not std::disjunction_v<std::is_same<Async, Arguments>...>;
+    constexpr static bool optional      = std::disjunction_v<std::is_same<Optional, Arguments>...>;
+    std::string           name          = static_cast<std::string>(PortName);
+    std::int16_t          priority      = 0; // → dependents of a higher-prio port should be scheduled first (Q: make this by order of ports?)
+    std::size_t           min_samples   = (Required::MinSamples == std::dynamic_extent ? 1 : Required::MinSamples);
+    std::size_t           max_samples   = Required::MaxSamples;
+    T                     default_value = T{};
 
 private:
     bool      _connected    = false;
@@ -112,21 +237,30 @@ private:
     TagIoType _tagIoHandler = new_tag_io_handler();
 
 public:
+    bool
+    initBuffer(std::size_t nSamples = 0) noexcept {
+        if constexpr (IS_OUTPUT) {
+            // write one default value into output -- needed for cyclic graph initialisation
+            return _ioHandler.try_publish([val = default_value](std::span<T> &out) { out[0] = val; }, 1_UZ);
+        }
+        return true;
+    }
+
     [[nodiscard]] constexpr auto
-    new_io_handler() const noexcept {
+    new_io_handler(std::size_t buffer_size = 65536) const noexcept {
         if constexpr (IS_INPUT) {
-            return BufferType(65536).new_reader();
+            return BufferType(buffer_size).new_reader();
         } else {
-            return BufferType(65536).new_writer();
+            return BufferType(buffer_size).new_writer();
         }
     }
 
     [[nodiscard]] constexpr auto
-    new_tag_io_handler() const noexcept {
+    new_tag_io_handler(std::size_t buffer_size = 65536) const noexcept {
         if constexpr (IS_INPUT) {
-            return TagBufferType(65536).new_reader();
+            return TagBufferType(buffer_size).new_reader();
         } else {
-            return TagBufferType(65536).new_writer();
+            return TagBufferType(buffer_size).new_writer();
         }
     }
 
@@ -158,22 +292,22 @@ public:
     }
 
 public:
-    port()             = default;
-    port(const port &) = delete;
+    constexpr Port()   = default;
+    Port(const Port &) = delete;
     auto
-    operator=(const port &)
+    operator=(const Port &)
             = delete;
 
-    port(std::string port_name, std::int16_t priority_ = 0, std::size_t min_samples_ = 0_UZ, std::size_t max_samples_ = SIZE_MAX) noexcept
+    Port(std::string port_name, std::int16_t priority_ = 0, std::size_t min_samples_ = 0_UZ, std::size_t max_samples_ = SIZE_MAX) noexcept
         : name(std::move(port_name)), priority{ priority_ }, min_samples(min_samples_), max_samples(max_samples_) {
         static_assert(PortName.empty(), "port name must be exclusively declared via NTTP or constructor parameter");
     }
 
-    constexpr port(port &&other) noexcept : name(std::move(other.name)), priority{ other.priority }, min_samples(other.min_samples), max_samples(other.max_samples) {}
+    constexpr Port(Port &&other) noexcept : name(std::move(other.name)), priority{ other.priority }, min_samples(other.min_samples), max_samples(other.max_samples) {}
 
-    constexpr port &
-    operator=(port &&other) {
-        port tmp(std::move(other));
+    constexpr Port &
+    operator=(Port &&other) {
+        Port tmp(std::move(other));
         std::swap(name, tmp._name);
         std::swap(min_samples, tmp._min_samples);
         std::swap(max_samples, tmp._max_samples);
@@ -195,6 +329,21 @@ public:
         return PortDirection;
     }
 
+    [[nodiscard]] constexpr static std::string_view
+    domain() noexcept {
+        return std::string_view(Domain::Name);
+    }
+
+    [[nodiscard]] constexpr static bool
+    isSynchronous() noexcept {
+        return synchronous;
+    }
+
+    [[nodiscard]] constexpr static bool
+    isOptional() noexcept {
+        return optional;
+    }
+
     [[nodiscard]] constexpr static decltype(PortName)
     static_name() noexcept
         requires(!PortName.empty())
@@ -208,8 +357,17 @@ public:
 #else
     [[nodiscard]] constexpr supported_type
 #endif
-    pmt_type() const noexcept {
-        return T();
+    defaultValue() const noexcept {
+        return default_value;
+    }
+
+    bool
+    setDefaultValue(const supported_type &newDefault) noexcept {
+        if (std::holds_alternative<T>(newDefault)) {
+            default_value = std::get<T>(newDefault);
+            return true;
+        }
+        return false;
     }
 
     [[nodiscard]] constexpr static std::size_t
@@ -219,19 +377,19 @@ public:
 
     [[nodiscard]] constexpr std::size_t
     min_buffer_size() const noexcept {
-        if constexpr (MIN_SAMPLES == std::dynamic_extent) {
+        if constexpr (Required::MinSamples == std::dynamic_extent) {
             return min_samples;
         } else {
-            return MIN_SAMPLES;
+            return Required::MinSamples;
         }
     }
 
     [[nodiscard]] constexpr std::size_t
     max_buffer_size() const noexcept {
-        if constexpr (MAX_SAMPLES == std::dynamic_extent) {
+        if constexpr (Required::MaxSamples == std::dynamic_extent) {
             return max_samples;
         } else {
-            return MAX_SAMPLES;
+            return Required::MaxSamples;
         }
     }
 
@@ -346,39 +504,52 @@ namespace detail {
 template<typename T, auto>
 using just_t = T;
 
-template<typename T, std::size_t... Is>
-consteval fair::meta::typelist<just_t<T, Is>...>
+template<typename T, fixed_string BaseName, port_type_t PortType, port_direction_t PortDirection, typename... Arguments, std::size_t... Is>
+consteval fair::meta::typelist<just_t<Port<T, BaseName + meta::make_fixed_string<Is>(), PortType, PortDirection, Arguments...>, Is>...>
 repeated_ports_impl(std::index_sequence<Is...>) {
     return {};
 }
 } // namespace detail
 
-// TODO: Add port index to BaseName
-template<std::size_t Count, typename T, fixed_string BaseName, port_type_t PortType, port_direction_t PortDirection, std::size_t MIN_SAMPLES = std::dynamic_extent,
-         std::size_t MAX_SAMPLES = std::dynamic_extent>
-using repeated_ports = decltype(detail::repeated_ports_impl<port<T, BaseName, PortType, PortDirection, MIN_SAMPLES, MAX_SAMPLES>>(std::make_index_sequence<Count>()));
+template<std::size_t Count, typename T, fixed_string BaseName, port_type_t PortType, port_direction_t PortDirection, typename... Arguments>
+using repeated_ports = decltype(detail::repeated_ports_impl<T, BaseName, PortType, PortDirection, Arguments...>(std::make_index_sequence<Count>()));
 
-template<typename T, std::size_t MIN_SAMPLES = std::dynamic_extent, std::size_t MAX_SAMPLES = std::dynamic_extent, fixed_string PortName = "">
-using IN = port<T, PortName, port_type_t::STREAM, port_direction_t::INPUT, MIN_SAMPLES, MAX_SAMPLES>;
-template<typename T, std::size_t MIN_SAMPLES = std::dynamic_extent, std::size_t MAX_SAMPLES = std::dynamic_extent, fixed_string PortName = "">
-using OUT = port<T, PortName, port_type_t::STREAM, port_direction_t::OUTPUT, MIN_SAMPLES, MAX_SAMPLES>;
-template<typename T, std::size_t MIN_SAMPLES = std::dynamic_extent, std::size_t MAX_SAMPLES = std::dynamic_extent, fixed_string PortName = "">
-using IN_MSG = port<T, PortName, port_type_t::MESSAGE, port_direction_t::INPUT, MIN_SAMPLES, MAX_SAMPLES>;
-template<typename T, std::size_t MIN_SAMPLES = std::dynamic_extent, std::size_t MAX_SAMPLES = std::dynamic_extent, fixed_string PortName = "">
-using OUT_MSG = port<T, PortName, port_type_t::MESSAGE, port_direction_t::OUTPUT, MIN_SAMPLES, MAX_SAMPLES>;
+static_assert(repeated_ports<3, float, "out", port_type_t::STREAM, port_direction_t::OUTPUT, Optional>::at<0>::Name == fixed_string("out0"));
+static_assert(repeated_ports<3, float, "out", port_type_t::STREAM, port_direction_t::OUTPUT, Optional>::at<1>::Name == fixed_string("out1"));
+static_assert(repeated_ports<3, float, "out", port_type_t::STREAM, port_direction_t::OUTPUT, Optional>::at<2>::Name == fixed_string("out2"));
 
-static_assert(Port<IN<float>>);
-static_assert(Port<decltype(IN<float>())>);
-static_assert(Port<OUT<float>>);
-static_assert(Port<IN_MSG<float>>);
-static_assert(Port<OUT_MSG<float>>);
+template<typename T, typename... Arguments>
+using PortIn = Port<T, "", port_type_t::STREAM, port_direction_t::INPUT, Arguments...>;
+template<typename T, typename... Arguments>
+using PortOut = Port<T, "", port_type_t::STREAM, port_direction_t::OUTPUT, Arguments...>;
+template<typename... Arguments>
+using MsgPortIn = Port<property_map, "", port_type_t::MESSAGE, port_direction_t::INPUT, Arguments...>;
+template<typename... Arguments>
+using MsgPortOut = Port<property_map, "", port_type_t::MESSAGE, port_direction_t::OUTPUT, Arguments...>;
 
-static_assert(IN<float, 0, 0, "in">::static_name() == fixed_string("in"));
-static_assert(requires { IN<float>("in").name; });
+template<typename T, fixed_string PortName = "", typename... Arguments>
+using PortInNamed = Port<T, PortName, port_type_t::STREAM, port_direction_t::INPUT, Arguments...>;
+template<typename T, fixed_string PortName = "", typename... Arguments>
+using PortOutNamed = Port<T, PortName, port_type_t::STREAM, port_direction_t::OUTPUT, Arguments...>;
+template<fixed_string PortName = "", typename... Arguments>
+using MsgPortInNamed = Port<property_map, PortName, port_type_t::STREAM, port_direction_t::INPUT, Arguments...>;
+template<fixed_string PortName = "", typename... Arguments>
+using MsgPortOutNamed = Port<property_map, PortName, port_type_t::STREAM, port_direction_t::OUTPUT, Arguments...>;
 
-static_assert(OUT_MSG<float, 0, 0, "out_msg">::static_name() == fixed_string("out_msg"));
-static_assert(!(OUT_MSG<float, 0, 0, "out_msg">::with_name<"out_message">::static_name() == fixed_string("out_msg")));
-static_assert(OUT_MSG<float, 0, 0, "out_msg">::with_name<"out_message">::static_name() == fixed_string("out_message"));
+static_assert(PortType<PortIn<float>>);
+static_assert(PortType<decltype(PortIn<float>())>);
+static_assert(PortType<PortOut<float>>);
+static_assert(PortType<MsgPortIn<float>>);
+static_assert(PortType<MsgPortOut<float>>);
+
+static_assert(PortIn<float, RequiredSamples<1, 2>>::Required::MinSamples == 1);
+static_assert(PortIn<float, RequiredSamples<1, 2>>::Required::MaxSamples == 2);
+static_assert(std::same_as<PortIn<float, RequiredSamples<1, 2>>::Domain, CPU>);
+static_assert(std::same_as<PortIn<float, RequiredSamples<1, 2>, GPU>::Domain, GPU>);
+
+static_assert(MsgPortOutNamed<"out_msg">::static_name() == fixed_string("out_msg"));
+static_assert(!(MsgPortOutNamed<"out_msg">::with_name<"out_message">::static_name() == fixed_string("out_msg")));
+static_assert(MsgPortOutNamed<"out_msg">::with_name<"out_message">::static_name() == fixed_string("out_message"));
 
 /**
  *  Runtime capable wrapper to be used within a block. It's primary purpose is to allow the runtime
@@ -404,7 +575,11 @@ private:
         virtual ~model() = default;
 
         [[nodiscard]] virtual supported_type
-        pmt_type() const noexcept
+        defaultValue() const noexcept
+                = 0;
+
+        [[nodiscard]] virtual bool
+        setDefaultValue(const supported_type &val) noexcept
                 = 0;
 
         [[nodiscard]] virtual port_type_t
@@ -413,6 +588,18 @@ private:
 
         [[nodiscard]] virtual port_direction_t
         direction() const noexcept
+                = 0;
+
+        [[nodiscard]] virtual std::string_view
+        domain() const noexcept
+                = 0;
+
+        [[nodiscard]] virtual bool
+        isSynchronous() noexcept
+                = 0;
+
+        [[nodiscard]] virtual bool
+        isOptional() noexcept
                 = 0;
 
         [[nodiscard]] virtual connection_result_t
@@ -435,7 +622,7 @@ private:
 
     std::unique_ptr<model> _accessor;
 
-    template<Port T, bool owning>
+    template<PortType T, bool owning>
     class wrapper final : public model {
         using PortType = std::decay_t<T>;
         std::conditional_t<owning, PortType, PortType &> _value;
@@ -489,15 +676,20 @@ private:
         }
 
         ~wrapper() override = default;
-        
+
         // TODO revisit: constexpr was removed because emscripten does not support constexpr function for non literal type, like DataSet<T>
 #if defined(__EMSCRIPTEN__)
         [[nodiscard]] supported_type
 #else
         [[nodiscard]] constexpr supported_type
 #endif
-        pmt_type() const noexcept override {
-            return _value.pmt_type();
+        defaultValue() const noexcept override {
+            return _value.defaultValue();
+        }
+
+        [[nodiscard]] bool
+        setDefaultValue(const supported_type &val) noexcept override {
+            return _value.setDefaultValue(val);
         }
 
         [[nodiscard]] constexpr port_type_t
@@ -508,6 +700,21 @@ private:
         [[nodiscard]] constexpr port_direction_t
         direction() const noexcept override {
             return _value.direction();
+        }
+
+        [[nodiscard]] constexpr std::string_view
+        domain() const noexcept override {
+            return _value.domain();
+        }
+
+        [[nodiscard]] bool
+        isSynchronous() noexcept override {
+            return _value.isSynchronous();
+        }
+
+        [[nodiscard]] bool
+        isOptional() noexcept override {
+            return _value.isOptional();
         }
 
         [[nodiscard]] connection_result_t
@@ -553,17 +760,22 @@ public:
             = delete;
 
     // TODO: Make owning versus non-owning API more explicit
-    template<Port T>
+    template<PortType T>
     explicit constexpr dynamic_port(T &arg) noexcept
         : name(arg.name), priority(arg.priority), min_samples(arg.min_samples), max_samples(arg.max_samples), _accessor{ std::make_unique<wrapper<T, false>>(arg) } {}
 
-    template<Port T>
+    template<PortType T>
     explicit constexpr dynamic_port(T &&arg) noexcept
         : name(arg.name), priority(arg.priority), min_samples(arg.min_samples), max_samples(arg.max_samples), _accessor{ std::make_unique<wrapper<T, true>>(std::forward<T>(arg)) } {}
 
     [[nodiscard]] supported_type
-    pmt_type() const noexcept {
-        return _accessor->pmt_type();
+    defaultValue() const noexcept {
+        return _accessor->defaultValue();
+    }
+
+    [[nodiscard]] bool
+    setDefaultValue(const supported_type &val) noexcept {
+        return _accessor->setDefaultValue(val);
     }
 
     [[nodiscard]] port_type_t
@@ -574,6 +786,21 @@ public:
     [[nodiscard]] port_direction_t
     direction() const noexcept {
         return _accessor->direction();
+    }
+
+    [[nodiscard]] std::string_view
+    domain() const noexcept {
+        return _accessor->domain();
+    }
+
+    [[nodiscard]] bool
+    isSynchronous() noexcept {
+        return _accessor->isSynchronous();
+    }
+
+    [[nodiscard]] bool
+    isOptional() noexcept {
+        return _accessor->isOptional();
     }
 
     [[nodiscard]] connection_result_t
@@ -595,10 +822,10 @@ public:
     }
 };
 
-static_assert(Port<dynamic_port>);
+static_assert(PortType<dynamic_port>);
 
 constexpr void
-publish_tag(Port auto &port, property_map &&tag_data, std::size_t tag_offset = 0) noexcept {
+publish_tag(PortType auto &port, property_map &&tag_data, std::size_t tag_offset = 0) noexcept {
     port.tagWriter().publish(
             [&port, data = std::move(tag_data), &tag_offset](std::span<fair::graph::tag_t> tag_output) {
                 tag_output[0].index = port.streamWriter().position() + std::make_signed_t<std::size_t>(tag_offset);
@@ -608,7 +835,7 @@ publish_tag(Port auto &port, property_map &&tag_data, std::size_t tag_offset = 0
 }
 
 constexpr void
-publish_tag(Port auto &port, const property_map &tag_data, std::size_t tag_offset = 0) noexcept {
+publish_tag(PortType auto &port, const property_map &tag_data, std::size_t tag_offset = 0) noexcept {
     port.tagWriter().publish(
             [&port, &tag_data, &tag_offset](std::span<fair::graph::tag_t> tag_output) {
                 tag_output[0].index = port.streamWriter().position() + tag_offset;
@@ -618,7 +845,7 @@ publish_tag(Port auto &port, const property_map &tag_data, std::size_t tag_offse
 }
 
 constexpr std::size_t
-samples_to_next_tag(const Port auto &port) {
+samples_to_next_tag(const PortType auto &port) {
     if (port.tagReader().available() == 0) [[likely]] {
         return std::numeric_limits<std::size_t>::max(); // default: no tags in sight
     }

--- a/include/port.hpp
+++ b/include/port.hpp
@@ -241,7 +241,7 @@ public:
     initBuffer(std::size_t nSamples = 0) noexcept {
         if constexpr (IS_OUTPUT) {
             // write one default value into output -- needed for cyclic graph initialisation
-            return _ioHandler.try_publish([val = default_value](std::span<T> &out) {  std::ranges::fill(out, val); }, nSamples);
+            return _ioHandler.try_publish([val = default_value](std::span<T> &out) { std::ranges::fill(out, val); }, nSamples);
         }
         return true;
     }
@@ -291,7 +291,6 @@ public:
         return true;
     }
 
-public:
     constexpr Port()   = default;
     Port(const Port &) = delete;
     auto
@@ -319,8 +318,7 @@ public:
         return *this;
     }
 
-    ~Port() { /* explicitely defined */
-    }
+    ~Port() = default;
 
     [[nodiscard]] constexpr static port_type_t
     type() noexcept {
@@ -398,17 +396,18 @@ public:
 
     [[nodiscard]] constexpr connection_result_t
     resize_buffer(std::size_t min_size) noexcept {
+        using enum fair::graph::connection_result_t;
         if constexpr (IS_INPUT) {
-            return connection_result_t::SUCCESS;
+            return SUCCESS;
         } else {
             try {
                 _ioHandler    = BufferType(min_size).new_writer();
                 _tagIoHandler = TagBufferType(min_size).new_writer();
             } catch (...) {
-                return connection_result_t::FAILED;
+                return FAILED;
             }
         }
-        return connection_result_t::SUCCESS;
+        return SUCCESS;
     }
 
     [[nodiscard]] auto
@@ -530,13 +529,13 @@ using MsgPortIn = Port<property_map, "", port_type_t::MESSAGE, port_direction_t:
 template<typename... Arguments>
 using MsgPortOut = Port<property_map, "", port_type_t::MESSAGE, port_direction_t::OUTPUT, Arguments...>;
 
-template<typename T, fixed_string PortName = "", typename... Arguments>
+template<typename T, fixed_string PortName, typename... Arguments>
 using PortInNamed = Port<T, PortName, port_type_t::STREAM, port_direction_t::INPUT, Arguments...>;
-template<typename T, fixed_string PortName = "", typename... Arguments>
+template<typename T, fixed_string PortName, typename... Arguments>
 using PortOutNamed = Port<T, PortName, port_type_t::STREAM, port_direction_t::OUTPUT, Arguments...>;
-template<fixed_string PortName = "", typename... Arguments>
+template<fixed_string PortName, typename... Arguments>
 using MsgPortInNamed = Port<property_map, PortName, port_type_t::STREAM, port_direction_t::INPUT, Arguments...>;
-template<fixed_string PortName = "", typename... Arguments>
+template<fixed_string PortName, typename... Arguments>
 using MsgPortOutNamed = Port<property_map, PortName, port_type_t::STREAM, port_direction_t::OUTPUT, Arguments...>;
 
 static_assert(PortType<PortIn<float>>);
@@ -732,12 +731,13 @@ private:
 
         [[nodiscard]] connection_result_t
         connect(dynamic_port &dst_port) override {
+            using enum fair::graph::connection_result_t;
             if constexpr (T::IS_OUTPUT) {
                 auto src_buffer = _value.writer_handler_internal();
-                return dst_port.update_reader_internal(src_buffer) ? connection_result_t::SUCCESS : connection_result_t::FAILED;
+                return dst_port.update_reader_internal(src_buffer) ? SUCCESS : FAILED;
             } else {
                 assert(false && "This works only on input ports");
-                return connection_result_t::FAILED;
+                return FAILED;
             }
         }
     };

--- a/include/port_traits.hpp
+++ b/include/port_traits.hpp
@@ -8,11 +8,11 @@ namespace fair::graph::traits::port {
 
 template<typename T>
 concept has_fixed_info_v = requires {
-                                    typename T::value_type;
-                                    { T::static_name() };
-                                    { T::direction() } -> std::same_as<port_direction_t>;
-                                    { T::type() } -> std::same_as<port_type_t>;
-                                };
+    typename T::value_type;
+    { T::static_name() };
+    { T::direction() } -> std::same_as<port_direction_t>;
+    { T::type() } -> std::same_as<port_type_t>;
+};
 
 template<typename T>
 using has_fixed_info = std::integral_constant<bool, has_fixed_info_v<T>>;
@@ -43,25 +43,15 @@ using is_output = std::integral_constant<bool, Port::direction() == port_directi
 template<typename Port>
 concept is_output_v = is_output<Port>::value;
 
-template <typename Type>
+template<typename Type>
 concept is_port_v = is_output_v<Type> || is_input_v<Type>;
 
 template<typename... Ports>
-struct min_samples : std::integral_constant<std::size_t, std::max({ min_samples<Ports>::value... })> {};
-
-template<typename T, fixed_string PortName, port_type_t PortType, port_direction_t PortDirection,
-         std::size_t MIN_SAMPLES, std::size_t MAX_SAMPLES, gr::Buffer BufferType>
-struct min_samples<fair::graph::port<T, PortName, PortType, PortDirection, MIN_SAMPLES, MAX_SAMPLES, BufferType>>
-    : std::integral_constant<std::size_t, MIN_SAMPLES> {};
+struct min_samples : std::integral_constant<std::size_t, std::max({ Ports::RequiredSamples::MinSamples... })> {};
 
 template<typename... Ports>
-struct max_samples : std::integral_constant<std::size_t, std::min({ max_samples<Ports>::value... })> {};
+struct max_samples : std::integral_constant<std::size_t, std::max({ Ports::RequiredSamples::MaxSamples... })> {};
 
-template<typename T, fixed_string PortName, port_type_t PortType, port_direction_t PortDirection,
-         std::size_t MIN_SAMPLES, std::size_t MAX_SAMPLES, gr::Buffer BufferType>
-struct max_samples<fair::graph::port<T, PortName, PortType, PortDirection, MIN_SAMPLES, MAX_SAMPLES, BufferType>>
-    : std::integral_constant<std::size_t, MAX_SAMPLES> {};
-
-} // namespace port
+} // namespace fair::graph::traits::port
 
 #endif // include guard

--- a/include/typelist.hpp
+++ b/include/typelist.hpp
@@ -428,6 +428,9 @@ struct typelist {
     }())>;
 };
 
+template<typename T, typename... Ts>
+constexpr bool is_any_of_v = std::disjunction_v<std::is_same<T, Ts>...>;
+
 namespace detail {
 template<template<typename...> typename OtherTypelist, typename... Args>
 meta::typelist<Args...>

--- a/test/blocklib/core/fft/fft.hpp
+++ b/test/blocklib/core/fft/fft.hpp
@@ -114,8 +114,8 @@ public:
     using OutUniquePtr  = typename fftw<T>::OutUniquePtr;
     using PlanUniquePtr = typename fftw<T>::PlanUniquePtr;
 
-    IN<T>                         in;
-    OUT<DataSet<U>>               out;
+    PortIn<T>                     in;
+    PortOut<DataSet<U>>           out;
 
     std::size_t                   fftSize{ 1024 };
     int                           window{ static_cast<int>(WindowFunction::None) };

--- a/test/blocklib/core/filter/time_domain_filter.hpp
+++ b/test/blocklib/core/filter/time_domain_filter.hpp
@@ -17,8 +17,8 @@ struct fir_filter : node<fir_filter<T>, Doc<R""(
 The transfer function of an FIR filter is given by:
 H(z) = b[0] + b[1]*z^-1 + b[2]*z^-2 + ... + b[N]*z^-N
 )"">> {
-    IN<T>             in;
-    OUT<T>            out;
+    PortIn<T>         in;
+    PortOut<T>        out;
     std::vector<T>    b{}; // feedforward coefficients
     history_buffer<T> inputHistory{ 32 };
 
@@ -51,8 +51,8 @@ struct iir_filter : node<iir_filter<T, form>, Doc<R""(
 b are the feed-forward coefficients (N.B. b[0] denoting the newest and n[-1] the previous sample)
 a are the feedback coefficients
 )"">> {
-    IN<T>             in;
-    OUT<T>            out;
+    PortIn<T>         in;
+    PortOut<T>        out;
     std::vector<T>    b{ 1 }; // feed-forward coefficients
     std::vector<T>    a{ 1 }; // feedback coefficients
     history_buffer<T> inputHistory{ 32 };

--- a/test/blocklib/core/sources/clock_source.hpp
+++ b/test/blocklib/core/sources/clock_source.hpp
@@ -30,7 +30,7 @@ ClockSource Documentation -- add here
 )"">> {
     std::chrono::time_point<ClockSourceType> nextTimePoint = ClockSourceType::now();
     //
-    OUT<T>             out;
+    PortOut<T>         out;
     std::vector<tag_t> tags{};
     std::size_t        next_tag{ 0 };
     //

--- a/test/blocklib/core/unit-test/common_nodes.hpp
+++ b/test/blocklib/core/unit-test/common_nodes.hpp
@@ -17,8 +17,8 @@ class builtin_multiply : public fair::graph::node<builtin_multiply<T>> {
     T _factor = static_cast<T>(1.0f);
 
 public:
-    fair::graph::IN<T>  in;
-    fair::graph::OUT<T> out;
+    fair::graph::PortIn<T>  in;
+    fair::graph::PortOut<T> out;
 
     builtin_multiply() = delete;
 
@@ -40,10 +40,10 @@ ENABLE_REFLECTION_FOR_TEMPLATE(builtin_multiply, in, out);
 template<typename T>
 class builtin_counter : public fair::graph::node<builtin_counter<T>> {
 public:
-    static std::size_t  s_event_count;
+    static std::size_t      s_event_count;
 
-    fair::graph::IN<T>  in;
-    fair::graph::OUT<T> out;
+    fair::graph::PortIn<T>  in;
+    fair::graph::PortOut<T> out;
 
     [[nodiscard]] constexpr auto
     process_one(T a) const noexcept {
@@ -69,11 +69,11 @@ public:
     const std::string unique_name_ = fmt::format("multi_adder#{}", unique_id); // TODO: resolve symbol duplication
 
 protected:
-    using in_port_t = fair::graph::IN<T>;
+    using in_port_t = fair::graph::PortIn<T>;
     // std::list because ports don't like to change in-memory address
     // after connection is established, and vector might reallocate
-    std::list<in_port_t> _input_ports;
-    fair::graph::OUT<T>  _output_port;
+    std::list<in_port_t>    _input_ports;
+    fair::graph::PortOut<T> _output_port;
 
 protected:
     using setting_map                                      = std::map<std::string, int, std::less<>>;

--- a/test/blocklib/core/unit-test/tag_monitors.hpp
+++ b/test/blocklib/core/unit-test/tag_monitors.hpp
@@ -81,7 +81,7 @@ equal_tag_lists(const std::vector<tag_t> &tags1, const std::vector<tag_t> &tags2
 
 template<typename T, ProcessFunction UseProcessOne>
 struct TagSource : public node<TagSource<T, UseProcessOne>> {
-    OUT<T>             out;
+    PortOut<T>         out;
     std::vector<tag_t> tags{};
     std::size_t        next_tag{ 0 };
     std::int64_t       n_samples_max = 1024;
@@ -139,8 +139,8 @@ struct TagSource : public node<TagSource<T, UseProcessOne>> {
 
 template<typename T, ProcessFunction UseProcessOne>
 struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
-    IN<T>              in;
-    OUT<T>             out;
+    PortIn<T>          in;
+    PortOut<T>         out;
     std::vector<tag_t> tags{};
     std::int64_t       n_samples_produced{ 0 };
 
@@ -179,7 +179,7 @@ struct TagMonitor : public node<TagMonitor<T, UseProcessOne>> {
 template<typename T, ProcessFunction UseProcessOne>
 struct TagSink : public node<TagSink<T, UseProcessOne>> {
     using ClockSourceType = std::chrono::system_clock;
-    IN<T>                                    in;
+    PortIn<T>                                in;
     std::vector<tag_t>                       tags{};
     std::int64_t                             n_samples_produced{ 0 };
     std::chrono::time_point<ClockSourceType> timeFirstSample = ClockSourceType::now();

--- a/test/plugins/good_base_plugin.cpp
+++ b/test/plugins/good_base_plugin.cpp
@@ -27,7 +27,7 @@ read_total_count(const fair::graph::property_map &params) {
 }
 
 template<typename T>
-class cout_sink : public fg::node<cout_sink<T>, fg::IN<T, 0, 1024, "in">> {
+class cout_sink : public fg::node<cout_sink<T>, fg::PortInNamed<T, "in">> {
 public:
     std::size_t total_count = -1_UZ;
 
@@ -45,7 +45,7 @@ public:
 };
 
 template<typename T>
-class fixed_source : public fg::node<fixed_source<T>, fg::OUT<T, 0, 1024, "out">> {
+class fixed_source : public fg::node<fixed_source<T>, fg::PortOutNamed<T, "out">> {
 public:
     std::size_t event_count = -1_UZ; // infinite count by default
 

--- a/test/plugins/good_conversion_plugin.cpp
+++ b/test/plugins/good_conversion_plugin.cpp
@@ -11,8 +11,8 @@ namespace fg = fair::graph;
 template<typename From, typename To>
 class convert : public fg::node<convert<From, To>> {
 public:
-    fg::IN<From> in;
-    fg::OUT<To>  out;
+    fg::PortIn<From> in;
+    fg::PortOut<To>  out;
 
     [[nodiscard]] constexpr auto
     process_one(From value) const noexcept {

--- a/test/plugins/good_math_plugin.cpp
+++ b/test/plugins/good_math_plugin.cpp
@@ -28,8 +28,8 @@ protected:
     T _factor = static_cast<T>(1.0f);
 
 public:
-    fg::IN<T, 0, 1024>  in;
-    fg::OUT<T, 0, 1024> out;
+    fg::PortIn<T, fg::RequiredSamples<1, 1024>>  in;
+    fg::PortOut<T, fg::RequiredSamples<1, 1024>> out;
 
     math_base() = delete;
 

--- a/test/qa_data_sink.cpp
+++ b/test/qa_data_sink.cpp
@@ -37,7 +37,7 @@ namespace fair::graph::data_sink_test {
 
 template<typename T>
 struct Source : public node<Source<T>> {
-    OUT<T>             out;
+    PortOut<T>         out;
     std::int32_t       n_samples_produced = 0;
     std::int32_t       n_samples_max      = 1024;
     std::size_t        n_tag_offset       = 0;
@@ -322,7 +322,7 @@ const boost::ut::suite DataSinkTests = [] {
 
         expect(eq(connection_result_t::SUCCESS, flow_graph.connect<"out">(src).to<"in">(sink)));
 
-        auto                     poller_data_only = data_sink_registry::instance().get_streaming_poller<float>(data_sink_query::sink_name("test_sink"), blocking_mode::Blocking);
+        auto poller_data_only = data_sink_registry::instance().get_streaming_poller<float>(data_sink_query::sink_name("test_sink"), blocking_mode::Blocking);
         expect(neq(poller_data_only, nullptr));
 
         auto poller_with_tags = data_sink_registry::instance().get_streaming_poller<float>(data_sink_query::sink_name("test_sink"), blocking_mode::Blocking);

--- a/test/qa_dynamic_node.cpp
+++ b/test/qa_dynamic_node.cpp
@@ -10,7 +10,7 @@ template<typename T>
 std::atomic_size_t multi_adder<T>::_unique_id_counter = 0;
 
 template<typename T>
-struct fixed_source : public fg::node<fixed_source<T>, fg::OUT<T, 0, 1024, "out">> {
+struct fixed_source : public fg::node<fixed_source<T>, fg::PortOutNamed<T, "out">> {
     T value = 1;
 
     fg::work_return_t
@@ -30,7 +30,7 @@ struct fixed_source : public fg::node<fixed_source<T>, fg::OUT<T, 0, 1024, "out"
 static_assert(fair::graph::NodeType<fixed_source<int>>);
 
 template<typename T>
-struct cout_sink : public fg::node<cout_sink<T>, fg::IN<T, 0, 1024, "in">> {
+struct cout_sink : public fg::node<cout_sink<T>, fg::PortInNamed<T, "in">> {
     std::size_t remaining = 0;
 
     void

--- a/test/qa_dynamic_port.cpp
+++ b/test/qa_dynamic_port.cpp
@@ -110,7 +110,7 @@ const boost::ut::suite PortApiTests = [] {
         static_assert(PortType<MsgPortOut<float>>);
 
         static_assert(PortType<PortInNamed<float, "in">>);
-        static_assert(PortType<decltype(PortInNamed<float>("in"))>);
+        static_assert(PortType<decltype(PortInNamed<float, "">("in"))>);
         static_assert(PortType<PortOutNamed<float, "out">>);
         static_assert(PortType<MsgPortInNamed<"in_msg">>);
         static_assert(PortType<MsgPortOutNamed<"out_msg">>);

--- a/test/qa_fft.cpp
+++ b/test/qa_fft.cpp
@@ -17,9 +17,9 @@ namespace fg = fair::graph;
 
 template<typename T>
 struct CountSource : public fg::node<CountSource<T>> {
-    fg::OUT<T> out{};
-    int        count{ 0 };
-    int        nSamples{ 1024 };
+    fg::PortOut<T> out{};
+    int            count{ 0 };
+    int            nSamples{ 1024 };
 
     constexpr std::make_signed_t<std::size_t>
     available_samples(const CountSource & /*d*/) noexcept {

--- a/test/qa_node.cpp
+++ b/test/qa_node.cpp
@@ -63,9 +63,9 @@ struct StrideTestData {
 
 template<typename T>
 struct CountSource : public fg::node<CountSource<T>> {
-    fg::OUT<T> out{};
-    int        count{ 0 };
-    int        n_samples{ 1024 };
+    fg::PortOut<T> out{};
+    int            count{ 0 };
+    int            n_samples{ 1024 };
 
     constexpr std::make_signed_t<std::size_t>
     available_samples(const CountSource & /*d*/) noexcept {
@@ -81,11 +81,11 @@ struct CountSource : public fg::node<CountSource<T>> {
 
 template<typename T>
 struct IntDecBlock : public fg::node<IntDecBlock<T>, fg::PerformDecimationInterpolation, fg::PerformStride> {
-    fg::IN<T>     in{};
-    fg::OUT<T>    out{};
+    fg::PortIn<T>  in{};
+    fg::PortOut<T> out{};
 
-    ProcessStatus status{};
-    bool          write_to_vector{ false };
+    ProcessStatus  status{};
+    bool           write_to_vector{ false };
 
     fg::work_return_status_t
     process_bulk(std::span<const T> input, std::span<T> output) noexcept {

--- a/test/qa_plugins_test.cpp
+++ b/test/qa_plugins_test.cpp
@@ -40,8 +40,8 @@ class builtin_multiply : public fg::node<builtin_multiply<T>> {
     T _factor = static_cast<T>(1.0f);
 
 public:
-    fg::IN<T>  in;
-    fg::OUT<T> out;
+    fg::PortIn<T>  in;
+    fg::PortOut<T> out;
 
     builtin_multiply() = delete;
 

--- a/test/qa_scheduler.cpp
+++ b/test/qa_scheduler.cpp
@@ -34,7 +34,7 @@ public:
 
 // define some example graph nodes
 template<typename T, std::size_t N>
-class count_source : public fg::node<count_source<T, N>, fg::OUT<T, 0, std::numeric_limits<std::size_t>::max(), "out">> {
+class count_source : public fg::node<count_source<T, N>, fg::PortOutNamed<T, "out">> {
     tracer     &_tracer;
     std::size_t _count = 0;
 
@@ -57,7 +57,7 @@ public:
 static_assert(fg::NodeType<count_source<float, 10U>>);
 
 template<typename T, std::int64_t N>
-class expect_sink : public fg::node<expect_sink<T, N>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "in">> {
+class expect_sink : public fg::node<expect_sink<T, N>, fg::PortInNamed<T, "in">> {
     tracer                                         &_tracer;
     std::int64_t                                    _count = 0;
     std::function<void(std::int64_t, std::int64_t)> _checker;
@@ -84,7 +84,7 @@ public:
 };
 
 template<typename T, T Scale, typename R = decltype(std::declval<T>() * std::declval<T>())>
-class scale : public fg::node<scale<T, Scale, R>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "original">, fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "scaled">> {
+class scale : public fg::node<scale<T, Scale, R>, fg::PortInNamed<T, "original">, fg::PortOutNamed<R, "scaled">> {
     tracer &_tracer;
 
 public:
@@ -99,8 +99,7 @@ public:
 };
 
 template<typename T, typename R = decltype(std::declval<T>() + std::declval<T>())>
-class adder : public fg::node<adder<T>, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend0">, fg::IN<T, 0, std::numeric_limits<std::size_t>::max(), "addend1">,
-                              fg::OUT<R, 0, std::numeric_limits<std::size_t>::max(), "sum">> {
+class adder : public fg::node<adder<T>, fg::PortInNamed<T, "addend0">, fg::PortInNamed<T, "addend1">, fg::PortOutNamed<R, "sum">> {
     tracer &_tracer;
 
 public:

--- a/test/qa_settings.cpp
+++ b/test/qa_settings.cpp
@@ -85,7 +85,7 @@ printChanges(const property_map &oldMap, const property_map &newMap) noexcept {
 
 template<typename T>
 struct Source : public node<Source<T>> {
-    OUT<T>       out;
+    PortOut<T>   out;
     std::int32_t n_samples_produced = 0;
     std::int32_t n_samples_max      = 1024;
     std::int32_t n_tag_offset       = 0;
@@ -121,8 +121,8 @@ some test doc documentation
 
 template<typename T>
 struct TestBlock : public node<TestBlock<T>, BlockingIO<true>, TestBlockDoc, SupportedTypes<float, double>> {
-    IN<T>  in{};
-    OUT<T> out{};
+    PortIn<T>  in{};
+    PortOut<T> out{};
     // parameters
     A<T, "scaling factor", Visible, Doc<"y = a * x">, Unit<"As">>                    scaling_factor = static_cast<T>(1); // N.B. unit 'As' = 'Coulomb'
     A<std::string, "context information", Visible>                                   context{};
@@ -165,8 +165,8 @@ template<typename T, bool Average = false>
 struct Decimate : public node<Decimate<T, Average>, SupportedTypes<float, double>, PerformDecimationInterpolation, Doc<R""(
 @brief reduces sample rate by given fraction controlled by denominator
 )"">> {
-    IN<T>                            in{};
-    OUT<T>                           out{};
+    PortIn<T>                        in{};
+    PortOut<T>                       out{};
     A<float, "sample rate", Visible> sample_rate = 1.f;
 
     void
@@ -205,7 +205,7 @@ static_assert(NodeType<Decimate<double>>);
 
 template<typename T>
 struct Sink : public node<Sink<T>> {
-    IN<T>        in;
+    PortIn<T>    in;
     std::int32_t n_samples_consumed = 0;
     std::int32_t n_samples_max      = -1;
     int64_t      last_tag_position  = -1;


### PR DESCRIPTION
... as outlined by GR Architecture WG and https://github.com/fair-acc/graph-prototype/issues/148

tackled items:
 * refactored port structure (mandatory enum NTTPs vs. optional type-wrapped arguments)
     ```cpp
    class template<typename T, fixed_string PortName, port_type_t PortType, port_direction_t PortDirection, 
                                typename...  Arguments>
    struct Port { /* ... */ };
    ```
 * added optional domain argument
 * added default init value (needed for cyclic graphs)
 * add isOptional() annotation
 * fixed repeated_port name -> name0, name1, name2, ...
 * fixed `0 -> 1` for the required min port samples in various tests & code examples (now ensured via a `static_assert(..)`)
 * added 'Async' port annotation and 'isSynchronous()' function
 * renamed IN,OUT,... short-hand aliases to more explicit/hopefully descriptive PortIn, PortOut names
     ```cpp
    template<typename T, typename... Arguments>
    using PortIn = Port<T, "", port_type_t::STREAM, port_direction_t::INPUT, Arguments...>;
    template<typename T, typename... Arguments>
    using PortOut = Port<T, "", port_type_t::STREAM, port_direction_t::OUTPUT, Arguments...>;
    template<typename... Arguments>
    using MsgPortIn = Port<property_map, "", port_type_t::MESSAGE, port_direction_t::INPUT, Arguments...>;
    template<typename... Arguments>
    using MsgPortOut = Port<property_map, "", port_type_t::MESSAGE, port_direction_t::OUTPUT, Arguments...>;
    // ...
    ```
 * updated the developer [Readme.md](https://github.com/fair-acc/graph-prototype/tree/missing_port_interfaces/include#user-content-ports) and code documentation where necessary (-> there's more work for technical writers):
     Some of the possible optional port annotation attributes are:
     * `RequiredSamples<size_t, size_t>` to describe the min/max number of samples required from this port before invoking the blocks work function,
     * `Optional` informing the graph/scheduler that a given port does not require to be connected,
     * `PortDomain<fixed_string>` described whether the port can be handled within the same scheduling domain (e.g. `CPU` or `GPU`),
     * `StreamBufferType` and `TagBufferType` to inject specific user-provided buffer implementations to the port, or
     * `Async` for making a port asynchronous in a signal flow-graph block.
 * changed to capitalised class naming following [C++ Core guideline item](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#example-389) and Bjarne Stroustrup's [style naming](https://www.stroustrup.com/Programming/PPP-style.pdf) convention where ISO-C++/STL-style classes (or in our case classes that could be) are lower-case but own declared types being declared capitalised. N.B. this helps to distinguish whether classes are standard ISO-C++ (and should perhaps be known by the user) and/or are defined in the GNU Radio context only.
 
 Thanks for the in-person and on-line pre-comments and feedbacks by @ivan-cukic, @drslebedev, and @wirew0rm.
 
 One of the follow-ups would be to implement the `Async` function in the node/block code.