### PR TITLE
CI: modernize compiler selection and cleanup workflow

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   release:
     types: [ created ]
 
@@ -26,6 +25,9 @@ jobs:
           - name: Ubuntu Latest clang16
             os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
             compiler: clang16
+          - name: Ubuntu Latest clang17
+            os: ubuntu-22.04
+            compiler: clang17
           - name: Ubuntu Latest emscripten
             os: ubuntu-22.04 # pre-release, ubuntu-latest still points to ubuntu-2004
             compiler: emscripten
@@ -75,6 +77,16 @@ jobs:
           sudo apt upgrade -y # update clang14 to fix packaging conflicts
           sudo apt install -y clang-16 libc++-16-dev libc++abi-16-dev
           sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-16 110
+
+      - name: Install clang-17
+        if: matrix.configurations.compiler == 'clang17'
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main'
+          sudo apt update
+          sudo apt upgrade -y # update clang14 to fix packaging conflicts
+          sudo apt install -y clang-17 libc++-17-dev libc++abi-17-dev
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 110
 
       - name: Install emscripten
         if: matrix.configurations.compiler == 'emscripten'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,10 +88,10 @@ jobs:
           cd
           git clone --depth=1 https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          # Download and install the latest SDK tools.
-          ./emsdk install releases-bf3c159888633d232c0507f4c76cc156a43c32dc-64bit
-          # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
-          ./emsdk activate releases-bf3c159888633d232c0507f4c76cc156a43c32dc-64bit
+          # Download and install emscripten.
+          ./emsdk install 3.1.43 # 07/2023 (latest = 3.1.46 -> 09/2023)
+          # Make "active" for the current user. (writes .emscripten file)
+          ./emsdk activate 3.1.43
 
       - name: Install sonar-scanner and build-wrapper
         if: matrix.configurations.compiler == 'gcc12' && matrix.cmake-build-type == 'Debug'
@@ -107,8 +107,9 @@ jobs:
         if: matrix.configurations.compiler == 'emscripten'
         shell: bash
         run: |
+          export SYSTEM_NODE=`which node` # use system node instead of old version distributed with emsdk for threading support
           source ~/emsdk/emsdk_env.sh
-          emcmake cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=OFF
+          emcmake cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=OFF -DCMAKE_CROSSCOMPILING_EMULATOR=${SYSTEM_NODE}
 
       - name: Build
         if: matrix.configurations.compiler != 'gcc12' || matrix.cmake-build-type != 'Debug'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   release:
     types: [ created ]
 
@@ -26,6 +25,9 @@ jobs:
           - name: Ubuntu Latest clang16
             os: ubuntu-22.04
             compiler: clang16
+          - name: Ubuntu Latest clang17
+            os: ubuntu-22.04
+            compiler: clang17
           - name: Ubuntu Latest emscripten
             os: ubuntu-22.04
             compiler: emscripten
@@ -68,6 +70,16 @@ jobs:
           sudo apt upgrade -y # update clang14 to fix packaging conflicts
           sudo apt install -y clang-16 libc++-16-dev libc++abi-16-dev
           sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-16 110
+
+      - name: Install clang-17
+        if: matrix.configurations.compiler == 'clang17'
+        run: |
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main'
+          sudo apt update
+          sudo apt upgrade -y # update clang14 to fix packaging conflicts
+          sudo apt install -y clang-17 libc++-17-dev libc++abi-17-dev
+          sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 110
 
       - name: Install emscripten
         if: matrix.configurations.compiler == 'emscripten'
@@ -142,6 +154,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          test -f ~/emsdk/emsdk_env.sh && source ~/emsdk/emsdk_env.sh
           sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
         # Consult https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/sonarscanner-cli/ for more information and options

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,5 +12,5 @@ sonar.organization=fair-acc
 #sonar.sourceEncoding=UTF-8
 
 # exclude benchmark which crashes the Analysis
-sonar.exclusions=bench/bm_case1.cpp
+sonar.exclusions=core/benchmarks/bm_node_api.cpp
 sonar.coverageReportPaths=/home/runner/work/graph-prototype/build/coverage.xml


### PR DESCRIPTION
- add clang17
- also run on prs not targeted at main
- small cleanups
- emscripten: change from difficult to maintain hash (was a workaround to use the system nodejs) to proper releases

Updating emscripten from 3.1.43 (07/2023) to the latest release 3.1.46 (09/2023) yields compilation errors: https://github.com/fair-acc/graph-prototype/actions/runs/6454443002/job/17520001932 to be investigated