### PR TITLE
updated FFT block and helper functions

### DIFF
--- a/test/blocklib/algorithm/include/algorithm/fft/window.hpp
+++ b/test/blocklib/algorithm/include/algorithm/fft/window.hpp
@@ -6,111 +6,192 @@
 #include <cmath>
 #include <numbers>
 #include <ranges>
+#include <utils.hpp>
 #include <vector>
 
-namespace gr::algorithm {
+#include <fmt/format.h>
+
+namespace gr::algorithm::window {
 
 /*
  * Implementation of window function (also known as an apodization function or tapering function).
  * See Wikipedia for more info: https://en.wikipedia.org/wiki/Window_function
  */
 
-enum class WindowFunction : int { None, Rectangular, Hamming, Hann, HannExp, Blackman, Nuttall, BlackmanHarris, BlackmanNuttall, FlatTop, Exponential };
+enum class Type : int { None, Rectangular, Hamming, Hann, HannExp, Blackman, Nuttall, BlackmanHarris, BlackmanNuttall, FlatTop, Exponential, Kaiser };
 
-// Only float or double are allowed because FFT supports only float or double precisions.
+namespace detail {
 template<typename T>
-    requires(std::is_floating_point_v<T>)
-std::vector<T>
-createWindowFunction(WindowFunction func, const std::size_t n) {
-    constexpr T pi  = std::numbers::pi_v<T>;
-    constexpr T pi2 = static_cast<T>(2.) * pi;
-    constexpr T c1  = 1.;
-    constexpr T c2  = 2.;
-    constexpr T c3  = 3.;
-    constexpr T c4  = 4.;
+    requires std::is_floating_point_v<T>
+constexpr T
+bessel_i0(const T x) noexcept {
+    T       sum    = 1;
+    T       term   = 1;
+    int     k      = 1;
 
-    switch (func) {
-    case WindowFunction::None: {
-        return {};
+    const T x_half = x / 2;
+
+    do {
+        term *= (x_half / static_cast<T>(k));
+        sum += term * term;
+        ++k;
+    } while (term * term > sum * std::numeric_limits<T>::epsilon());
+
+    return sum;
+}
+} // namespace detail
+
+/**
+ * @brief Creates in-place a window function (mathematically aka. 'apodisation function') of a specified type and size.
+ *
+ * This function generates various window functions used in digital signal processing.
+ * See Wikipedia for more info: https://en.wikipedia.org/wiki/Window_function
+ *
+ * @tparam T The floating-point type to use for the window function values.
+ * @param windowFunction The type of window function to create.
+ * @param Container std::vector containing the values of the window function.
+ */
+template<fair::meta::array_or_vector_type ContainerType, typename T = ContainerType::value_type>
+    requires std::is_floating_point_v<T>
+void
+create(ContainerType &container, Type windowFunction, const T beta = static_cast<T>(1.6)) {
+    constexpr T       pi2 = 2 * std::numbers::pi_v<T>;
+    const std::size_t n   = container.size();
+    if (n == 0) {
+        return;
     }
-    case WindowFunction::Rectangular: {
-        return std::vector<T>(n, T(1.));
+
+    using enum Type;
+    switch (windowFunction) {
+    case None:
+    case Rectangular: {
+        std::ranges::fill(container, 1);
+        return;
     }
-    case WindowFunction::Hamming: {
-        std::vector<T> res(n);
-        const T        a = pi2 / static_cast<T>(n);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a](const auto i) { return T(0.53836) - T(0.46164) * std::cos(a * static_cast<T>(i)); });
-        return res;
+    case Hamming: {
+        // formula: w(n) = 0.54 - 0.46 * cos((2 * pi * n) / (N - 1))
+        // reference: Hamming, R. W. (1977). Digital filters. Prentice-Hall.
+        const T a = pi2 / static_cast<T>(n);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) { return static_cast<T>(0.53836) - static_cast<T>(0.46164) * std::cos(a * static_cast<T>(i)); });
+        return;
     }
-    case WindowFunction::Hann: {
-        std::vector<T> res(n);
-        const T        a = pi2 / static_cast<T>(n - 1);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a](const auto i) { return T(0.5) - T(0.5) * std::cos(a * static_cast<T>(i)); });
-        return res;
+    case Hann: {
+        // formula: w(n) = 0.5 - 0.5 * cos((2 * pi * n) / (N - 1))
+        // reference: von Hann, J. (1901). Über den Durchgang einer elektrischen Welle längs der Erdoberfläche. Elektrische Nachrichtentechnik, 17, 421-424.
+        const T a = pi2 / static_cast<T>(n - 1);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) { return static_cast<T>(.5) - static_cast<T>(.5) * std::cos(a * static_cast<T>(i)); });
+        return;
     }
-    case WindowFunction::HannExp: {
-        std::vector<T> res(n);
-        const T        a = pi2 / static_cast<T>(n - 1);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a](const auto i) { return std::pow(std::sin(a * static_cast<T>(i)), c2); });
-        return res;
+    case HannExp: {
+        const T a = pi2 / static_cast<T>(n - 1);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) { return std::pow(std::sin(a * static_cast<T>(i)), static_cast<T>(2.)); });
+        return;
     }
-    case WindowFunction::Blackman: {
-        std::vector<T> res(n);
-        const T        a = pi2 / static_cast<T>(n - 1);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a](const auto i) {
+    case Blackman: {
+        // formula: w(n) = 0.42 - 0.5 * cos((2 * pi * n) / (N - 1)) + 0.08 * cos((4 * pi * n) / (N - 1))
+        // reference: Blackman, R. B., & Tukey, J. W. (1958). The measurement of power spectra from the point of view of communications engineering. Dover Publications.
+        const T a = pi2 / static_cast<T>(n - 1);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
             const T ai = a * static_cast<T>(i);
-            return T(0.42) - T(0.5) * std::cos(ai) + T(0.08) * std::cos(c2 * ai);
+            return static_cast<T>(0.42) - static_cast<T>(0.5) * std::cos(ai) + static_cast<T>(0.08) * std::cos(static_cast<T>(2.) * ai);
         });
-        return res;
+        return;
     }
-    case WindowFunction::Nuttall: {
-        std::vector<T> res(n);
-        const T        a = pi2 / static_cast<T>(n - 1);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a](const auto i) {
+    case Nuttall: {
+        // Formula: w(n) = a0 - a1 * cos((2 * pi * n) / (N - 1)) + a2 * cos((4 * pi * n) / (N - 1)) - a3 * cos((6 * pi * n) / (N - 1))
+        // Reference: Nuttall, A. (1981). Some Windows with Very Good Sidelobe Behavior. IEEE Transactions on Acoustics, Speech, and Signal Processing, 29(1), 84-91.
+        const T a = pi2 / static_cast<T>(n - 1);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
+            constexpr std::array<T, 4> coeff = { static_cast<T>(0.355768), static_cast<T>(0.487396), static_cast<T>(0.144232), static_cast<T>(0.012604) };
+            const T                    ai    = a * static_cast<T>(i);
+            return coeff[0] - coeff[1] * std::cos(ai) + coeff[2] * std::cos(2 * ai) - coeff[3] * std::cos(3 * ai);
+        });
+        return;
+    }
+    case BlackmanHarris: {
+        // formula: w(n) = a0 - a1 * cos((2 * pi * n) / (N - 1)) + a2 * cos((4 * pi * n) / (N - 1)) - a3 * cos((6 * pi * n) / (N - 1))
+        // reference: Harris, F. J. (1978). On the use of windows for harmonic analysis with the discrete Fourier transform. Proceedings of the IEEE, 66(1), 51-83.
+        const T a = pi2 / static_cast<T>(n - 1);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
+            constexpr std::array<T, 4> coeff = { static_cast<T>(0.35875), static_cast<T>(0.48829), static_cast<T>(0.14128), static_cast<T>(0.01168) };
+            const T                    ai    = a * static_cast<T>(i);
+            return coeff[0] - coeff[1] * std::cos(ai) + coeff[2] * std::cos(2 * ai) - coeff[3] * std::cos(3 * ai);
+        });
+        return;
+    }
+    case BlackmanNuttall: {
+        // formula: w(n) = 0.3635819 - 0.4891775 * cos(2*pi*n/(N-1)) + 0.1365995 * cos(4*pi*n/(N-1)) - 0.0106411 * cos(6*pi*n/(N-1))
+        // reference: Generalized from Nuttall, A. (1981) and Harris, F. J. (1978).
+        const T a = pi2 / static_cast<T>(n - 1);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
             const T ai = a * static_cast<T>(i);
-            return T(0.355768) - T(0.487396) * std::cos(ai) + T(0.144232) * std::cos(c2 * ai) - T(0.012604) * std::cos(c3 * ai);
+            return static_cast<T>(0.3635819) - static_cast<T>(0.4891775) * std::cos(ai) + static_cast<T>(0.1365995) * std::cos(static_cast<T>(2.) * ai)
+                 - static_cast<T>(0.0106411) * std::cos(static_cast<T>(3.) * ai);
         });
-        return res;
+        return;
     }
-    case WindowFunction::BlackmanHarris: {
-        std::vector<T> res(n);
-        const T        a = pi2 / static_cast<T>(n - 1);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a](const auto i) {
-            const T ai = a * static_cast<T>(i);
-            return T(0.35875) - T(0.48829) * std::cos(ai) + T(0.14128) * std::cos(c2 * ai) - T(0.01168) * std::cos(c3 * ai);
+    case FlatTop: {
+        // formula: w(n) = a0 - a1 * cos((2 * pi * n) / (N - 1)) + a2 * cos((4 * pi * n) / (N - 1)) - a3 * cos((6 * pi * n) / (N - 1)) + a4 * cos((8 * pi * n) / (N - 1))
+        // reference: D'Antona, G., & Ferrero, A. (2006). Digital Signal Processing for Measurement Systems: Theory and Applications. Springer.
+        const T a = pi2 / static_cast<T>(n - 1);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) {
+            constexpr std::array<T, 5> coeff = { static_cast<T>(1.0), static_cast<T>(1.93), static_cast<T>(1.29), static_cast<T>(0.388), static_cast<T>(0.032) };
+            const T                    ai    = a * static_cast<T>(i);
+            return coeff[0] - coeff[1] * std::cos(ai) + coeff[2] * std::cos(2 * ai) - coeff[3] * std::cos(3 * ai) + coeff[4] * std::cos(4 * ai);
         });
-        return res;
+        return;
     }
-    case WindowFunction::BlackmanNuttall: {
-        std::vector<T> res(n);
-        const T        a = pi2 / static_cast<T>(n - 1);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a](const auto i) {
-            const T ai = a * static_cast<T>(i);
-            return T(0.3635819) - T(0.4891775) * std::cos(ai) + T(0.1365995) * std::cos(c2 * ai) - T(0.0106411) * std::cos(c3 * ai);
+    case Exponential: {
+        // formula: w(n) = exp(n/a)
+        const T exp0 = std::exp(static_cast<T>(0.));
+        const T a    = static_cast<T>(3.) * static_cast<T>(n);
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a, exp0](const auto i) { return std::exp(static_cast<T>(i) / a) / exp0; });
+        return;
+    }
+    case Kaiser: {
+        // formula: w(n) = I0(beta * sqrt(1 - ((2*n/(N-1)) - 1)^2)) / I0(beta)
+        // reference: J. F. Kaiser and R. W. Schafer. On the use of the i0-sinh window for spectrum analysis. IEEE Transactions on Acoustics, Speech, and Signal Processing, 28(1):105–107, 1980.
+        if (beta < 0) throw std::invalid_argument("beta must be non-negative");
+        if (n <= 1) throw std::invalid_argument("n must be larger than one");
+
+        const T factor = static_cast<T>(1) / static_cast<T>(n - 1);
+        const T i0Beta = detail::bessel_i0(static_cast<T>(beta)); // Compute the zeroth order modified Bessel function of the first kind for beta
+        std::ranges::transform(std::views::iota(0UL, n), container.begin(), [beta, factor, i0Beta](const auto i) {
+            const T term = (static_cast<T>(2 * i) * factor) - static_cast<T>(1);
+            return detail::bessel_i0(static_cast<T>(beta) * std::sqrt(std::abs(static_cast<T>(1) - term * term))) / i0Beta;
         });
-        return res;
+        return;
     }
-    case WindowFunction::FlatTop: {
-        std::vector<T> res(n);
-        const T        a = pi2 / static_cast<T>(n - 1);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a](const auto i) {
-            const T ai = a * static_cast<T>(i);
-            return c1 - T(1.93) * std::cos(ai) + T(1.29) * std::cos(c2 * ai) - T(0.388) * std::cos(c3 * ai) + T(0.032) * std::cos(c4 * ai);
-        });
-        return res;
-    }
-    case WindowFunction::Exponential: {
-        std::vector<T> res(n);
-        const T        exp0 = std::exp(T(0.));
-        const T        a    = c3 * static_cast<T>(n);
-        std::ranges::transform(std::views::iota(std::size_t(0), n), std::ranges::begin(res), [a, exp0](const auto i) { return std::exp(static_cast<T>(i) / a) / exp0; });
-        return res;
-    }
-    default: {
-        return {};
-    }
+    default: throw std::invalid_argument(fmt::format("Unsupported window type id {}.", static_cast<int>(windowFunction)));
     }
 }
-} // namespace gr::algorithm
+
+/**
+ * @brief Creates a new window function (mathematically aka. 'apodisation function') of a specified type and size.
+ *
+ * This function generates various window functions used in digital signal processing.
+ * See Wikipedia for more info: https://en.wikipedia.org/wiki/Window_function
+ *
+ * @tparam T The floating-point type to use for the window function values.
+ * @param windowFunction The type of window function to create.
+ * @param n The size of the window function.
+ * @return A std::vector<float> containing the values of the window function.
+ */
+template<typename T = float>
+    requires std::is_floating_point_v<T>
+auto
+create(Type windowFunction, const std::size_t n, const T beta = static_cast<T>(1.6)) {
+    std::vector<T> container(n);
+    create(container, windowFunction, beta);
+    return container;
+}
+
+// this is to speed-up typical instantiations
+template void
+create<std::vector<float>>(std::vector<float> &container, Type windowFunction, float beta);
+template void
+create<std::vector<double>>(std::vector<double> &container, Type windowFunction, double beta);
+
+} // namespace gr::algorithm::window
 
 #endif // GRAPH_PROTOTYPE_ALGORITHM_WINDOW_HPP

--- a/test/blocklib/core/fft/fft.hpp
+++ b/test/blocklib/core/fft/fft.hpp
@@ -14,79 +14,145 @@
 namespace gr::blocks::fft {
 
 using namespace fair::graph;
-using gr::algorithm::ComplexType;
-using gr::algorithm::FFTInDataType;
-using gr::algorithm::FFTOutDataType;
 
-template<typename T, typename U = DataSet<float>, typename FourierAlgoImpl = gr::algorithm::FFT<FFTInDataType<T, typename U::value_type>>>
-    requires(ComplexType<T> || std::floating_point<T> || std::is_same_v<U, DataSet<float>> || std::is_same_v<U, DataSet<double>>)
-struct FFT : public node<FFT<T, U, FourierAlgoImpl>, PerformDecimationInterpolation> {
+template<typename T, typename U = DataSet<float>, typename FourierAlgorithm = gr::algorithm::FFT<gr::algorithm::FFTInDataType<T, typename U::value_type>>>
+    requires(gr::algorithm::ComplexType<T> || std::floating_point<T> || std::is_same_v<U, DataSet<float>> || std::is_same_v<U, DataSet<double>>)
+struct FFT : public node<FFT<T, U, FourierAlgorithm>, PerformDecimationInterpolation, Doc<R""(
+@brief Performs a (Fast) Fourier Transform (FFT) on the given input data.
+
+The FFT block is capable of performing Fourier Transform computations on real or complex data,
+and populates a DataSet with the results, including real, imaginary, magnitude, and phase
+spectrum of the signal. For details see:
+ * https://en.wikipedia.org/wiki/Fourier_transform
+ * https://en.wikipedia.org/wiki/Discrete-time_Fourier_transform
+ * https://en.wikipedia.org/wiki/Fast_Fourier_transform
+
+On the choice of window (mathematically aka. apodisation) functions
+(SA = Side-lobe Attenuation (near ... far), FR = Frequency Resolution, MR = Magnitude Response):
+ * None (0):
+   - SA: ~13 ... 40 dB | FR: Narrow (finest distinction between frequencies) | MR: Large ripple.
+   - No window applied, same as Rectangular
+ * Rectangular (1):
+   - SA: ~13 ... 40 dB | FR: Narrow | MR: Large ripple.
+   - No window applied, same as None
+ * Hamming (2):
+   - SA: ~41 ... 60 dB | FR: Moderate | MR: ~0.019% ripple.
+   - Balanced between frequency resolution and side-lobe attenuation.
+   - Best for: General purpose.
+ * Hann (3, default):
+   - SA: ~31 ... 105 dB | FR: Narrower than Hamming | MR: ~0.036% ripple.
+   - Good frequency resolution, relatively low side-lobe.
+   - Best for: Spectral analysis, especially when resolving closely spaced frequencies or for
+     ensuring minimal leakage when multiple signals are present. This makes it an ideal default
+     choice for most applications.
+ * HannExp (4):
+   - SA: ~50 ... 90 dB (estimate) | FR: Moderate | MR: Variable.
+ * Blackman (5):
+   - SA: ~58 ... 80 dB | FR: Wider than Hamming | MR: ~0.002% ripple.
+   - Reduced leakage at the expense of a wider main-lobe.
+ * Nuttall (6):
+   - SA: ~64 ... 90 dB | FR: Wider than Blackman | MR: ~0.001% ripple.
+   - Very low side-lobe but reduced frequency resolution.
+   - Best for: Spectral purity.
+ * BlackmanHarris (7):
+   - SA: ~67 ... 92 dB | FR: Similar to Blackman | MR: ~0.0002% ripple.
+   - High side-lobe attenuation, lesser frequency resolution than Hamming.
+ * BlackmanNuttall (8):
+   - SA: ~65 ... 88 dB | FR: Similar to Blackman | MR: ~0.0001% ripple.
+   - Blend of Blackman & Nuttall properties.
+ * FlatTop (9):
+   - SA: ~44 ... 70 dB | FR: Widest among all | MR: Very precise (minimal ripple).
+   - Precision amplitude measurements but poor frequency resolution.
+   - Best for: Precise amplitude measurements.
+ * Exponential (10):
+   - SA: Variable | FR: Moderate | MR: Variable.
+   - Best for: signals with decaying amplitudes.
+ * Kaiser (11):
+   - SA: Adjustable | FR: Adjustable | MR: Variable.
+   - Customizable side-lobe attenuation and frequency resolution trade-off.
+   - Best for: Custom trade-offs between SA and FR.
+
+@tparam T type of the input signal.
+@tparam U type of the output data (presently limited to DataSet<float> and DataSet<double>)
+@tparam FourierAlgorithm the specific algorithm used to perform the Fourier Transform (can be DFT, FFT, FFTW).
+)"">> {
 public:
-    using PrecisionType = U::value_type;
-    using InDataType    = FFTInDataType<T, PrecisionType>;
-    using OutDataType   = FFTOutDataType<PrecisionType>;
+    using value_type  = U::value_type;
+    using InDataType  = gr::algorithm::FFTInDataType<T, value_type>;
+    using OutDataType = gr::algorithm::FFTOutDataType<value_type>;
 
-    PortIn<T>                                                                        in;
-    PortOut<U, RequiredSamples<1, 1>>                                                out;
+    PortIn<T>               in;
+    PortOut<U>              out;
 
-    FourierAlgoImpl                                                                  fftImpl;
-    Annotated<std::size_t, "FFT size", Doc<"FFT size">>                              fftSize{ 1024 };
-    Annotated<int, "window function", Doc<"window (apodization) function">>          window{ static_cast<int>(gr::algorithm::WindowFunction::Hann) };
-    Annotated<float, "sample rate", Doc<"signal sample rate">, Unit<"Hz">>           sampleRate = 1.f;
-    Annotated<std::string, "signal name", Visible>                                   signalName = std::string("unknown signal");
-    Annotated<std::string, "signal unit", Visible, Doc<"signal's physical SI unit">> signalUnit = std::string("a.u.");
-    Annotated<T, "signal min", Doc<"signal physical min. (e.g. DAQ) limit">>         signalMin  = std::numeric_limits<T>::lowest();
-    Annotated<T, "signal max", Doc<"signal physical max. (e.g. DAQ) limit">>         signalMax  = std::numeric_limits<T>::max();
+    FourierAlgorithm        _fftImpl;
+    std::vector<value_type> _window = gr::algorithm::window::create<value_type>(gr::algorithm::window::Type::Hann, 1024U);
+
+    // settings
+    const std::string                                                                algorithm = fair::meta::type_name<FourierAlgorithm>();
+    Annotated<std::uint32_t, "FFT size", Doc<"FFT size">>                            fftSize{ 1024U };
+    Annotated<int, "window function", Doc<"window (apodization) function">>          window{ static_cast<int>(gr::algorithm::window::Type::Hann) };
     Annotated<bool, "output in dB", Doc<"calculate output in decibels">>             outputInDb{ false };
-    std::vector<PrecisionType>                                                       windowVector;
-    std::vector<InDataType>                                                          inData{};
-    std::vector<OutDataType>                                                         outData{};
-    std::vector<PrecisionType>                                                       magnitudeSpectrum{};
-    std::vector<PrecisionType>                                                       phaseSpectrum{};
+    Annotated<float, "sample rate", Doc<"signal sample rate">, Unit<"Hz">>           sample_rate = 1.f;
+    Annotated<std::string, "signal name", Visible>                                   signal_name = std::string("unknown signal");
+    Annotated<std::string, "signal unit", Visible, Doc<"signal's physical SI unit">> signal_unit = std::string("a.u.");
+    Annotated<T, "signal min", Doc<"signal physical min. (e.g. DAQ) limit">>         signal_min  = std::numeric_limits<T>::lowest();
+    Annotated<T, "signal max", Doc<"signal physical max. (e.g. DAQ) limit">>         signal_max  = std::numeric_limits<T>::max();
 
-    FFT() {
-        initAll();
-        initWindowFunction();
-    };
-
-    explicit FFT(std::initializer_list<std::pair<const std::string, pmtv::pmt>> init_parameter) noexcept : node<FFT<T, U, FourierAlgoImpl>, PerformDecimationInterpolation>(init_parameter) {}
-
-    FFT(const FFT &rhs)     = delete;
-    FFT(FFT &&rhs) noexcept = delete;
-    FFT &
-    operator=(const FFT &rhs)
-            = delete;
-    FFT &
-    operator=(FFT &&rhs) noexcept
-            = delete;
-
-    ~FFT() = default;
+    // semi-private caching vectors (need to be public for unit-test) -> TODO: move to FFT implementations, casting from T -> U::value_type should be done there
+    std::vector<InDataType>  _inData            = std::vector<InDataType>(fftSize, 0);
+    std::vector<OutDataType> _outData           = std::vector<OutDataType>(gr::algorithm::ComplexType<T> ? fftSize.value : (1U + fftSize.value / 2U), 0);
+    std::vector<value_type>  _magnitudeSpectrum = std::vector<value_type>(_outData.size(), 0);
+    std::vector<value_type>  _phaseSpectrum     = std::vector<value_type>(_outData.size(), 0);
 
     void
     settings_changed(const property_map & /*old_settings*/, const property_map &newSettings) noexcept {
-        if (newSettings.contains("fftSize") && fftSize != inData.size()) {
-            initAll();
-            initWindowFunction();
-        } else if (newSettings.contains("window")) {
-            initWindowFunction();
+        if (!newSettings.contains("fftSize") && !newSettings.contains("window")) {
+            // do need to only handle interdependent settings -> can early return
+            return;
         }
+
+        const std::size_t newSize = fftSize;
+        in.max_samples            = newSize;
+        in.min_samples            = newSize;
+        this->denominator         = newSize;
+        _window.resize(newSize, 0);
+        gr::algorithm::window::create(_window, static_cast<gr::algorithm::window::Type>(window.value));
+
+        // N.B. this should become part of the Fourier transform implementation
+        _inData.resize(fftSize, 0);
+        constexpr bool computeHalfSpectrum = gr::algorithm::ComplexType<T>;
+        _outData.resize(computeHalfSpectrum ? newSize : (1U + newSize / 2), 0);
+        _magnitudeSpectrum.resize(computeHalfSpectrum ? newSize : (newSize / 2), 0);
+        _phaseSpectrum.resize(computeHalfSpectrum ? newSize : (newSize / 2), 0);
     }
 
     [[nodiscard]] constexpr work_return_status_t
     process_bulk(std::span<const T> input, std::span<U> output) {
-        if (input.size() != fftSize) {
-            throw std::out_of_range(fmt::format("Input span size ({}) is not equal to FFT size ({}).", input.size(), fftSize));
+        if constexpr (std::is_same_v<T, InDataType>) {
+            std::copy_n(input.begin(), fftSize, _inData.begin());
+        } else {
+            std::ranges::transform(input.begin(), input.end(), _inData.begin(), [](const T c) { return static_cast<InDataType>(c); });
         }
 
-        if (output.size() != 1) {
-            throw std::out_of_range(fmt::format("Output span size ({}) must be 1.", output.size()));
+        // apply window function
+        for (std::size_t i = 0U; i < fftSize; i++) {
+            if constexpr (gr::algorithm::ComplexType<T>) {
+                _inData[i].real(_inData[i].real() * _window[i]);
+                _inData[i].imag(_inData[i].imag() * _window[i]);
+            } else {
+                _inData[i] *= _window[i];
+            }
         }
 
-        prepareInput(input);
-        computeFFT();
-        computeMagnitudeSpectrum();
-        computePhaseSpectrum();
-        output[0] = createDataset();
+        _outData = _fftImpl.computeFFT(_inData);
+
+        gr::algorithm::computeMagnitudeSpectrum(_outData, _magnitudeSpectrum, fftSize, outputInDb);
+        gr::algorithm::computePhaseSpectrum(_outData, _phaseSpectrum);
+        if constexpr (std::is_same_v<U, DataSet<float>> || std::is_same_v<U, DataSet<double>>) {
+            output[0] = createDataset();
+        } else {
+            static_assert(!std::is_same_v<U, DataSet<float>> && "FFT output type not (yet) implemented");
+        }
 
         return work_return_status_t::OK;
     }
@@ -95,29 +161,30 @@ public:
     createDataset() {
         U ds{};
         ds.timestamp = 0;
-        const std::size_t N{ magnitudeSpectrum.size() };
+        const std::size_t N{ _magnitudeSpectrum.size() };
         const std::size_t dim = 5;
 
         ds.axis_names         = { "Frequency", "Re(FFT)", "Im(FFT)", "Magnitude", "Phase" };
-        ds.axis_units         = { "Hz", signalUnit, fmt::format("i{}", signalUnit), fmt::format("{}/√Hz", signalUnit), "rad" };
+        ds.axis_units         = { "Hz", signal_unit, fmt::format("i{}", signal_unit), fmt::format("{}/√Hz", signal_unit), "rad" };
         ds.extents            = { dim, static_cast<int32_t>(N) };
         ds.layout             = fair::graph::layout_right{};
-        ds.signal_names = { signalName, fmt::format("Re(FFT({}))", signalName), fmt::format("Im(FFT({}))", signalName), fmt::format("Magnitude({})", signalName), fmt::format("Phase({})", signalName) };
-        ds.signal_units = { "Hz", signalUnit, fmt::format("i{}", signalUnit), fmt::format("{}/√Hz", signalUnit), "rad" };
+        ds.signal_names       = { signal_name, fmt::format("Re(FFT({}))", signal_name), fmt::format("Im(FFT({}))", signal_name), fmt::format("Magnitude({})", signal_name),
+                                  fmt::format("Phase({})", signal_name) };
+        ds.signal_units       = { "Hz", signal_unit, fmt::format("i{}", signal_unit), fmt::format("{}/√Hz", signal_unit), "rad" };
 
         ds.signal_values.resize(dim * N);
-        auto const freqWidth = static_cast<PrecisionType>(sampleRate) / static_cast<PrecisionType>(fftSize);
-        if constexpr (ComplexType<T>) {
-            auto const freqOffset = static_cast<PrecisionType>(N / 2) * freqWidth;
-            std::ranges::transform(std::views::iota(std::size_t(0), N), std::ranges::begin(ds.signal_values),
-                                   [freqWidth, freqOffset](const auto i) { return static_cast<PrecisionType>(i) * freqWidth - freqOffset; });
+        auto const freqWidth = static_cast<value_type>(sample_rate) / static_cast<value_type>(fftSize);
+        if constexpr (gr::algorithm::ComplexType<T>) {
+            auto const freqOffset = static_cast<value_type>(N / 2) * freqWidth;
+            std::ranges::transform(std::views::iota(0UL, N), std::ranges::begin(ds.signal_values),
+                                   [freqWidth, freqOffset](const auto i) { return static_cast<value_type>(i) * freqWidth - freqOffset; });
         } else {
-            std::ranges::transform(std::views::iota(std::size_t(0), N), std::ranges::begin(ds.signal_values), [freqWidth](const auto i) { return static_cast<PrecisionType>(i) * freqWidth; });
+            std::ranges::transform(std::views::iota(0UL, N), std::ranges::begin(ds.signal_values), [freqWidth](const auto i) { return static_cast<T>(i * freqWidth); });
         }
-        std::ranges::transform(outData.begin(), outData.end(), std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(N)), [](const auto &c) { return c.real(); });
-        std::ranges::transform(outData.begin(), outData.end(), std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(2U * N)), [](const auto &c) { return c.imag(); });
-        std::copy_n(magnitudeSpectrum.begin(), N, std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(3U * N)));
-        std::copy_n(phaseSpectrum.begin(), N, std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(4U * N)));
+        std::ranges::transform(_outData.begin(), _outData.end(), std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(N)), [](const auto &c) { return c.real(); });
+        std::ranges::transform(_outData.begin(), _outData.end(), std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(2U * N)), [](const auto &c) { return c.imag(); });
+        std::copy_n(_magnitudeSpectrum.begin(), N, std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(3U * N)));
+        std::copy_n(_phaseSpectrum.begin(), N, std::next(ds.signal_values.begin(), static_cast<std::ptrdiff_t>(4U * N)));
 
         ds.signal_ranges.resize(dim);
         for (std::size_t i = 0; i < dim; i++) {
@@ -126,11 +193,11 @@ public:
         }
 
         ds.signal_errors    = {};
-        ds.meta_information = { { { "sampleRate", sampleRate },
-                                  { "signalName", signalName },
-                                  { "signalUnit", signalUnit },
-                                  { "signalMin", signalMin },
-                                  { "signalMax", signalMax },
+        ds.meta_information = { { { "sampleRate", sample_rate },
+                                  { "signalName", signal_name },
+                                  { "signalUnit", signal_unit },
+                                  { "signalMin", signal_min },
+                                  { "signalMax", signal_max },
                                   { "fftSize", fftSize },
                                   { "window", window },
                                   { "outputInDb", outputInDb },
@@ -140,81 +207,11 @@ public:
 
         return ds;
     }
-
-    void
-    prepareInput(std::span<const T> input) {
-        if (std::is_same_v<T, InDataType>) {
-            std::copy_n(input.begin(), fftSize, inData.begin());
-        } else {
-            std::ranges::transform(input.begin(), input.end(), inData.begin(), [](const T c) { return static_cast<InDataType>(c); });
-        }
-
-        // apply window function if needed
-        if (window != static_cast<int>(gr::algorithm::WindowFunction::None)) {
-            if (fftSize != windowVector.size()) {
-                throw std::invalid_argument(fmt::format("fftSize({}) and windowVector.size({}) are not equal.", fftSize, windowVector.size()));
-            }
-            for (std::size_t i = 0; i < fftSize; i++) {
-                if constexpr (ComplexType<T>) {
-                    inData[i].real(inData[i].real() * windowVector[i]);
-                    inData[i].imag(inData[i].imag() * windowVector[i]);
-                } else {
-                    inData[i] *= windowVector[i];
-                }
-            }
-        }
-    }
-
-    inline void
-    computeFFT() {
-        outData = fftImpl.computeFFT(inData);
-    }
-
-    inline void
-    computeMagnitudeSpectrum() {
-        gr::algorithm::computeMagnitudeSpectrum(outData, magnitudeSpectrum, fftSize, outputInDb);
-    }
-
-    inline void
-    computePhaseSpectrum() {
-        gr::algorithm::computePhaseSpectrum(outData, phaseSpectrum);
-    }
-
-    void
-    initAll() {
-        in.max_samples    = fftSize;
-        in.min_samples    = fftSize;
-        this->denominator = fftSize;
-        clear();
-        inData.resize(fftSize);
-        if constexpr (ComplexType<T>) {
-            outData.resize(fftSize);
-            magnitudeSpectrum.resize(fftSize);
-            phaseSpectrum.resize(fftSize);
-        } else {
-            outData.resize(1 + fftSize / 2);
-            magnitudeSpectrum.resize(fftSize / 2);
-            phaseSpectrum.resize(fftSize / 2);
-        }
-    }
-
-    inline void
-    initWindowFunction() {
-        windowVector = createWindowFunction<PrecisionType>(static_cast<gr::algorithm::WindowFunction>(window.value), fftSize);
-    }
-
-    void
-    clear() {
-        inData.clear();
-        outData.clear();
-        magnitudeSpectrum.clear();
-        phaseSpectrum.clear();
-    }
 };
 
 } // namespace gr::blocks::fft
 
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, typename U, typename FourierAlgoImpl), (gr::blocks::fft::FFT<T, U, FourierAlgoImpl>), in, out, fftSize, sampleRate, signalName, signalUnit, signalMin,
-                                    signalMax, outputInDb, window, fftImpl);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, typename U, typename FourierAlgoImpl), (gr::blocks::fft::FFT<T, U, FourierAlgoImpl>), //
+                                    in, out, algorithm, fftSize, window, outputInDb, sample_rate, signal_name, signal_unit, signal_min, signal_max);
 
 #endif // GRAPH_PROTOTYPE_FFT_HPP


### PR DESCRIPTION
* reduced the API towards a more clean and lean implementation
  - reduced 'using' declarations
  - removed redundant functions in the block implementation
* changed fftSize from problematic/non-portable `std::size_t` to `std::uint32_t`
* fixed sample_rate, and signal_... names to follow the tag::DEFAULT_TAGS conventions
* added Kaiser window function (pre-requisite for FIR filter calculations)
* updated block documentation

Future Todos:
 * semi-private caching vectors (need to be public for unit-test) should be moved to FFT implementations, notably casting from T -> U::value_type should be done there
 * use of SIMD primitives where possible
 * change window function from int to std::string (parsing + default fall back) function