### PR TITLE
FFT implementaion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,11 +85,12 @@ target_include_directories(pmtv INTERFACE ${pmt_SOURCE_DIR}/include/)
 
 # FFTW3 is build 2 times for float and double precisions
 SET(FFTW_PREFIX ${CMAKE_CURRENT_BINARY_DIR}/fftw)
-SET(FFTW_CFLAGS "${CFLAGS} -w")
 if (EMSCRIPTEN)
+    SET(FFTW_CFLAGS "${CFLAGS} -w")
     SET(FFTW_CONFIG cd ${FFTW_PREFIX}/src/ && emconfigure ./configure --enable-silent-rules --quiet --disable-fortran --prefix=${FFTW_PREFIX}/install)
     SET(FFTW_BUILD emmake make -j CFLAGS=${FFTW_CFLAGS} --silent V=0 && emmake make install --silent V=0 && emmake make clean --silent V=0)
 else ()
+    SET(FFTW_CFLAGS "${CFLAGS} -w -O3 -march=native -mtune=native")
     SET(FFTW_CONFIG ${FFTW_PREFIX}/src/configure --enable-silent-rules --quiet --disable-fortran --prefix=${FFTW_PREFIX}/install)
     SET(FFTW_BUILD make -j CFLAGS=${FFTW_CFLAGS} --silent V=0 && make install --silent V=0 && make clean --silent V=0)
 endif ()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -13,7 +13,7 @@ endfunction()
 function(add_benchmark BM_NAME)
     add_executable(${BM_NAME} ${BM_NAME}.cpp)
     append_compiler_flags(${BM_NAME})
-    target_link_libraries(${BM_NAME} PRIVATE graph-prototype-options graph-prototype refl-cpp fmt ut fftw)
+    target_link_libraries(${BM_NAME} PRIVATE graph-prototype-options graph-prototype refl-cpp fmt ut fftw graph-prototype-algorithm)
 endfunction()
 
 add_benchmark(bm_buffer)

--- a/bench/bm_fft.cpp
+++ b/bench/bm_fft.cpp
@@ -1,53 +1,20 @@
-#include "benchmark.hpp"
-
 #include "../test/blocklib/core/fft/fft.hpp"
-
+#include "benchmark.hpp"
+#include "dataset.hpp"
+#include <algorithm/fft/fft.hpp>
+#include <algorithm/fft/fftw.hpp>
 #include <fmt/format.h>
 #include <numbers>
 
-/// This custom implementation of FFT ("compute_fft_v1" and "computeFftV1") is done only for performance comparison with default FFTW implementation.
-
-/**
- * Real-valued fast fourier transform algorithms
- * H.V. Sorensen, D.L. Jones, M.T. Heideman, C.S. Burrus (1987),
- * in: IEEE Trans on Acoustics, Speech, & Signal Processing, 35
- */
-
-template<typename T>
-    requires gr::blocks::fft::ComplexType<T>
-void
-computeFftV1(std::vector<T> &signal) {
-    const std::size_t N{ signal.size() };
-    for (std::size_t j = 0, rev = 0; j < N; j++) {
-        if (j < rev) std::swap(signal[j], signal[rev]);
-        auto maskLen = static_cast<std::size_t>(std::countr_zero(j + 1) + 1);
-        rev ^= N - (N >> maskLen);
-    }
-
-    for (std::size_t s = 2; s <= N; s *= 2) {
-        const std::size_t m{ s / 2 };
-        const T           w{ exp(T(0., static_cast<typename T::value_type>(-2. * std::numbers::pi) / static_cast<typename T::value_type>(s))) };
-        for (std::size_t k = 0; k < N; k += s) {
-            T wk{ 1., 0. };
-            for (std::size_t j = 0; j < m; j++) {
-                const T t{ wk * signal[k + j + m] };
-                const T u{ signal[k + j] };
-                signal[k + j]     = u + t;
-                signal[k + j + m] = u - t;
-                wk *= w;
-            }
-        }
-    }
-}
-
+/// This custom implementation of FFT is done only for performance comparison with default FFTW implementation.
 /**
  * Fast Fourier-Transform according to Cooley–Tukey
  * reference: https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm#Pseudocode
  */
 template<typename T>
-    requires gr::blocks::fft::ComplexType<T>
+    requires gr::algorithm::ComplexType<T>
 void
-computeFftV2(std::vector<T> &signal) {
+computeFFFTCooleyTukey(std::vector<T> &signal) {
     const std::size_t N{ signal.size() };
 
     if (N == 1) return;
@@ -59,10 +26,10 @@ computeFftV2(std::vector<T> &signal) {
         odd[i]  = signal[2 * i + 1];
     }
 
-    computeFftV2(even);
-    computeFftV2(odd);
+    computeFFFTCooleyTukey(even);
+    computeFFFTCooleyTukey(odd);
 
-    const typename T::value_type wn{ static_cast<typename T::value_type>(2. * std::numbers::pi) / static_cast<typename T::value_type>(N) };
+    const typename T::value_type wn{ static_cast<typename T::value_type>(2. * std::numbers::pi_v<double>) / static_cast<typename T::value_type>(N) };
     for (std::size_t i = 0; i < N / 2; i++) {
         const T wkn(std::cos(wn * static_cast<typename T::value_type>(i)), std::sin(wn * static_cast<typename T::value_type>(i)));
         signal[i]         = even[i] + wkn * odd[i];
@@ -71,23 +38,11 @@ computeFftV2(std::vector<T> &signal) {
 }
 
 template<typename T>
-    requires gr::blocks::fft::ComplexType<T>
-std::vector<typename T::value_type>
-computeMagnitudeSpectrum(std::vector<T> &fftSignal) {
-    const std::size_t                   N{ fftSignal.size() };
-    std::vector<typename T::value_type> magnitudeSpectrum(N / 2);
-    for (std::size_t i = 0; i < N / 2; i++) {
-        magnitudeSpectrum[i] = std::hypot(fftSignal[i].real(), fftSignal[i].imag()) * static_cast<typename T::value_type>(2.) / static_cast<typename T::value_type>(N);
-    }
-    return magnitudeSpectrum;
-}
-
-template<typename T>
 std::vector<T>
 generateSinSample(std::size_t N, double sampleRate, double frequency, double amplitude) {
     std::vector<T> signal(N);
     for (std::size_t i = 0; i < N; i++) {
-        if constexpr (gr::blocks::fft::ComplexType<T>) {
+        if constexpr (gr::algorithm::ComplexType<T>) {
             signal[i] = { static_cast<typename T::value_type>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate)), 0. };
         } else {
             signal[i] = static_cast<T>(amplitude * std::sin(2. * std::numbers::pi * frequency * static_cast<double>(i) / sampleRate));
@@ -98,9 +53,11 @@ generateSinSample(std::size_t N, double sampleRate, double frequency, double amp
 
 template<typename T>
 void
-testFft(bool withMagSpectrum) {
+testFFT() {
     using namespace benchmark;
     using namespace boost::ut::reflection;
+    using namespace fair::graph;
+    using namespace gr::algorithm;
 
     constexpr std::size_t N{ 1024 }; // must be power of 2
     constexpr double      sampleRate{ 256. };
@@ -108,52 +65,64 @@ testFft(bool withMagSpectrum) {
     constexpr double      amplitude{ 1. };
     constexpr int         nRepetitions{ 100 };
 
+    using PrecisionType = FFTAlgoPrecision<T>::type;
+
     static_assert(std::has_single_bit(N));
 
-    std::vector<T> signal  = generateSinSample<T>(N, sampleRate, frequency, amplitude);
-    std::string    nameOpt = withMagSpectrum ? "fft+mag" : "fft";
+    std::vector<T> signal = generateSinSample<T>(N, sampleRate, frequency, amplitude);
 
     {
-        gr::blocks::fft::fft<T> fft1{};
-        std::ignore = fft1.settings().set({ { "fftSize", N } });
-        std::ignore = fft1.settings().apply_staged_parameters();
-        fft1.inputHistory.push_back_bulk(signal.begin(), signal.end());
+        gr::blocks::fft::FFT<T, DataSet<PrecisionType>, FFTw<FFTInDataType<T, PrecisionType>>> fft1({ { "fftSize", N } });
+        std::ignore                                                                    = fft1.settings().apply_staged_parameters();
 
-        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - {} fftw", nameOpt, type_name<T>())) = [&fft1, &withMagSpectrum] {
-            fft1.prepareInput();
-            fft1.computeFft();
-            if (withMagSpectrum) fft1.computeMagnitudeSpectrum();
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - fftw", type_name<T>())) = [&fft1, &signal] {
+            fft1.prepareInput(signal);
+            fft1.computeFFT();
+        };
+    }
+    {
+        gr::blocks::fft::FFT<T, DataSet<PrecisionType>, FFT<FFTInDataType<T, PrecisionType>>> fft1({ { "fftSize", N } });
+        std::ignore                                                                   = fft1.settings().apply_staged_parameters();
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - fft", type_name<T>())) = [&fft1, &signal] {
+            fft1.prepareInput(signal);
+            fft1.computeFFT();
         };
     }
 
     if constexpr (gr::blocks::fft::ComplexType<T>) {
-        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - {} fft_v1", nameOpt, type_name<T>())) = [&signal, &withMagSpectrum] {
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - fftCT", type_name<T>())) = [&signal] {
             auto signalCopy = signal;
-            computeFftV1<T>(signalCopy);
-            if (withMagSpectrum) [[maybe_unused]]
-                auto magnitudeSpectrum = computeMagnitudeSpectrum<T>(signalCopy);
-        };
-
-        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - {} fft_v2", nameOpt, type_name<T>())) = [&signal, &withMagSpectrum] {
-            auto signalCopy = signal;
-            computeFftV2<T>(signalCopy);
-            if (withMagSpectrum) [[maybe_unused]]
-                auto magnitudeSpectrum = computeMagnitudeSpectrum<T>(signalCopy);
+            computeFFFTCooleyTukey<T>(signalCopy);
         };
     }
+
+    {
+        gr::blocks::fft::FFT<T, DataSet<PrecisionType>, gr::algorithm::FFTw<FFTInDataType<T, PrecisionType>>> fft1({ { "fftSize", N } });
+        std::ignore = fft1.settings().apply_staged_parameters();
+        fft1.prepareInput(signal);
+        fft1.computeFFT();
+
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - magnitude", type_name<T>())) = [&fft1] { fft1.computeMagnitudeSpectrum(); };
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - phase", type_name<T>()))     = [&fft1] { fft1.computePhaseSpectrum(); };
+
+        double sum{ 0. };
+        fft1.computeMagnitudeSpectrum();
+        fft1.computePhaseSpectrum();
+        ::benchmark::benchmark<nRepetitions>(fmt::format("{} - dataset", type_name<T>())) = [&fft1, &sum] {
+            const auto ds1 = fft1.createDataset();
+            sum += static_cast<double>(ds1.signal_values[0]);
+        };
+    }
+
+    ::benchmark::results::add_separator();
 }
 
 inline const boost::ut::suite _fft_bm_tests = [] {
     std::tuple<std::complex<float>, std::complex<double>> complexTypesToTest{};
     std::tuple<float, double>                             realTypesToTest{};
 
-    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFft<TArgs>(false), ...); }, complexTypesToTest);
-    benchmark::results::add_separator();
-    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFft<TArgs>(true), ...); }, complexTypesToTest);
-    benchmark::results::add_separator();
-    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFft<TArgs>(false), ...); }, realTypesToTest);
-    benchmark::results::add_separator();
-    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFft<TArgs>(true), ...); }, realTypesToTest);
+    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFFT<TArgs>(), ...); }, complexTypesToTest);
+    std::apply([]<class... TArgs>(TArgs... /*args*/) { (testFFT<TArgs>(), ...); }, realTypesToTest);
 };
 
 int

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ configure_file(build_configure.hpp.in build_configure.hpp @ONLY)
 
 function(setup_test_no_asan TARGET_NAME)
     target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_BINARY_DIR}/include ${CMAKE_CURRENT_BINARY_DIR})
-    target_link_libraries(${TARGET_NAME} PRIVATE graph-prototype-options graph-prototype fmt refl-cpp ut fftw)
+    target_link_libraries(${TARGET_NAME} PRIVATE graph-prototype-options graph-prototype fmt refl-cpp ut fftw graph-prototype-algorithm)
     add_test(NAME ${TARGET_NAME} COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME})
 endfunction()
 
@@ -44,6 +44,8 @@ add_ut_test(qa_thread_affinity)
 add_ut_test(qa_thread_pool)
 add_ut_test(qa_traits)
 
+add_subdirectory(blocklib/algorithm)
+
 if (NOT (EMSCRIPTEN OR (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")))
     add_subdirectory(plugins)
 
@@ -56,4 +58,4 @@ if (NOT (EMSCRIPTEN OR (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")))
 
     add_app_test(app_grc)
     target_link_libraries(app_grc PRIVATE yaml-cpp::yaml-cpp)
-endif()
+endif ()

--- a/test/blocklib/algorithm/CMakeLists.txt
+++ b/test/blocklib/algorithm/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(graph-prototype-algorithm INTERFACE)
+target_include_directories(graph-prototype-algorithm INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/> $<INSTALL_INTERFACE:include/>)
+
+install(
+        TARGETS graph-prototype-algorithm
+        EXPORT graphTargets
+        PUBLIC_HEADER DESTINATION include/
+)

--- a/test/blocklib/algorithm/include/algorithm/fft/fft.hpp
+++ b/test/blocklib/algorithm/include/algorithm/fft/fft.hpp
@@ -1,0 +1,112 @@
+#ifndef GRAPH_PROTOTYPE_ALGORITHM_FFT_HPP
+#define GRAPH_PROTOTYPE_ALGORITHM_FFT_HPP
+
+#include "fft_types.hpp"
+#include "node.hpp"
+#include "window.hpp"
+#include <ranges>
+
+namespace gr::algorithm {
+
+template<typename T>
+    requires(ComplexType<T> || std::floating_point<T>)
+struct FFT {
+    using PrecisionType = FFTAlgoPrecision<T>::type;
+    using OutDataType   = std::conditional_t<ComplexType<T>, T, std::complex<T>>;
+
+    std::vector<OutDataType> twiddleFactors{};
+    std::size_t              fftSize{ 0 };
+
+    FFT()                   = default;
+    FFT(const FFT &rhs)     = delete;
+    FFT(FFT &&rhs) noexcept = delete;
+    FFT &
+    operator=(const FFT &rhs)
+            = delete;
+    FFT &
+    operator=(FFT &&rhs) noexcept
+            = delete;
+
+    ~FFT() = default;
+
+    void
+    initAll() {
+        precomputeTwiddleFactors();
+    }
+
+    std::vector<OutDataType>
+    computeFFT(const std::vector<T> &in) {
+        std::vector<OutDataType> out(in.size());
+        computeFFT(in, out);
+        return out;
+    }
+
+    void
+    computeFFT(const std::vector<T> &in, std::vector<OutDataType> &out) {
+        if (!std::has_single_bit(in.size())) {
+            throw std::invalid_argument(fmt::format("Input data must have 2^N samples, input size: ", in.size()));
+        }
+        if (fftSize != in.size()) {
+            fftSize = in.size();
+            initAll();
+        }
+
+        // For the moment no optimization for real data inputs, just create complex with zero imaginary value.
+        if constexpr (!ComplexType<T>) {
+            std::ranges::transform(in.begin(), in.end(), out.begin(), [](const auto c) { return OutDataType(c, 0.); });
+        } else {
+            std::ranges::copy(in.begin(), in.end(), out.begin());
+        }
+
+        /**
+         * Real-valued fast fourier transform algorithms
+         * H.V. Sorensen, D.L. Jones, M.T. Heideman, C.S. Burrus (1987),
+         * in: IEEE Trans on Acoustics, Speech, & Signal Processing, 35
+         */
+        bitReversalPermutation(out);
+
+        std::size_t omega_kCounter = 0;
+        for (std::size_t s = 2; s <= fftSize; s *= 2) {
+            const auto half_s = s / 2;
+            for (std::size_t k = 0; k < fftSize; k += s) {
+                for (std::size_t j = 0; j < half_s; j++) {
+                    const auto t{ twiddleFactors[omega_kCounter++] * out[k + j + half_s] };
+                    const auto u{ out[k + j] };
+                    out[k + j]          = u + t;
+                    out[k + j + half_s] = u - t;
+                }
+            }
+        }
+    }
+
+private:
+    void
+    bitReversalPermutation(std::vector<OutDataType> &vec) const noexcept {
+        for (std::size_t j = 0, rev = 0; j < fftSize; j++) {
+            if (j < rev) std::swap(vec[j], vec[rev]);
+            auto maskLen = static_cast<std::size_t>(std::countr_zero(j + 1) + 1);
+            rev ^= fftSize - (fftSize >> maskLen);
+        }
+    }
+
+    void
+    precomputeTwiddleFactors() {
+        twiddleFactors.clear();
+        const auto minus2Pi = PrecisionType(-2. * std::numbers::pi);
+        for (std::size_t s = 2; s <= fftSize; s *= 2) {
+            const std::size_t m{ s / 2 };
+            const OutDataType w{ std::exp(OutDataType(0., minus2Pi / static_cast<PrecisionType>(s))) };
+            for (std::size_t k = 0; k < fftSize; k += s) {
+                OutDataType wk{ 1., 0. };
+                for (std::size_t j = 0; j < m; j++) {
+                    twiddleFactors.push_back(wk);
+                    wk *= w;
+                }
+            }
+        }
+    }
+};
+
+} // namespace gr::algorithm
+
+#endif // GRAPH_PROTOTYPE_ALGORITHM_FFT_HPP

--- a/test/blocklib/algorithm/include/algorithm/fft/fft_common.hpp
+++ b/test/blocklib/algorithm/include/algorithm/fft/fft_common.hpp
@@ -1,0 +1,35 @@
+#ifndef GRAPH_PROTOTYPE_ALGORITHM_FFT_COMMON_HPP
+#define GRAPH_PROTOTYPE_ALGORITHM_FFT_COMMON_HPP
+
+#include "fft_types.hpp"
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace gr::algorithm {
+
+template<ComplexType T, typename U>
+void
+computeMagnitudeSpectrum(const std::vector<T> &fftOut, std::vector<U> &magnitudeSpectrum, std::size_t fftSize, bool outputInDb) {
+    if (fftOut.size() < magnitudeSpectrum.size()) {
+        throw std::invalid_argument(fmt::format("FFT vector size ({}) must be more or equal than magnitude vector size ({}).", fftOut.size(), magnitudeSpectrum.size()));
+    }
+    using PrecisionType = typename T::value_type;
+    std::transform(fftOut.begin(), std::next(fftOut.begin(), static_cast<std::ptrdiff_t>(magnitudeSpectrum.size())), magnitudeSpectrum.begin(), [fftSize, outputInDb](const auto &c) {
+        const auto mag{ std::hypot(c.real(), c.imag()) * PrecisionType(2.0) / static_cast<PrecisionType>(fftSize) };
+        return static_cast<U>(outputInDb ? PrecisionType(20.) * std::log10(std::abs(mag)) : mag);
+    });
+}
+
+template<ComplexType T, typename U>
+void
+computePhaseSpectrum(const std::vector<T> &fftOut, std::vector<U> &phaseSpectrum) {
+    if (fftOut.size() < phaseSpectrum.size()) {
+        throw std::invalid_argument(fmt::format("FFT vector size ({}) must be more or equal than phase vector size ({}).", fftOut.size(), phaseSpectrum.size()));
+    }
+    std::transform(fftOut.begin(), std::next(fftOut.begin(), static_cast<std::ptrdiff_t>(phaseSpectrum.size())), phaseSpectrum.begin(),
+                   [](const auto &c) { return static_cast<U>(std::atan2(c.imag(), c.real())); });
+}
+
+} // namespace gr::algorithm
+#endif // GRAPH_PROTOTYPE_ALGORITHM_FFT_COMMON_HPP

--- a/test/blocklib/algorithm/include/algorithm/fft/fft_types.hpp
+++ b/test/blocklib/algorithm/include/algorithm/fft/fft_types.hpp
@@ -1,0 +1,27 @@
+#ifndef GRAPH_PROTOTYPE_ALGORITHM_FFT_TYPES_HPP
+#define GRAPH_PROTOTYPE_ALGORITHM_FFT_TYPES_HPP
+
+#include "node.hpp"
+
+namespace gr::algorithm {
+template<typename T>
+concept ComplexType = std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>;
+
+template<typename T, typename U>
+using FFTInDataType = std::conditional_t<ComplexType<T>, std::complex<U>, U>;
+
+template<typename U>
+using FFTOutDataType = std::complex<U>;
+
+template<typename T>
+struct FFTAlgoPrecision {
+    using type = T;
+};
+
+template<ComplexType T>
+struct FFTAlgoPrecision<T> {
+    using type = T::value_type;
+};
+
+} // namespace gr::algorithm
+#endif // GRAPH_PROTOTYPE_ALGORITHM_FFT_TYPES_HPP

--- a/test/blocklib/algorithm/include/algorithm/fft/fftw.hpp
+++ b/test/blocklib/algorithm/include/algorithm/fft/fftw.hpp
@@ -1,0 +1,218 @@
+#ifndef GRAPH_PROTOTYPE_ALGORITHM_FFTW_HPP
+#define GRAPH_PROTOTYPE_ALGORITHM_FFTW_HPP
+
+#include "dataset.hpp"
+#include "fft_types.hpp"
+#include "fftw3.h"
+#include "history_buffer.hpp"
+#include "node.hpp"
+#include "window.hpp"
+
+namespace gr::algorithm {
+
+using namespace fair::graph;
+
+template<typename T>
+concept FFTwDoubleType = std::is_same_v<T, std::complex<double>> || std::is_same_v<T, double>;
+
+template<typename T>
+    requires(ComplexType<T> || std::floating_point<T>)
+struct FFTw {
+private:
+    inline static std::mutex fftw_plan_mutex;
+
+public:
+    // clang-format off
+    template<typename FftwT>
+    struct fftwImpl {
+        using PlanType        = fftwf_plan;
+        using InAlgoDataType  = std::conditional_t<ComplexType<FftwT>, fftwf_complex, float>;
+        using OutAlgoDataType = fftwf_complex;
+        using InUniquePtr     = std::unique_ptr<InAlgoDataType [], decltype([](InAlgoDataType *ptr) { fftwf_free(ptr); })>;
+        using OutUniquePtr    = std::unique_ptr<OutAlgoDataType [], decltype([](OutAlgoDataType *ptr) { fftwf_free(ptr); })>;
+        using PlanUniquePtr   = std::unique_ptr<std::remove_pointer_t<PlanType>, decltype([](PlanType ptr) { fftwf_destroy_plan(ptr); })>;
+
+        static void execute(const PlanType p) { fftwf_execute(p); }
+        static void cleanup() { fftwf_cleanup(); }
+        static void * malloc(std::size_t n) { return fftwf_malloc(n);}
+        static PlanType plan(int p_n, InAlgoDataType *p_in, OutAlgoDataType *p_out, int p_sign, unsigned int p_flags) {
+            if constexpr (std::is_same_v<InAlgoDataType, float>) {
+                return fftwf_plan_dft_r2c_1d(p_n, p_in, p_out, p_flags);
+            } else {
+                return fftwf_plan_dft_1d(p_n, p_in, p_out, p_sign, p_flags);
+            }
+        }
+        static int importWisdomFromFilename(const std::string& path) {return fftwf_import_wisdom_from_filename(path.c_str());}
+        static int exportWisdomToFilename(const std::string& path) {return fftwf_export_wisdom_to_filename(path.c_str());}
+        static int importWisdomFromString(const std::string& str) {return fftwf_import_wisdom_from_string(str.c_str());}
+        static std::string exportWisdomToString() {
+            char* cstr = fftwf_export_wisdom_to_string();
+            if (cstr == nullptr) return "";
+            std::string str(cstr);
+            fftwf_free(cstr);
+            return str;
+        }
+        static void forgetWisdom() {fftwf_forget_wisdom();}
+    };
+
+    template<FFTwDoubleType FftwDoubleT>
+    struct fftwImpl<FftwDoubleT> {
+        using PlanType        = fftw_plan;
+        using InAlgoDataType  = std::conditional_t<ComplexType<FftwDoubleT>, fftw_complex, double>;
+        using OutAlgoDataType = fftw_complex;
+        using InUniquePtr     = std::unique_ptr<InAlgoDataType [], decltype([](InAlgoDataType *ptr) { fftwf_free(ptr); })>;
+        using OutUniquePtr    = std::unique_ptr<OutAlgoDataType [], decltype([](OutAlgoDataType *ptr) { fftwf_free(ptr); })>;
+        using PlanUniquePtr   = std::unique_ptr<std::remove_pointer_t<PlanType>, decltype([](PlanType ptr) { fftw_destroy_plan(ptr); })>;
+
+        static void execute(const PlanType p) { fftw_execute(p); }
+        static void cleanup() { fftw_cleanup(); }
+        static void * malloc(std::size_t n) { return fftw_malloc(n);}
+        static PlanType plan(int p_n, InAlgoDataType *p_in, OutAlgoDataType *p_out, int p_sign, unsigned int p_flags) {
+            if constexpr (std::is_same_v<InAlgoDataType, double>) {
+                return fftw_plan_dft_r2c_1d(p_n, p_in, p_out, p_flags);
+            } else {
+                return fftw_plan_dft_1d(p_n, p_in, p_out, p_sign, p_flags);
+            }
+        }
+        static int importWisdomFromFilename(const std::string& path) {return fftw_import_wisdom_from_filename(path.c_str());}
+        static int exportWisdomToFilename(const std::string& path) {return fftw_export_wisdom_to_filename(path.c_str());}
+        static int importWisdomFromString(const std::string& str) {return fftw_import_wisdom_from_string(str.c_str());}
+        static std::string exportWisdomToString() {
+            char* cstr = fftw_export_wisdom_to_string();
+            if (cstr == nullptr) return "";
+            std::string str(cstr);
+            fftw_free(cstr);
+            return str;
+        }
+        static void forgetWisdom() {fftw_forget_wisdom();}
+    };
+
+    // clang-format on
+    using OutDataType     = std::conditional_t<ComplexType<T>, T, std::complex<T>>;
+    using InAlgoDataType  = typename fftwImpl<T>::InAlgoDataType;
+    using OutAlgoDataType = typename fftwImpl<T>::OutAlgoDataType;
+    using InUniquePtr     = typename fftwImpl<T>::InUniquePtr;
+    using OutUniquePtr    = typename fftwImpl<T>::OutUniquePtr;
+    using PlanUniquePtr   = typename fftwImpl<T>::PlanUniquePtr;
+
+    std::size_t   fftSize{ 0 };
+    std::string   wisdomPath{ ".gr_fftw_wisdom" };
+    int           sign{ FFTW_FORWARD };
+    unsigned int  flags{ FFTW_ESTIMATE }; // FFTW_EXHAUSTIVE, FFTW_MEASURE, FFTW_ESTIMATE
+    InUniquePtr   fftwIn{};
+    OutUniquePtr  fftwOut{};
+    PlanUniquePtr fftwPlan{};
+
+    FFTw()                    = default;
+    FFTw(const FFTw &rhs)     = delete;
+    FFTw(FFTw &&rhs) noexcept = delete;
+    FFTw &
+    operator=(const FFTw &rhs)
+            = delete;
+    FFTw &
+    operator=(FFTw &&rhs) noexcept
+            = delete;
+
+    ~FFTw() { clearFftw(); }
+
+    std::vector<OutDataType>
+    computeFFT(const std::vector<T> &in) {
+        if (fftSize != in.size()) {
+            fftSize = in.size();
+            initAll();
+        }
+        std::vector<OutDataType> out(getOutputSize());
+        computeFFT(in, out);
+        return out;
+    }
+
+    void
+    computeFFT(const std::vector<T> &in, std::vector<OutDataType> &out) {
+        if (!std::has_single_bit(in.size())) {
+            throw std::invalid_argument(fmt::format("Input data must have 2^N samples, input size: ", in.size()));
+        }
+
+        if (fftSize != in.size()) {
+            fftSize = in.size();
+            initAll();
+        }
+
+        if (out.size() < getOutputSize()) {
+            throw std::out_of_range(fmt::format("Output vector size ({}) is not enough, at least {} needed. ", out.size(), getOutputSize()));
+        }
+
+        static_assert(sizeof(InAlgoDataType) == sizeof(T), "Input std::complex<T> and T[2] must have the same size.");
+        std::memcpy(fftwIn.get(), &(*in.begin()), sizeof(InAlgoDataType) * fftSize);
+
+        fftwImpl<T>::execute(fftwPlan.get());
+
+        static_assert(sizeof(OutDataType) == sizeof(OutAlgoDataType), "Output std::complex<T> and T[2] must have the same size.");
+        std::memcpy(out.data(), fftwOut.get(), sizeof(OutDataType) * getOutputSize());
+    }
+
+    [[nodiscard]] inline int
+    importWisdom() const {
+        // lock file while importing wisdom?
+        return fftwImpl<T>::importWisdomFromFilename(wisdomPath);
+    }
+
+    [[nodiscard]] inline int
+    exportWisdom() const {
+        // lock file while exporting wisdom?
+        return fftwImpl<T>::exportWisdomToFilename(wisdomPath);
+    }
+
+    [[nodiscard]] inline int
+    importWisdomFromString(const std::string &wisdomString) const {
+        return fftwImpl<T>::importWisdomFromString(wisdomString);
+    }
+
+    [[nodiscard]] std::string
+    exportWisdomToString() const {
+        return fftwImpl<T>::exportWisdomToString();
+    }
+
+    inline void
+    forgetWisdom() const {
+        return fftwImpl<T>::forgetWisdom();
+    }
+
+private:
+    [[nodiscard]] constexpr std::size_t
+    getOutputSize() const {
+        if constexpr (ComplexType<T>) {
+            return fftSize;
+        } else {
+            return 1 + fftSize / 2;
+        }
+    }
+
+    void
+    initAll() {
+        clearFftw();
+        fftwIn  = InUniquePtr(static_cast<InAlgoDataType *>(fftwImpl<T>::malloc(sizeof(InAlgoDataType) * fftSize)));
+        fftwOut = OutUniquePtr(static_cast<OutAlgoDataType *>(fftwImpl<T>::malloc(sizeof(OutAlgoDataType) * getOutputSize())));
+
+        {
+            std::lock_guard lg{ fftw_plan_mutex };
+            // what to do if error is returned
+            std::ignore = importWisdom();
+            fftwPlan    = PlanUniquePtr(fftwImpl<T>::plan(static_cast<int>(fftSize), fftwIn.get(), fftwOut.get(), sign, flags));
+            std::ignore = exportWisdom();
+        }
+    }
+
+    void
+    clearFftw() {
+        {
+            std::lock_guard lg{ fftw_plan_mutex };
+            fftwPlan.reset();
+        }
+        fftwIn.reset();
+        fftwOut.reset();
+    }
+};
+
+} // namespace gr::algorithm
+
+#endif // GRAPH_PROTOTYPE_ALGORITHM_FFTW_HPP

--- a/test/blocklib/algorithm/include/algorithm/fft/window.hpp
+++ b/test/blocklib/algorithm/include/algorithm/fft/window.hpp
@@ -1,24 +1,25 @@
 
-#ifndef GRAPH_PROTOTYPE_WINDOW_HPP
-#define GRAPH_PROTOTYPE_WINDOW_HPP
+#ifndef GRAPH_PROTOTYPE_ALGORITHM_WINDOW_HPP
+#define GRAPH_PROTOTYPE_ALGORITHM_WINDOW_HPP
 
+#include <algorithm>
 #include <cmath>
 #include <numbers>
 #include <ranges>
 #include <vector>
 
-namespace gr::blocks::fft {
+namespace gr::algorithm {
 
-template<typename T>
-concept FloatOrDoubleType = std::is_same_v<T, float> || std::is_same_v<T, double>;
-
-// Implementation of window function (also known as an apodization function or tapering function).
-// See Wikipedia for more info: https://en.wikipedia.org/wiki/Window_function
+/*
+ * Implementation of window function (also known as an apodization function or tapering function).
+ * See Wikipedia for more info: https://en.wikipedia.org/wiki/Window_function
+ */
 
 enum class WindowFunction : int { None, Rectangular, Hamming, Hann, HannExp, Blackman, Nuttall, BlackmanHarris, BlackmanNuttall, FlatTop, Exponential };
 
 // Only float or double are allowed because FFT supports only float or double precisions.
-template<FloatOrDoubleType T>
+template<typename T>
+    requires(std::is_floating_point_v<T>)
 std::vector<T>
 createWindowFunction(WindowFunction func, const std::size_t n) {
     constexpr T pi  = std::numbers::pi_v<T>;
@@ -110,6 +111,6 @@ createWindowFunction(WindowFunction func, const std::size_t n) {
     }
     }
 }
-} // namespace gr::blocks::fft
+} // namespace gr::algorithm
 
-#endif // GRAPH_PROTOTYPE_WINDOW_HPP
+#endif // GRAPH_PROTOTYPE_ALGORITHM_WINDOW_HPP

--- a/test/blocklib/core/fft/fft.hpp
+++ b/test/blocklib/core/fft/fft.hpp
@@ -1,338 +1,220 @@
 #ifndef GRAPH_PROTOTYPE_FFT_HPP
 #define GRAPH_PROTOTYPE_FFT_HPP
 
-#include "window.hpp"
+#include <algorithm/fft/fft.hpp>
+#include <algorithm/fft/fft_common.hpp>
+#include <algorithm/fft/fft_types.hpp>
+#include <algorithm/fft/fftw.hpp>
+#include <algorithm/fft/window.hpp>
 #include <dataset.hpp>
-#include <fftw3.h>
+#include <execution>
 #include <history_buffer.hpp>
 #include <node.hpp>
 
 namespace gr::blocks::fft {
 
 using namespace fair::graph;
+using gr::algorithm::ComplexType;
+using gr::algorithm::FFTInDataType;
+using gr::algorithm::FFTOutDataType;
 
-template<typename T>
-concept ComplexType = std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>;
-
-template<typename T>
-concept DoubleType = std::is_same_v<T, std::complex<double>> || std::is_same_v<T, double>;
-
-template<typename T>
-concept LongDoubleType = std::is_same_v<T, std::complex<long double>> || std::is_same_v<T, long double>;
-
-template<typename T>
-concept FFTSupportedTypes = ComplexType<T> || std::integral<T> || std::floating_point<T>;
-
-inline static std::mutex fftw_plan_mutex;
-
-template<FFTSupportedTypes T>
-struct fft : node<fft<T>> {
+template<typename T, typename U = DataSet<float>, typename FourierAlgoImpl = gr::algorithm::FFT<FFTInDataType<T, typename U::value_type>>>
+    requires(ComplexType<T> || std::floating_point<T> || std::is_same_v<U, DataSet<float>> || std::is_same_v<U, DataSet<double>>)
+struct FFT : public node<FFT<T, U, FourierAlgoImpl>, PerformDecimationInterpolation> {
 public:
-    static_assert(not LongDoubleType<T>, "long double is not supported");
+    using PrecisionType = U::value_type;
+    using InDataType    = FFTInDataType<T, PrecisionType>;
+    using OutDataType   = FFTOutDataType<PrecisionType>;
 
-    // clang-format off
-    template<typename FftwT>
-    struct fftw {
-        using PlanType       = fftwf_plan;
-        using InDataType    = std::conditional_t<ComplexType<FftwT>, fftwf_complex, float>;
-        using OutDataType   = fftwf_complex;
-        using PrecisionType  = float;
-        using InHistoryType = std::conditional_t<ComplexType<FftwT>, std::complex<float>, float>; // history_buffer can not store c-arrays -> use std::complex
-        using InUniquePtr   = std::unique_ptr<InDataType [], decltype([](InDataType *ptr) { fftwf_free(ptr); })>;
-        using OutUniquePtr  = std::unique_ptr<OutDataType [], decltype([](OutDataType *ptr) { fftwf_free(ptr); })>;
-        using PlanUniquePtr = std::unique_ptr<std::remove_pointer_t<PlanType>, decltype([](PlanType ptr) { fftwf_destroy_plan(ptr); })>;
+    PortIn<T>                                                                        in;
+    PortOut<U, RequiredSamples<1, 1>>                                                out;
 
-        static void execute(const PlanType p) { fftwf_execute(p); }
-        static void cleanup() { fftwf_cleanup(); }
-        static void * malloc(std::size_t n) { return fftwf_malloc(n);}
-        static PlanType plan(int p_n, InDataType *p_in, OutDataType *p_out, int p_sign, unsigned int p_flags) {
-            if constexpr (std::is_same_v<InDataType, float>) {
-                return fftwf_plan_dft_r2c_1d(p_n, p_in, p_out, p_flags);
-            } else {
-                return fftwf_plan_dft_1d(p_n, p_in, p_out, p_sign, p_flags);
-            }
-        }
-        static int importWisdomFromFilename(const std::string& path) {return fftwf_import_wisdom_from_filename(path.c_str());}
-        static int exportWisdomToFilename(const std::string& path) {return fftwf_export_wisdom_to_filename(path.c_str());}
-        static int importWisdomFromString(const std::string& str) {return fftwf_import_wisdom_from_string(str.c_str());}
-        static std::string exportWisdomToString() {
-            char* cstr = fftwf_export_wisdom_to_string();
-            if (cstr == nullptr) return "";
-            std::string str(cstr);
-            fftwf_free(cstr);
-            return str;
-        }
-        static void forgetWisdom() {fftwf_forget_wisdom();}
+    FourierAlgoImpl                                                                  fftImpl;
+    Annotated<std::size_t, "FFT size", Doc<"FFT size">>                              fftSize{ 1024 };
+    Annotated<int, "window function", Doc<"window (apodization) function">>          window{ static_cast<int>(gr::algorithm::WindowFunction::Hann) };
+    Annotated<float, "sample rate", Doc<"signal sample rate">, Unit<"Hz">>           sampleRate = 1.f;
+    Annotated<std::string, "signal name", Visible>                                   signalName = std::string("unknown signal");
+    Annotated<std::string, "signal unit", Visible, Doc<"signal's physical SI unit">> signalUnit = std::string("a.u.");
+    Annotated<T, "signal min", Doc<"signal physical min. (e.g. DAQ) limit">>         signalMin  = std::numeric_limits<T>::lowest();
+    Annotated<T, "signal max", Doc<"signal physical max. (e.g. DAQ) limit">>         signalMax  = std::numeric_limits<T>::max();
+    Annotated<bool, "output in dB", Doc<"calculate output in decibels">>             outputInDb{ false };
+    std::vector<PrecisionType>                                                       windowVector;
+    std::vector<InDataType>                                                          inData{};
+    std::vector<OutDataType>                                                         outData{};
+    std::vector<PrecisionType>                                                       magnitudeSpectrum{};
+    std::vector<PrecisionType>                                                       phaseSpectrum{};
+
+    FFT() {
+        initAll();
+        initWindowFunction();
     };
 
-    template<DoubleType FftwDoubleT>
-    struct fftw<FftwDoubleT> {
-        using PlanType       = fftw_plan;
-        using InDataType    = std::conditional_t<ComplexType<FftwDoubleT>, fftw_complex, double>;
-        using OutDataType   = fftw_complex;
-        using PrecisionType  = double;
-        using InHistoryType = std::conditional_t<ComplexType<FftwDoubleT>, std::complex<double>, double>; // history_buffer can not store c-arrays -> use std::complex
-        using InUniquePtr   = std::unique_ptr<InDataType [], decltype([](InDataType *ptr) { fftwf_free(ptr); })>;
-        using OutUniquePtr  = std::unique_ptr<OutDataType [], decltype([](OutDataType *ptr) { fftwf_free(ptr); })>;
-        using PlanUniquePtr = std::unique_ptr<std::remove_pointer_t<PlanType>, decltype([](PlanType ptr) { fftw_destroy_plan(ptr); })>;
+    explicit FFT(std::initializer_list<std::pair<const std::string, pmtv::pmt>> init_parameter) noexcept : node<FFT<T, U, FourierAlgoImpl>, PerformDecimationInterpolation>(init_parameter) {}
 
-        static void execute(const PlanType p) { fftw_execute(p); }
-        static void cleanup() { fftw_cleanup(); }
-        static void * malloc(std::size_t n) { return fftw_malloc(n);}
-        static PlanType plan(int p_n, InDataType *p_in, OutDataType *p_out, int p_sign, unsigned int p_flags) {
-            if constexpr (std::is_same_v<InDataType, double>) {
-                return fftw_plan_dft_r2c_1d(p_n, p_in, p_out, p_flags);
-            } else {
-                return fftw_plan_dft_1d(p_n, p_in, p_out, p_sign, p_flags);
-            }
-        }
-        static int importWisdomFromFilename(const std::string& path) {return fftw_import_wisdom_from_filename(path.c_str());}
-        static int exportWisdomToFilename(const std::string& path) {return fftw_export_wisdom_to_filename(path.c_str());}
-        static int importWisdomFromString(const std::string& str) {return fftw_import_wisdom_from_string(str.c_str());}
-        static std::string exportWisdomToString() {
-            char* cstr = fftw_export_wisdom_to_string();
-            if (cstr == nullptr) return "";
-            std::string str(cstr);
-            fftw_free(cstr);
-            return str;
-        }
-        static void forgetWisdom() {fftw_forget_wisdom();}
-    };
-
-    template <typename signedT> struct MakeSigned { using type = signedT;};
-    template <std::integral signedT> struct MakeSigned<signedT> { using type = std::make_signed_t<signedT>; };
-    template<typename evalU> struct EvalOutputType { using type1 = evalU; using type2 = typename MakeSigned<T>::type;};
-    template<ComplexType evalU> struct EvalOutputType<evalU> { using type1 = typename evalU::value_type; using type2 = evalU;};
-    using U = std::conditional_t<ComplexType<T>, typename EvalOutputType<T>::type1, typename EvalOutputType<T>::type2>;
-    // clang-format on
-
-    using InDataType    = typename fftw<T>::InDataType;
-    using OutDataType   = typename fftw<T>::OutDataType;
-    using PrecisionType = typename fftw<T>::PrecisionType;
-    using InHistoryType = typename fftw<T>::InHistoryType;
-    using InUniquePtr   = typename fftw<T>::InUniquePtr;
-    using OutUniquePtr  = typename fftw<T>::OutUniquePtr;
-    using PlanUniquePtr = typename fftw<T>::PlanUniquePtr;
-
-    PortIn<T>                     in;
-    PortOut<DataSet<U>>           out;
-
-    std::size_t                   fftSize{ 1024 };
-    int                           window{ static_cast<int>(WindowFunction::None) };
-    std::vector<PrecisionType>    windowVector;
-    bool                          outputInDb{ false };
-    std::string                   wisdomPath{ ".gr_fftw_wisdom" };
-    int                           sign{ FFTW_FORWARD };
-    unsigned int                  flags{ FFTW_ESTIMATE }; // FFTW_EXHAUSTIVE, FFTW_MEASURE, FFTW_ESTIMATE
-    history_buffer<InHistoryType> inputHistory{ fftSize };
-    InUniquePtr                   fftwIn{};
-    OutUniquePtr                  fftwOut{};
-    PlanUniquePtr                 fftwPlan{};
-    std::vector<U>                magnitudeSpectrum{};
-    std::vector<U>                phaseSpectrum{};
-
-    fft() { initAll(); }
-
-    fft(const fft &rhs)     = delete;
-    fft(fft &&rhs) noexcept = delete;
-    fft &
-    operator=(const fft &rhs)
+    FFT(const FFT &rhs)     = delete;
+    FFT(FFT &&rhs) noexcept = delete;
+    FFT &
+    operator=(const FFT &rhs)
             = delete;
-    fft &
-    operator=(fft &&rhs) noexcept
+    FFT &
+    operator=(FFT &&rhs) noexcept
             = delete;
 
-    ~fft() { clearFftw(); }
+    ~FFT() = default;
 
     void
     settings_changed(const property_map & /*old_settings*/, const property_map &newSettings) noexcept {
-        if (newSettings.contains("fftSize") && fftSize != inputHistory.capacity()) {
-            inputHistory = history_buffer<InHistoryType>(fftSize);
+        if (newSettings.contains("fftSize") && fftSize != inData.size()) {
             initAll();
-        } else if (newSettings.contains("window")) { // no need to create window twice if fftSize was changed
+            initWindowFunction();
+        } else if (newSettings.contains("window")) {
             initWindowFunction();
         }
     }
 
-    constexpr DataSet<U>
-    process_one(T input) noexcept {
-        if constexpr (std::is_same_v<T, InHistoryType>) {
-            inputHistory.push_back(input);
-        } else {
-            inputHistory.push_back(static_cast<InHistoryType>(input));
+    [[nodiscard]] constexpr work_return_status_t
+    process_bulk(std::span<const T> input, std::span<U> output) {
+        if (input.size() != fftSize) {
+            throw std::out_of_range(fmt::format("Input span size ({}) is not equal to FFT size ({}).", input.size(), fftSize));
         }
 
-        if (inputHistory.size() >= fftSize) {
-            prepareInput();
-            computeFft();
-            computeMagnitudeSpectrum();
-            computePhaseSpectrum();
-            return createDataset();
-        } else {
-            return DataSet<U>();
+        if (output.size() != 1) {
+            throw std::out_of_range(fmt::format("Output span size ({}) must be 1.", output.size()));
         }
+
+        prepareInput(input);
+        computeFFT();
+        computeMagnitudeSpectrum();
+        computePhaseSpectrum();
+        output[0] = createDataset();
+
+        return work_return_status_t::OK;
     }
 
-    constexpr DataSet<U>
+    constexpr U
     createDataset() {
-        DataSet<U> ds{};
+        U ds{};
         ds.timestamp = 0;
         const std::size_t N{ magnitudeSpectrum.size() };
+        const std::size_t dim = 5;
 
-        ds.axis_names   = { "time", "fft.real", "fft.imag", "magnitude", "phase" };
-        ds.axis_units   = { "u.a.", "u.a.", "u.a.", "u.a.", "rad" };
-        ds.extents      = { 4, static_cast<int32_t>(N) };
-        ds.layout       = fair::graph::layout_right{};
-        ds.signal_names = { "fft.real", "fft.imag", "magnitude", "phase" };
-        ds.signal_units = { "u.a.", "u.a.", "u.a.", "rad" };
+        ds.axis_names         = { "Frequency", "Re(FFT)", "Im(FFT)", "Magnitude", "Phase" };
+        ds.axis_units         = { "Hz", signalUnit, fmt::format("i{}", signalUnit), fmt::format("{}/√Hz", signalUnit), "rad" };
+        ds.extents            = { dim, static_cast<int32_t>(N) };
+        ds.layout             = fair::graph::layout_right{};
+        ds.signal_names = { signalName, fmt::format("Re(FFT({}))", signalName), fmt::format("Im(FFT({}))", signalName), fmt::format("Magnitude({})", signalName), fmt::format("Phase({})", signalName) };
+        ds.signal_units = { "Hz", signalUnit, fmt::format("i{}", signalUnit), fmt::format("{}/√Hz", signalUnit), "rad" };
 
-        ds.signal_values.resize(4 * N);
-        ds.signal_ranges = { { std::numeric_limits<U>::max(), std::numeric_limits<U>::lowest() },
-                             { std::numeric_limits<U>::max(), std::numeric_limits<U>::lowest() },
-                             { std::numeric_limits<U>::max(), std::numeric_limits<U>::lowest() },
-                             { std::numeric_limits<U>::max(), std::numeric_limits<U>::lowest() } };
-        for (std::size_t i = 0; i < N; i++) {
-            if constexpr (std::is_same_v<U, PrecisionType>) {
-                ds.signal_values[i]     = fftwOut[i][0];
-                ds.signal_values[i + N] = fftwOut[i][1];
-            } else {
-                ds.signal_values[i]     = static_cast<U>(fftwOut[i][0]);
-                ds.signal_values[i + N] = static_cast<U>(fftwOut[i][1]);
-            }
-            ds.signal_ranges[0][0]      = std::min(ds.signal_ranges[0][0], ds.signal_values[i]);
-            ds.signal_ranges[0][1]      = std::max(ds.signal_ranges[0][1], ds.signal_values[i]);
-            ds.signal_ranges[1][0]      = std::min(ds.signal_ranges[1][0], ds.signal_values[i + N]);
-            ds.signal_ranges[1][1]      = std::max(ds.signal_ranges[1][1], ds.signal_values[i + N]);
+        ds.signal_values.resize(dim * N);
+        auto const freqWidth = static_cast<PrecisionType>(sampleRate) / static_cast<PrecisionType>(fftSize);
+        if constexpr (ComplexType<T>) {
+            auto const freqOffset = static_cast<PrecisionType>(N / 2) * freqWidth;
+            std::ranges::transform(std::views::iota(std::size_t(0), N), std::ranges::begin(ds.signal_values),
+                                   [freqWidth, freqOffset](const auto i) { return static_cast<PrecisionType>(i) * freqWidth - freqOffset; });
+        } else {
+            std::ranges::transform(std::views::iota(std::size_t(0), N), std::ranges::begin(ds.signal_values), [freqWidth](const auto i) { return static_cast<PrecisionType>(i) * freqWidth; });
+        }
+        std::ranges::transform(outData.begin(), outData.end(), std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(N)), [](const auto &c) { return c.real(); });
+        std::ranges::transform(outData.begin(), outData.end(), std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(2U * N)), [](const auto &c) { return c.imag(); });
+        std::copy_n(magnitudeSpectrum.begin(), N, std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(3U * N)));
+        std::copy_n(phaseSpectrum.begin(), N, std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(4U * N)));
 
-            ds.signal_values[i + 2 * N] = magnitudeSpectrum[i];
-            ds.signal_ranges[2][0]      = std::min(ds.signal_ranges[2][0], magnitudeSpectrum[i]);
-            ds.signal_ranges[2][1]      = std::max(ds.signal_ranges[2][1], magnitudeSpectrum[i]);
-
-            ds.signal_values[i + 3 * N] = phaseSpectrum[i];
-            ds.signal_ranges[3][0]      = std::min(ds.signal_ranges[3][0], phaseSpectrum[i]);
-            ds.signal_ranges[3][1]      = std::max(ds.signal_ranges[3][1], phaseSpectrum[i]);
+        ds.signal_ranges.resize(dim);
+        for (std::size_t i = 0; i < dim; i++) {
+            const auto mm = std::minmax_element(std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(i * N)), std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>((i + 1U) * N)));
+            ds.signal_ranges[i] = { *mm.first, *mm.second };
         }
 
         ds.signal_errors    = {};
-        ds.meta_information = {
-            { { "fftSize", fftSize }, { "window", window }, { "outputInDb", outputInDb }, { "numerator", this->numerator }, { "denominator", this->denominator }, { "stride", this->stride } }
-        };
+        ds.meta_information = { { { "sampleRate", sampleRate },
+                                  { "signalName", signalName },
+                                  { "signalUnit", signalUnit },
+                                  { "signalMin", signalMin },
+                                  { "signalMax", signalMax },
+                                  { "fftSize", fftSize },
+                                  { "window", window },
+                                  { "outputInDb", outputInDb },
+                                  { "numerator", this->numerator },
+                                  { "denominator", this->denominator },
+                                  { "stride", this->stride } } };
 
         return ds;
     }
 
     void
-    prepareInput() {
-        static_assert(sizeof(InDataType) == sizeof(InHistoryType), "std::complex<T> and T[2] must have the same size");
-        std::memcpy(fftwIn.get(), &(*inputHistory.begin()), sizeof(InDataType) * fftSize);
+    prepareInput(std::span<const T> input) {
+        if (std::is_same_v<T, InDataType>) {
+            std::copy_n(input.begin(), fftSize, inData.begin());
+        } else {
+            std::ranges::transform(input.begin(), input.end(), inData.begin(), [](const T c) { return static_cast<InDataType>(c); });
+        }
+
         // apply window function if needed
-        if (window != static_cast<int>(WindowFunction::None)) {
-            if (fftSize != windowVector.size()) throw std::runtime_error(fmt::format("fftSize({}) and windowVector.size({}) are not equal.", fftSize, windowVector.size()));
+        if (window != static_cast<int>(gr::algorithm::WindowFunction::None)) {
+            if (fftSize != windowVector.size()) {
+                throw std::invalid_argument(fmt::format("fftSize({}) and windowVector.size({}) are not equal.", fftSize, windowVector.size()));
+            }
             for (std::size_t i = 0; i < fftSize; i++) {
                 if constexpr (ComplexType<T>) {
-                    fftwIn[i][0] *= windowVector[i];
-                    fftwIn[i][1] *= windowVector[i];
+                    inData[i].real(inData[i].real() * windowVector[i]);
+                    inData[i].imag(inData[i].imag() * windowVector[i]);
                 } else {
-                    fftwIn[i] *= windowVector[i];
+                    inData[i] *= windowVector[i];
                 }
             }
         }
     }
 
-    void
-    computeFft() {
-        fftw<T>::execute(fftwPlan.get());
+    inline void
+    computeFFT() {
+        outData = fftImpl.computeFFT(inData);
     }
 
-    void
+    inline void
     computeMagnitudeSpectrum() {
-        for (std::size_t i = 0; i < magnitudeSpectrum.size(); i++) {
-            const PrecisionType mag{ std::hypot(fftwOut[i][0], fftwOut[i][1]) * static_cast<PrecisionType>(2.0) / static_cast<PrecisionType>(fftSize) };
-            magnitudeSpectrum[i] = static_cast<U>(outputInDb ? static_cast<PrecisionType>(20.) * std::log10(std::abs(mag)) : mag);
-        }
+        gr::algorithm::computeMagnitudeSpectrum(outData, magnitudeSpectrum, fftSize, outputInDb);
     }
 
-    void
+    inline void
     computePhaseSpectrum() {
-        for (std::size_t i = 0; i < phaseSpectrum.size(); i++) {
-            const auto phase{ std::atan2(fftwOut[i][1], fftwOut[i][0]) };
-            phaseSpectrum[i] = outputInDb ? static_cast<U>(20.) * static_cast<U>(std::log10(std::abs(phase))) : static_cast<U>(phase);
-        }
+        gr::algorithm::computePhaseSpectrum(outData, phaseSpectrum);
     }
 
     void
     initAll() {
-        clearFftw();
-        fftwIn = InUniquePtr(static_cast<InDataType *>(fftw<T>::malloc(sizeof(InDataType) * fftSize)));
+        in.max_samples    = fftSize;
+        in.min_samples    = fftSize;
+        this->denominator = fftSize;
+        clear();
+        inData.resize(fftSize);
         if constexpr (ComplexType<T>) {
-            fftwOut = OutUniquePtr(static_cast<OutDataType *>(fftw<T>::malloc(sizeof(OutDataType) * fftSize)));
+            outData.resize(fftSize);
             magnitudeSpectrum.resize(fftSize);
             phaseSpectrum.resize(fftSize);
         } else {
-            fftwOut = OutUniquePtr(static_cast<OutDataType *>(fftw<T>::malloc(sizeof(OutDataType) * (1 + fftSize / 2))));
+            outData.resize(1 + fftSize / 2);
             magnitudeSpectrum.resize(fftSize / 2);
             phaseSpectrum.resize(fftSize / 2);
         }
-        {
-            std::lock_guard lg{ fftw_plan_mutex };
-            importWisdom();
-            fftwPlan = PlanUniquePtr(fftw<T>::plan(static_cast<int>(fftSize), fftwIn.get(), fftwOut.get(), sign, flags));
-            exportWisdom();
-        }
-
-        initWindowFunction();
     }
 
-    void
+    inline void
     initWindowFunction() {
-        windowVector = createWindowFunction<PrecisionType>(static_cast<WindowFunction>(window), fftSize);
+        windowVector = createWindowFunction<PrecisionType>(static_cast<gr::algorithm::WindowFunction>(window.value), fftSize);
     }
 
     void
-    clearFftw() {
-        {
-            std::lock_guard lg{ fftw_plan_mutex };
-            fftwPlan.reset();
-        }
-
-        fftwIn.reset();
-        fftwOut.reset();
-
-        // fftw<T>::cleanup(); // No need for fftw_cleanup -> After calling it, all existing plans become undefined
+    clear() {
+        inData.clear();
+        outData.clear();
         magnitudeSpectrum.clear();
         phaseSpectrum.clear();
-    }
-
-    int
-    importWisdom() {
-        // TODO: lock file while importing wisdom?
-        return fftw<T>::importWisdomFromFilename(wisdomPath);
-    }
-
-    int
-    exportWisdom() {
-        // TODO: lock file while exporting wisdom?
-        return fftw<T>::exportWisdomToFilename(wisdomPath);
-    }
-
-    int
-    importWisdomFromString(const std::string wisdomString) {
-        return fftw<T>::importWisdomFromString(wisdomString);
-    }
-
-    std::string
-    exportWisdomToString() {
-        return fftw<T>::exportWisdomToString();
-    }
-
-    void
-    forgetWisdom() {
-        return fftw<T>::forgetWisdom();
     }
 };
 
 } // namespace gr::blocks::fft
 
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (gr::blocks::fft::fft<T>), in, out, fftSize, outputInDb, window);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, typename U, typename FourierAlgoImpl), (gr::blocks::fft::FFT<T, U, FourierAlgoImpl>), in, out, fftSize, sampleRate, signalName, signalUnit, signalMin,
+                                    signalMax, outputInDb, window, fftImpl);
 
 #endif // GRAPH_PROTOTYPE_FFT_HPP


### PR DESCRIPTION
This PR contains the following changes:
* Implementation of the iterative radix-2 FFT algorithm using bit-reversal permutation.
* FFT block contains 2 template parameters: data type and algorithm type.
* Add test of different FFT algorithms.
* Use `process_bulk` instead of `process_one`
* Allow user to set also output type
* Add additional meta information to the output `dataset`

### Performance tests
### Clang-16
```text
┌────────────benchmark:─────────────┬──────┬──#N──┬─CTX-SW─┬───CPU cache misses────┬───CPU branch misses───┬─<CPU-I>─┬──min───┬──mean──┬─stddev─┬─median─┬──max───┬─total time─┬─ops/s─┐
│ std::complex<float> - fftw        │ PASS │ 100  │     0  │  29.6k / 179k = 16.5% │  6.76k / 355k =  1.9% │   92.1k │   6 us │  10 us │  37 us │   6 us │ 380 us │       1 ms │ 98.3k │
│ std::complex<float> - fft         │ PASS │ 100  │     1  │  8.18k / 148k =  5.5% │ 4.51k / 1.58M =  0.3% │    190k │  10 us │  11 us │   6 us │  10 us │  54 us │       1 ms │ 91.6k │
│ std::complex<float> - fftCT       │ PASS │ 100  │     0  │ 3.46k / 52.6k =  6.6% │ 7.80k / 18.8M =  0.0% │    1.0M │  75 us │  75 us │   1 us │  75 us │  85 us │       7 ms │ 13.4k │
│ std::complex<float> - magnitude   │ PASS │ 100  │     0  │  770  / 2.30k = 33.6% │   229  / 723k =  0.0% │   36.1k │   4 us │   4 us │ 208 ns │   4 us │   6 us │     399 us │  251k │
│ std::complex<float> - phase       │ PASS │ 100  │     0  │ 2.07k / 4.44k = 46.7% │ 3.57k / 3.04M =  0.1% │    146k │  12 us │  13 us │ 782 ns │  13 us │  18 us │       1 ms │ 78.7k │
│ std::complex<float> - dataset     │ PASS │ 100  │     0  │ 1.63k / 55.0k =  3.0% │ 4.09k / 1.52M =  0.3% │   67.5k │   4 us │   5 us │   1 us │   4 us │  17 us │     464 us │  215k │
├───────────────────────────────────┼──────┼──────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ std::complex<double> - fftw       │ PASS │ 100  │     0  │  31.1k / 388k =  8.0% │  7.02k / 371k =  1.9% │   96.8k │   6 us │  10 us │  33 us │   6 us │ 338 us │     955 us │  105k │
│ std::complex<double> - fft        │ PASS │ 100  │     1  │  16.4k / 352k =  4.7% │ 4.52k / 1.63M =  0.3% │    212k │  11 us │  12 us │   7 us │  11 us │  80 us │       1 ms │ 85.4k │
│ std::complex<double> - fftCT      │ PASS │ 100  │     1  │  9.57k / 393k =  2.4% │ 16.6k / 22.1M =  0.1% │    1.5M │ 121 us │ 122 us │   2 us │ 122 us │ 140 us │      12 ms │  8.2k │
│ std::complex<double> - magnitude  │ PASS │ 100  │     0  │ 2.52k / 7.92k = 31.8% │ 1.35k / 1.28M =  0.1% │   68.5k │   7 us │   7 us │ 661 ns │   7 us │  13 us │     702 us │  142k │
│ std::complex<double> - phase      │ PASS │ 100  │     0  │ 1.35k / 38.3k =  3.5% │ 1.56k / 3.54M =  0.0% │    157k │  13 us │  13 us │ 262 ns │  13 us │  15 us │       1 ms │ 77.7k │
│ std::complex<double> - dataset    │ PASS │ 100  │     0  │  3.84k / 260k =  1.5% │ 3.39k / 1.53M =  0.2% │   71.3k │   5 us │   5 us │ 611 ns │   5 us │  11 us │     489 us │  204k │
├───────────────────────────────────┼──────┼──────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ float - fftw                      │ PASS │ 100  │     0  │  29.5k / 142k = 20.7% │  15.0k / 959k =  1.6% │   85.8k │   2 us │   8 us │  53 us │   2 us │ 531 us │     763 us │  131k │
│ float - fft                       │ PASS │ 100  │     0  │  3.86k / 107k =  3.6% │ 3.54k / 1.65M =  0.2% │    193k │  10 us │  10 us │   2 us │  10 us │  29 us │       1 ms │ 99.7k │
│ float - magnitude                 │ PASS │ 100  │     0  │  514  / 1.60k = 32.0% │   203  / 364k =  0.1% │   18.2k │   2 us │   2 us │  53 ns │   2 us │   2 us │     187 us │  534k │
│ float - phase                     │ PASS │ 100  │     0  │  342  / 1.15k = 29.7% │ 1.60k / 1.53M =  0.1% │   72.8k │   6 us │   6 us │ 332 ns │   6 us │   9 us │     624 us │  160k │
│ float - dataset                   │ PASS │ 100  │     0  │ 1.19k / 9.24k = 12.9% │  2.24k / 928k =  0.2% │   41.1k │   3 us │   3 us │   1 us │   3 us │  12 us │     285 us │  351k │
├───────────────────────────────────┼──────┼──────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ double - fftw                     │ PASS │ 100  │     1  │  31.3k / 251k = 12.5% │  15.1k / 969k =  1.6% │   87.6k │   3 us │   9 us │  60 us │   3 us │ 602 us │     872 us │  115k │
│ double - fft                      │ PASS │ 100  │     0  │  8.81k / 244k =  3.6% │ 3.93k / 1.59M =  0.2% │    206k │  10 us │  11 us │   4 us │  10 us │  55 us │       1 ms │ 91.9k │
│ double - magnitude                │ PASS │ 100  │     0  │  554  / 1.86k = 29.8% │   565  / 642k =  0.1% │   34.3k │   3 us │   3 us │ 106 ns │   3 us │   4 us │     349 us │  287k │
│ double - phase                    │ PASS │ 100  │     0  │  742  / 7.29k = 10.2% │  834  / 1.77M =  0.0% │   78.7k │   6 us │   6 us │ 137 ns │   6 us │   8 us │     644 us │  155k │
│ double - dataset                  │ PASS │ 100  │     1  │ 4.78k / 66.0k =  7.2% │  2.67k / 905k =  0.3% │   42.0k │   3 us │   3 us │   2 us │   3 us │  25 us │     308 us │  325k │
├───────────────────────────────────┼──────┼──────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
└───────────────────────────────────┴──────┴──────┴────────┴───────────────────────┴───────────────────────┴─────────┴────────┴────────┴────────┴────────┴────────┴────────────┴───────┘
```

### gcc-13
```text
┌────────────benchmark:─────────────┬──────┬──#N──┬─CTX-SW─┬───CPU cache misses────┬───CPU branch misses───┬─<CPU-I>─┬──min──┬─mean──┬─stddev─┬─median─┬──max───┬─total time─┬─ops/s─┐
│ std::complex<float> - fftw        │ PASS │ 100  │     0  │  32.6k / 180k = 18.2% │  7.32k / 363k =  2.0% │   92.8k │  7 us │ 11 us │  42 us │   7 us │ 427 us │       1 ms │ 91.1k │
│ std::complex<float> - fft         │ PASS │ 100  │     0  │  6.23k / 136k =  4.6% │ 5.48k / 1.54M =  0.4% │    159k │ 35 us │ 36 us │   5 us │  35 us │  87 us │       4 ms │ 28.1k │
│ std::complex<float> - fftCT       │ PASS │ 100  │     1  │ 5.47k / 64.1k =  8.5% │ 6.22k / 14.8M =  0.0% │    966k │ 75 us │ 76 us │   3 us │  75 us │  95 us │       8 ms │ 13.2k │
│ std::complex<float> - magnitude   │ PASS │ 100  │     0  │  602  / 1.90k = 31.6% │   227  / 825k =  0.0% │   41.3k │  4 us │  4 us │  94 ns │   4 us │   5 us │     374 us │  267k │
│ std::complex<float> - phase       │ PASS │ 100  │     0  │ 1.18k / 2.68k = 44.2% │ 3.58k / 3.04M =  0.1% │    147k │ 12 us │ 12 us │ 981 ns │  12 us │  20 us │       1 ms │ 82.6k │
│ std::complex<float> - dataset     │ PASS │ 100  │     0  │ 1.77k / 46.3k =  3.8% │  2.61k / 992k =  0.3% │   46.3k │  7 us │  8 us │ 928 ns │   7 us │  17 us │     755 us │  132k │
├───────────────────────────────────┼──────┼──────┼────────┼───────────────────────┼───────────────────────┼─────────┼───────┼───────┼────────┼────────┼────────┼────────────┼───────┤
│ std::complex<double> - fftw       │ PASS │ 100  │     0  │  33.0k / 410k =  8.1% │  7.22k / 391k =  1.8% │   97.1k │  6 us │ 10 us │  30 us │   6 us │ 312 us │     970 us │  103k │
│ std::complex<double> - fft        │ PASS │ 100  │     0  │  10.4k / 361k =  2.9% │ 4.22k / 1.59M =  0.3% │    163k │ 37 us │ 37 us │   7 us │  37 us │ 106 us │       4 ms │ 26.8k │
│ std::complex<double> - fftCT      │ PASS │ 100  │     1  │  17.0k / 426k =  4.0% │ 9.24k / 17.8M =  0.1% │    1.3M │ 94 us │ 95 us │   3 us │  94 us │ 124 us │       9 ms │ 10.5k │
│ std::complex<double> - magnitude  │ PASS │ 100  │     0  │  694  / 4.95k = 14.0% │ 1.21k / 1.38M =  0.1% │   73.5k │  7 us │  7 us │ 120 ns │   7 us │   8 us │     728 us │  137k │
│ std::complex<double> - phase      │ PASS │ 100  │     0  │ 1.63k / 41.5k =  3.9% │ 1.56k / 3.54M =  0.0% │    158k │ 13 us │ 13 us │ 755 ns │  13 us │  18 us │       1 ms │ 77.0k │
│ std::complex<double> - dataset    │ PASS │ 100  │     0  │  5.00k / 288k =  1.7% │ 3.01k / 1.06M =  0.3% │   50.5k │  8 us │  9 us │ 742 ns │   9 us │  16 us │     938 us │  107k │
├───────────────────────────────────┼──────┼──────┼────────┼───────────────────────┼───────────────────────┼─────────┼───────┼───────┼────────┼────────┼────────┼────────────┼───────┤
│ float - fftw                      │ PASS │ 100  │     0  │  26.9k / 143k = 18.8% │  15.1k / 967k =  1.6% │   86.0k │  2 us │  8 us │  53 us │   2 us │ 532 us │     768 us │  130k │
│ float - fft                       │ PASS │ 100  │     1  │  5.31k / 104k =  5.1% │ 5.53k / 1.53M =  0.4% │    157k │ 34 us │ 35 us │   3 us │  34 us │  61 us │       3 ms │ 28.7k │
│ float - magnitude                 │ PASS │ 100  │     0  │  617  / 1.71k = 36.0% │   216  / 416k =  0.1% │   20.8k │  2 us │  2 us │  63 ns │   2 us │   2 us │     187 us │  535k │
│ float - phase                     │ PASS │ 100  │     1  │ 3.04k / 5.97k = 50.9% │ 2.03k / 1.53M =  0.1% │   73.5k │  6 us │  6 us │   2 us │   6 us │  26 us │     613 us │  163k │
│ float - dataset                   │ PASS │ 100  │     0  │ 1.30k / 9.60k = 13.5% │  1.40k / 703k =  0.2% │   31.8k │  4 us │  4 us │ 697 ns │   4 us │  11 us │     442 us │  226k │
├───────────────────────────────────┼──────┼──────┼────────┼───────────────────────┼───────────────────────┼─────────┼───────┼───────┼────────┼────────┼────────┼────────────┼───────┤
│ double - fftw                     │ PASS │ 100  │     0  │  27.7k / 263k = 10.5% │  15.7k / 991k =  1.6% │   88.4k │  3 us │  8 us │  53 us │   3 us │ 532 us │     811 us │  123k │
│ double - fft                      │ PASS │ 100  │     0  │  10.5k / 279k =  3.8% │ 4.21k / 1.59M =  0.3% │    159k │ 36 us │ 36 us │   4 us │  36 us │  77 us │       4 ms │ 27.5k │
│ double - magnitude                │ PASS │ 100  │     0  │  545  / 1.84k = 29.6% │   578  / 693k =  0.1% │   36.9k │  4 us │  4 us │ 125 ns │   4 us │   5 us │     369 us │  271k │
│ double - phase                    │ PASS │ 100  │     0  │  853  / 9.25k =  9.2% │  818  / 1.77M =  0.0% │   79.2k │  6 us │  6 us │ 131 ns │   6 us │   8 us │     644 us │  155k │
│ double - dataset                  │ PASS │ 100  │     0  │ 1.76k / 56.3k =  3.1% │  2.00k / 720k =  0.3% │   33.3k │  4 us │  5 us │ 496 ns │   4 us │   9 us │     453 us │  221k │
├───────────────────────────────────┼──────┼──────┼────────┼───────────────────────┼───────────────────────┼─────────┼───────┼───────┼────────┼────────┼────────┼────────────┼───────┤
└───────────────────────────────────┴──────┴──────┴────────┴───────────────────────┴───────────────────────┴─────────┴───────┴───────┴────────┴────────┴────────┴────────────┴───────┘
```