### PR TITLE
Fix test fails, switch off fsanitize=address for emscriptem.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,8 +10,10 @@ function(setup_test_no_asan TARGET_NAME)
 endfunction()
 
 function(setup_test TARGET_NAME)
-    target_compile_options(${TARGET_NAME} PRIVATE "-fsanitize=address")
-    target_link_options(${TARGET_NAME} PRIVATE "-fsanitize=address")
+    if (NOT EMSCRIPTEN)
+        target_compile_options(${TARGET_NAME} PRIVATE -fsanitize=address)
+        target_link_options(${TARGET_NAME} PRIVATE -fsanitize=address)
+    endif ()
     setup_test_no_asan(${TARGET_NAME})
 endfunction()
 


### PR DESCRIPTION
Fix test fails. It seems that `-fsanitize=address` flag causes that too many locals are created. 
For the moment just do not use `-fsanitize=address` flag for emscriptem. 