### PR TITLE
Updated syntax for connections, for ports in collections as well

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -87,29 +87,29 @@ protected:
     std::unique_ptr<gr::SettingsBase> _settings = std::make_unique<gr::BasicSettings<multi_adder<T>>>(*this);
 
     void
-    apply_input_count() {
+    applyInputCount() {
         if (_input_ports.size() == static_cast<std::size_t>(input_port_count)) return;
 
         _input_ports.resize(static_cast<std::size_t>(input_port_count));
 
-        _dynamic_input_ports.clear();
+        _dynamicInputPorts.clear();
         for (auto &input_port : _input_ports) {
-            _dynamic_input_ports.emplace_back(input_port, gr::DynamicPort::non_owned_reference_tag{});
+            _dynamicInputPorts.emplace_back(gr::DynamicPort(input_port, gr::DynamicPort::non_owned_reference_tag{}));
         }
-        if (_dynamic_output_ports.empty()) {
-            _dynamic_output_ports.emplace_back(_output_port, gr::DynamicPort::non_owned_reference_tag{});
+        if (_dynamicOutputPorts.empty()) {
+            _dynamicOutputPorts.emplace_back(gr::DynamicPort(_output_port, gr::DynamicPort::non_owned_reference_tag{}));
         }
-        _DynamicPorts_loaded = true;
+        _dynamicPortsLoaded = true;
     }
 
 public:
-    explicit multi_adder(int input_ports_size) : input_port_count(input_ports_size) { apply_input_count(); };
+    explicit multi_adder(int input_ports_size) : input_port_count(input_ports_size) { applyInputCount(); };
 
     ~multi_adder() override = default;
 
     void
     settingsChanged(const gr::property_map & /*old_setting*/, const gr::property_map & /*new_setting*/) noexcept {
-        apply_input_count();
+        applyInputCount();
     }
 
     void

--- a/blocks/basic/test/qa_selector.cpp
+++ b/blocks/basic/test/qa_selector.cpp
@@ -154,20 +154,26 @@ execute_selector_test(test_definition definition) {
                                                                                        { "identifier", source_index },                       //
                                                                                        { "values", definition.input_values[source_index] } })));
         expect(sources[source_index]->settings().applyStagedParameters().empty());
-        expect(gr::ConnectionResult::SUCCESS == graph.dynamic_connect(*sources[source_index], 0, *selector, source_index + 1 /* there's one port before the inputs */));
+        expect(gr::ConnectionResult::SUCCESS
+               == graph.connect(                                                   //
+                       *sources[source_index], { "out", gr::meta::invalid_index }, //
+                       *selector, { "inputs", source_index }));
     }
 
     for (std::uint32_t sink_index = 0; sink_index < sinks_count; ++sink_index) {
         sinks.push_back(std::addressof(graph.emplaceBlock<validator_sink<double>>({ { "identifier", sink_index }, //
                                                                                     { "expected_values", definition.output_values[sink_index] } })));
         expect(sinks[sink_index]->settings().applyStagedParameters().empty());
-        expect(gr::ConnectionResult::SUCCESS == graph.dynamic_connect(*selector, sink_index + 1 /* there's one port before the outputs */, *sinks[sink_index], 0));
+        expect(gr::ConnectionResult::SUCCESS
+               == graph.connect(                             //
+                       *selector, { "outputs", sink_index }, //
+                       *sinks[sink_index], { "in" }));
     }
 
     validator_sink<double> *monitor_sink = std::addressof(graph.emplaceBlock<validator_sink<double>>({ { "identifier", static_cast<std::uint32_t>(-1) }, //
                                                                                                        { "expected_values", definition.monitor_values } }));
     expect(monitor_sink->settings().applyStagedParameters().empty());
-    expect(gr::ConnectionResult::SUCCESS == graph.dynamic_connect(*selector, 0, *monitor_sink, 0));
+    expect(gr::ConnectionResult::SUCCESS == graph.connect(*selector, 0, *monitor_sink, 0));
 
     for (std::size_t iterration = 0; iterration < definition.value_count * sources_count; ++iterration) {
         const auto max = std::numeric_limits<std::size_t>::max();

--- a/blocks/fourier/test/qa_fourier.cpp
+++ b/blocks/fourier/test/qa_fourier.cpp
@@ -281,18 +281,17 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
         gr::Graph flow1;
         auto     &source1  = flow1.emplaceBlock<CountSource<double>>();
         auto     &fftBlock = flow1.emplaceBlock<FFT<double>>({ { "fftSize", static_cast<std::uint32_t>(16) } });
-        std::ignore        = flow1.connect<"out">(source1).to<"in">(fftBlock);
-        auto sched1        = Scheduler(std::move(flow1), threadPool);
+        expect(eq(gr::ConnectionResult::SUCCESS, flow1.connect<"out">(source1).to<"in">(fftBlock)));
+        auto sched1 = Scheduler(std::move(flow1), threadPool);
 
         // run 2 times to check potential memory problems
         for (int i = 0; i < 2; i++) {
             gr::Graph flow2;
             auto     &source2 = flow2.emplaceBlock<CountSource<double>>();
             auto     &fft2    = flow2.emplaceBlock<FFT<double>>({ { "fftSize", static_cast<std::uint32_t>(16) } });
-            std::ignore       = flow2.connect<"out">(source2).to<"in">(fft2);
-            auto sched2       = Scheduler(std::move(flow2), threadPool);
+            expect(eq(gr::ConnectionResult::SUCCESS, flow2.connect<"out">(source2).to<"in">(fft2)));
+            auto sched2 = Scheduler(std::move(flow2), threadPool);
             sched2.runAndWait();
-            expect(approx(source2.count, source2.nSamples, 1e-4));
         }
         sched1.runAndWait();
         expect(approx(source1.count, source1.nSamples, 1e-4));

--- a/core/benchmarks/bm_filter.cpp
+++ b/core/benchmarks/bm_filter.cpp
@@ -88,7 +88,7 @@ inline const boost::ut::suite _constexpr_bm = [] {
         auto     &src  = testGraph.emplaceBlock<::test::source<float>>(N_SAMPLES);
         auto     &sink = testGraph.emplaceBlock<::test::sink<float>>();
 
-        expect(eq(gr::connection_result_t::SUCCESS, testGraph.connect<"out">(src).to<"in">(sink)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(sink)));
 
         gr::scheduler::simple sched{ std::move(testGraph) };
 
@@ -101,8 +101,8 @@ inline const boost::ut::suite _constexpr_bm = [] {
         auto     &sink   = testGraph.emplaceBlock<::test::sink<float>>();
         auto     &filter = testGraph.emplaceBlock<fir_filter<float>>({ { "b", fir_coeffs } });
 
-        expect(eq(gr::connection_result_t::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
-        expect(eq(gr::connection_result_t::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
         gr::scheduler::simple sched{ std::move(testGraph) };
 
@@ -115,8 +115,8 @@ inline const boost::ut::suite _constexpr_bm = [] {
         auto     &sink   = testGraph.emplaceBlock<::test::sink<float>>();
         auto     &filter = testGraph.emplaceBlock<iir_filter<float, IIRForm::DF_I>>({ { "b", iir_coeffs_b }, { "a", iir_coeffs_a } });
 
-        expect(eq(gr::connection_result_t::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
-        expect(eq(gr::connection_result_t::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
         gr::scheduler::simple sched{ std::move(testGraph) };
 
@@ -129,8 +129,8 @@ inline const boost::ut::suite _constexpr_bm = [] {
         auto     &sink   = testGraph.emplaceBlock<::test::sink<float>>();
         auto     &filter = testGraph.emplaceBlock<iir_filter<float, IIRForm::DF_II>>({ { "b", iir_coeffs_b }, { "a", iir_coeffs_a } });
 
-        expect(eq(gr::connection_result_t::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
-        expect(eq(gr::connection_result_t::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect(src, &::test::source<float>::out).to<"in">(filter)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(filter).to(sink, &::test::sink<float>::in)));
 
         gr::scheduler::simple sched{ std::move(testGraph) };
 

--- a/core/benchmarks/bm_node_api.cpp
+++ b/core/benchmarks/bm_node_api.cpp
@@ -506,8 +506,8 @@ inline const boost::ut::suite _runtime_tests = [] {
         auto     &sink = testGraph.emplaceBlock<test::sink<float>>();
         auto     &cpy  = testGraph.emplaceBlock<copy<float>>();
 
-        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect(src, &test::source<float>::out).to<"in">(cpy)));
-        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(cpy).to(sink, &test::sink<float>::in)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(cpy)));
+        expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(cpy).to<"in">(sink)));
 
         gr::scheduler::Simple sched{ std::move(testGraph) };
 
@@ -527,7 +527,7 @@ inline const boost::ut::suite _runtime_tests = [] {
             if (i == 0) {
                 expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(*cpy[i])));
             } else {
-                expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect(*cpy[i - 1], &copy::out).to(*cpy[i], &copy::in)));
+                expect(eq(gr::ConnectionResult::SUCCESS, testGraph.connect<"out">(*cpy[i - 1]).to<"in">(*cpy[i])));
             }
         }
 

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -37,11 +37,17 @@ using namespace gr::literals;
 
 class BlockModel {
 protected:
-    using DynamicPorts                         = std::vector<gr::DynamicPort>;
-    bool                  _DynamicPorts_loaded = false;
-    std::function<void()> _DynamicPorts_loader;
-    DynamicPorts          _dynamic_input_ports;
-    DynamicPorts          _dynamic_output_ports;
+    struct NamedPortCollection {
+        std::string                  name;
+        std::vector<gr::DynamicPort> ports;
+    };
+
+    using DynamicPortOrCollection             = std::variant<gr::DynamicPort, NamedPortCollection>;
+    using DynamicPorts                        = std::vector<DynamicPortOrCollection>;
+    bool                  _dynamicPortsLoaded = false;
+    std::function<void()> _dynamicPortsLoader;
+    DynamicPorts          _dynamicInputPorts;
+    DynamicPorts          _dynamicOutputPorts;
 
     BlockModel() = default;
 
@@ -57,31 +63,113 @@ public:
 
     void
     initDynamicPorts() const {
-        if (!_DynamicPorts_loaded) _DynamicPorts_loader();
+        if (!_dynamicPortsLoaded) _dynamicPortsLoader();
     }
 
-    gr::DynamicPort &
-    dynamicInputPort(std::size_t index) { // TODO: do we need the 'dynamic' prefix here?
+    [[nodiscard]] gr::DynamicPort &
+    dynamicInputPort(std::size_t index, std::size_t subIndex = meta::invalid_index) {
         initDynamicPorts();
-        return _dynamic_input_ports.at(index);
+        if (auto *portCollection = std::get_if<NamedPortCollection>(&_dynamicInputPorts.at(index))) {
+            if (subIndex == meta::invalid_index) {
+                throw std::invalid_argument("Need to specify the index in the port collection");
+            } else {
+                return portCollection->ports[subIndex];
+            }
+
+        } else if (auto *port = std::get_if<gr::DynamicPort>(&_dynamicInputPorts.at(index))) {
+            if (subIndex == meta::invalid_index) {
+                return *port;
+            } else {
+                throw std::invalid_argument("Specified sub-index for a normal port");
+            }
+        }
+
+        throw std::logic_error("Variant construction failed");
     }
 
-    gr::DynamicPort &
-    dynamicOutputPort(std::size_t index) { // TODO: do we need the 'dynamic' prefix here?
+    [[nodiscard]] gr::DynamicPort &
+    dynamicOutputPort(std::size_t index, std::size_t subIndex = meta::invalid_index) {
         initDynamicPorts();
-        return _dynamic_output_ports.at(index);
+        if (auto *portCollection = std::get_if<NamedPortCollection>(&_dynamicOutputPorts.at(index))) {
+            if (subIndex == meta::invalid_index) {
+                throw std::invalid_argument("Need to specify the index in the port collection");
+            } else {
+                return portCollection->ports[subIndex];
+            }
+
+        } else if (auto *port = std::get_if<gr::DynamicPort>(&_dynamicOutputPorts.at(index))) {
+            if (subIndex == meta::invalid_index) {
+                return *port;
+            } else {
+                throw std::invalid_argument("Specified sub-index for a normal port");
+            }
+        }
+
+        throw std::logic_error("Variant construction failed");
     }
 
-    [[nodiscard]] auto
-    dynamicInputPortsSize() const { // TODO: return collection and rely on 'size()' of underlying collection
+    [[nodiscard]] std::size_t
+    dynamicInputPortsSize(std::size_t parentIndex = meta::invalid_index) const {
         initDynamicPorts();
-        return _dynamic_input_ports.size();
+        if (parentIndex == meta::invalid_index) {
+            return _dynamicInputPorts.size();
+        } else {
+            if (auto *portCollection = std::get_if<NamedPortCollection>(&_dynamicInputPorts.at(parentIndex))) {
+                return portCollection->ports.size();
+            } else {
+                return meta::invalid_index;
+            }
+        }
     }
 
-    [[nodiscard]] auto
-    dynamicOutputPortsSize() const { // TODO: return collection and rely on 'size()' of underlying collection
+    [[nodiscard]] std::size_t
+    dynamicOutputPortsSize(std::size_t parentIndex = meta::invalid_index) const {
         initDynamicPorts();
-        return _dynamic_output_ports.size();
+        if (parentIndex == meta::invalid_index) {
+            return _dynamicOutputPorts.size();
+        } else {
+            if (auto *portCollection = std::get_if<NamedPortCollection>(&_dynamicOutputPorts.at(parentIndex))) {
+                return portCollection->ports.size();
+            } else {
+                return meta::invalid_index;
+            }
+        }
+    }
+
+    std::size_t
+    dynamicInputPortIndex(std::string_view name) const {
+        initDynamicPorts();
+        for (std::size_t i = 0; i < _dynamicInputPorts.size(); ++i) {
+            if (auto *portCollection = std::get_if<NamedPortCollection>(&_dynamicInputPorts.at(i))) {
+                if (portCollection->name == name) {
+                    return i;
+                }
+            } else if (auto *port = std::get_if<gr::DynamicPort>(&_dynamicInputPorts.at(i))) {
+                if (port->name == name) {
+                    return i;
+                }
+            }
+        }
+
+        throw std::invalid_argument(fmt::format("Port {} does not exist", name));
+    }
+
+    std::size_t
+    dynamicOutputPortIndex(std::string_view name) const {
+        initDynamicPorts();
+        for (std::size_t i = 0; i < _dynamicOutputPorts.size(); ++i) {
+            if (auto *portCollection = std::get_if<NamedPortCollection>(&_dynamicOutputPorts.at(i))) {
+                if (portCollection->name == name) {
+                    return i;
+                }
+            } else if (auto *port = std::get_if<gr::DynamicPort>(&_dynamicOutputPorts.at(i))) {
+                if (port->name == name) {
+                    return i;
+                }
+            }
+        }
+
+        throw std::invalid_argument(fmt::format("Port {} does not exist", name));
     }
 
     virtual ~BlockModel() = default;
@@ -194,36 +282,53 @@ private:
 
     void
     createDynamicPortsLoader() {
-        _DynamicPorts_loader = [this] {
-            if (_DynamicPorts_loaded) return;
+        _dynamicPortsLoader = [this] {
+            if (_dynamicPortsLoaded) return;
 
-            using TBlock       = std::remove_cvref_t<decltype(blockRef())>;
+            using Node        = std::remove_cvref_t<decltype(blockRef())>;
 
-            auto register_port = []<typename PortOrCollection>(PortOrCollection &port_or_collection, auto &where) {
-                auto process_port = [&where]<typename Port>(Port &port) { where.push_back(gr::DynamicPort(port, DynamicPort::non_owned_reference_tag{})); };
+            auto registerPort = [&](auto &where, [[maybe_unused]] auto direction, [[maybe_unused]] auto index, auto &&t) {
+                auto processPort = []<typename Port>(auto &where_, Port &port) -> auto & {
+                    where_.push_back(gr::DynamicPort(port, DynamicPort::non_owned_reference_tag{}));
+                    return where_.back();
+                };
 
-                if constexpr (traits::port::is_port_v<PortOrCollection>) {
-                    process_port(port_or_collection);
-
+                using CurrentPortType = std::remove_cvref_t<decltype(t)>;
+                if constexpr (traits::port::is_port_v<CurrentPortType>) {
+                    using PortDescriptor = typename CurrentPortType::ReflDescriptor;
+                    if constexpr (refl::trait::is_descriptor_v<PortDescriptor>) {
+                        auto &port = (blockRef().*(PortDescriptor::pointer));
+                        processPort(where, port);
+                    } else {
+                        // We can also have ports defined as template parameters
+                        if constexpr (decltype(direction)::value == PortDirection::INPUT) {
+                            processPort(where, gr::inputPort<decltype(index)::value>(&blockRef()));
+                        } else {
+                            processPort(where, gr::outputPort<decltype(index)::value>(&blockRef()));
+                        }
+                    }
                 } else {
-                    for (auto &port : port_or_collection) {
-                        process_port(port);
+                    using PortCollectionDescriptor = typename CurrentPortType::value_type::ReflDescriptor;
+                    if constexpr (refl::trait::is_descriptor_v<PortCollectionDescriptor>) {
+                        auto               &collection = (blockRef().*(PortCollectionDescriptor::pointer));
+                        NamedPortCollection result;
+                        result.name = refl::descriptor::get_name(PortCollectionDescriptor()).data;
+                        for (auto &port : collection) {
+                            processPort(result.ports, port);
+                        }
+                        where.push_back(std::move(result));
+                    } else {
+                        static_assert(meta::always_false<PortCollectionDescriptor>, "Port collections are only supported for member variables");
                     }
                 }
             };
+            traits::block::input_ports<Node>::template apply_func(registerPort, _dynamicInputPorts, std::integral_constant<PortDirection, PortDirection::INPUT>{});
+            traits::block::output_ports<Node>::template apply_func(registerPort, _dynamicOutputPorts, std::integral_constant<PortDirection, PortDirection::OUTPUT>{});
 
-            constexpr std::size_t input_port_count = gr::traits::block::template input_port_types<TBlock>::size;
-            [this, register_port]<std::size_t... Is>(std::index_sequence<Is...>) {
-                (register_port(gr::inputPort<Is>(&blockRef()), this->_dynamic_input_ports), ...);
-            }(std::make_index_sequence<input_port_count>());
-
-            constexpr std::size_t output_port_count = gr::traits::block::template output_port_types<TBlock>::size;
-            [this, register_port]<std::size_t... Is>(std::index_sequence<Is...>) {
-                (register_port(gr::outputPort<Is>(&blockRef()), this->_dynamic_output_ports), ...);
-            }(std::make_index_sequence<output_port_count>());
-
+            constexpr std::size_t input_port_count  = gr::traits::block::template input_port_types<Node>::size;
+            constexpr std::size_t output_port_count = gr::traits::block::template output_port_types<Node>::size;
             static_assert(input_port_count + output_port_count > 0);
-            _DynamicPorts_loaded = true;
+            _dynamicPortsLoaded = true;
         };
     }
 
@@ -325,11 +430,11 @@ class edge {
 public: // TODO: consider making this private and to use accessors (that can be safely used by users)
     using PortDirection::INPUT;
     using PortDirection::OUTPUT;
-    BlockModel  *_src_block;
-    BlockModel  *_dst_block;
-    std::size_t  _src_port_index;
-    std::size_t  _dst_port_index;
-    std::size_t  _min_buffer_size;
+    BlockModel  *_sourceBlock;
+    BlockModel  *_destinationBlock;
+    std::size_t  _sourcePortIndex;
+    std::size_t  _destinationPortIndex;
+    std::size_t  _minBufferSize;
     std::int32_t _weight;
     std::string  _name; // custom edge name
     bool         _connected;
@@ -349,27 +454,33 @@ public:
     operator=(edge &&) noexcept
             = default;
 
-    edge(BlockModel *src_block, std::size_t src_port_index, BlockModel *dst_block, std::size_t dst_port_index, std::size_t min_buffer_size, std::int32_t weight, std::string_view name)
-        : _src_block(src_block), _dst_block(dst_block), _src_port_index(src_port_index), _dst_port_index(dst_port_index), _min_buffer_size(min_buffer_size), _weight(weight), _name(name) {}
+    edge(BlockModel *sourceBlock, std::size_t sourcePortIndex, BlockModel *destinationBlock, std::size_t destinationPortIndex, std::size_t minBufferSize, std::int32_t weight, std::string_view name)
+        : _sourceBlock(sourceBlock)
+        , _destinationBlock(destinationBlock)
+        , _sourcePortIndex(sourcePortIndex)
+        , _destinationPortIndex(destinationPortIndex)
+        , _minBufferSize(minBufferSize)
+        , _weight(weight)
+        , _name(name) {}
 
     [[nodiscard]] constexpr const BlockModel &
-    src_block() const noexcept {
-        return *_src_block;
+    sourceBlock() const noexcept {
+        return *_sourceBlock;
     }
 
     [[nodiscard]] constexpr const BlockModel &
-    dst_block() const noexcept {
-        return *_dst_block;
+    destinationBlock() const noexcept {
+        return *_destinationBlock;
     }
 
     [[nodiscard]] constexpr std::size_t
-    src_port_index() const noexcept {
-        return _src_port_index;
+    sourcePortIndex() const noexcept {
+        return _sourcePortIndex;
     }
 
     [[nodiscard]] constexpr std::size_t
-    dst_port_index() const noexcept {
-        return _dst_port_index;
+    destinationPortIndex() const noexcept {
+        return _destinationPortIndex;
     }
 
     [[nodiscard]] constexpr std::string_view
@@ -378,8 +489,8 @@ public:
     }
 
     [[nodiscard]] constexpr std::size_t
-    min_buffer_size() const noexcept {
-        return _min_buffer_size;
+    minBufferSize() const noexcept {
+        return _minBufferSize;
     }
 
     [[nodiscard]] constexpr std::int32_t
@@ -399,7 +510,7 @@ struct Graph {
             "graph_thread_pool", gr::thread_pool::TaskType::IO_BOUND, 2_UZ, std::numeric_limits<uint32_t>::max());
 
 private:
-    std::vector<std::function<ConnectionResult(Graph &)>> _connection_definitions;
+    std::vector<std::function<ConnectionResult(Graph &)>> _connectionDefinitions;
     std::vector<std::unique_ptr<BlockModel>>              _blocks;
     std::vector<edge>                                     _edges;
 
@@ -409,53 +520,60 @@ private:
         static_assert(!std::is_pointer_v<std::remove_cvref_t<TBlock>>);
         auto it = [&, this] {
             if constexpr (std::is_same_v<TBlock, BlockModel>) {
-                return std::find_if(_blocks.begin(), _blocks.end(), [&](const auto &node) { return node.get() == &what; });
+                return std::find_if(_blocks.begin(), _blocks.end(), [&](const auto &block) { return block.get() == &what; });
             } else {
-                return std::find_if(_blocks.begin(), _blocks.end(), [&](const auto &node) { return node->raw() == &what; });
+                return std::find_if(_blocks.begin(), _blocks.end(), [&](const auto &block) { return block->raw() == &what; });
             }
         }();
 
-        if (it == _blocks.end()) throw std::runtime_error(fmt::format("No such node in this graph"));
+        if (it == _blocks.end()) throw std::runtime_error(fmt::format("No such block in this graph"));
         return *it;
     }
 
-    template<typename TBlock>
-    [[nodiscard]] DynamicPort &
-    dynamicOutputPort(TBlock &node, std::size_t index) {
-        return findBlock(node)->dynamicOutputPort(index);
-    }
-
-    template<typename TBlock>
-    [[nodiscard]] DynamicPort &
-    dynamicInputPort(TBlock &node, std::size_t index) {
-        return findBlock(node)->dynamicInputPort(index);
-    }
-
-    template<std::size_t src_port_index, std::size_t dst_port_index, typename Source, typename SourcePort, typename Destination, typename DestinationPort>
+    template<std::size_t sourcePortIndex, std::size_t sourcePortSubIndex, std::size_t destinationPortIndex, std::size_t destinationPortSubIndex, typename Source, typename SourcePort,
+             typename Destination, typename DestinationPort>
     [[nodiscard]] ConnectionResult
-    connectImpl(Source &src_block_raw, SourcePort &source_port, Destination &dst_block_raw, DestinationPort &destination_port, std::size_t min_buffer_size = 65536, std::int32_t weight = 0,
-                std::string_view name = "unnamed edge") {
-        static_assert(std::is_same_v<typename SourcePort::value_type, typename DestinationPort::value_type>, "The source port type needs to match the sink port type");
-
-        if (!std::any_of(_blocks.begin(), _blocks.end(), [&](const auto &registered_block) { return registered_block->raw() == std::addressof(src_block_raw); })
-            || !std::any_of(_blocks.begin(), _blocks.end(), [&](const auto &registered_block) { return registered_block->raw() == std::addressof(dst_block_raw); })) {
-            throw std::runtime_error(fmt::format("Can not connect nodes that are not registered first:\n {}:{} -> {}:{}\n", src_block_raw.name, src_port_index, dst_block_raw.name, dst_port_index));
+    connectImpl(Source &sourceNodeRaw, SourcePort &source_port_or_collection, Destination &destinationNodeRaw, DestinationPort &destinationPort_or_collection, std::size_t minBufferSize = 65536,
+                std::int32_t weight = 0, std::string_view name = "unnamed edge") {
+        if (!std::any_of(_blocks.begin(), _blocks.end(), [&](const auto &registeredNode) { return registeredNode->raw() == std::addressof(sourceNodeRaw); })
+            || !std::any_of(_blocks.begin(), _blocks.end(), [&](const auto &registeredNode) { return registeredNode->raw() == std::addressof(destinationNodeRaw); })) {
+            throw std::runtime_error(
+                    fmt::format("Can not connect nodes that are not registered first:\n {}:{} -> {}:{}\n", sourceNodeRaw.name, sourcePortIndex, destinationNodeRaw.name, destinationPortIndex));
         }
 
-        auto result = source_port.connect(destination_port);
+        auto *sourcePort = [&] {
+            if constexpr (traits::port::is_port_v<SourcePort>) {
+                return &source_port_or_collection;
+            } else {
+                return &source_port_or_collection[sourcePortSubIndex];
+            }
+        }();
+
+        auto *destinationPort = [&] {
+            if constexpr (traits::port::is_port_v<DestinationPort>) {
+                return &destinationPort_or_collection;
+            } else {
+                return &destinationPort_or_collection[destinationPortSubIndex];
+            }
+        }();
+
+        static_assert(std::is_same_v<typename std::remove_pointer_t<decltype(destinationPort)>::value_type, typename std::remove_pointer_t<decltype(sourcePort)>::value_type>,
+                      "The source port type needs to match the sink port type");
+
+        auto result = sourcePort->connect(*destinationPort);
         if (result == ConnectionResult::SUCCESS) {
-            auto *src_block = findBlock(src_block_raw).get();
-            auto *dst_block = findBlock(dst_block_raw).get();
-            _edges.emplace_back(src_block, src_port_index, dst_block, src_port_index, min_buffer_size, weight, name);
+            auto *sourceNode      = findBlock(sourceNodeRaw).get();
+            auto *destinationNode = findBlock(destinationNodeRaw).get();
+            _edges.emplace_back(sourceNode, sourcePortIndex, destinationNode, sourcePortIndex, minBufferSize, weight, name);
         }
 
         return result;
     }
 
-    // Just a dummy class that stores the graph and the source node and port
+    // Just a dummy class that stores the graph and the source block and port
     // to be able to split the connection into two separate calls
     // connect(source) and .to(destination)
-    template<typename Source, typename Port, std::size_t src_port_index = 1_UZ>
+    template<typename Source, typename Port, std::size_t sourcePortIndex = 1_UZ, std::size_t sourcePortSubIndex = meta::invalid_index>
     struct SourceConnector {
         Graph  &self;
         Source &source;
@@ -463,49 +581,63 @@ private:
 
         SourceConnector(Graph &_self, Source &_source, Port &_port) : self(_self), source(_source), port(_port) {}
 
+        static_assert(traits::port::is_port_v<Port> || (sourcePortSubIndex != meta::invalid_index),
+                      "When we have a collection of ports, we need to have an index to access the desired port in the collection");
+
     private:
-        template<typename Destination, typename DestinationPort, std::size_t dst_port_index = meta::invalid_index>
-        [[nodiscard]] constexpr auto
-        to(Destination &destination, DestinationPort &destination_port) {
-            // Not overly efficient as the node doesn't know the graph it belongs to,
+        template<typename Destination, typename DestinationPort, std::size_t destinationPortIndex = meta::invalid_index, std::size_t destinationPortSubIndex = meta::invalid_index>
+        [[nodiscard]] constexpr ConnectionResult
+        to(Destination &destination, DestinationPort &destinationPort) {
+            // Not overly efficient as the block doesn't know the graph it belongs to,
             // but this is not a frequent operation and the check is important.
             auto is_block_known = [this](const auto &query_block) {
                 return std::any_of(self._blocks.cbegin(), self._blocks.cend(), [&query_block](const auto &known_block) { return known_block->raw() == std::addressof(query_block); });
             };
             if (!is_block_known(source) || !is_block_known(destination)) {
-                throw fmt::format("Source {} and/or destination {} do not belong to this graph\n", source.name, destination.name);
+                fmt::print("Source {} and/or destination {} do not belong to this graph\n", source.name, destination.name);
+                return ConnectionResult::FAILED;
             }
-            self._connection_definitions.push_back([source_ = &source, source_port = &port, destination = &destination, destination_port = &destination_port](Graph &graph) {
-                return graph.connectImpl<src_port_index, dst_port_index>(*source_, *source_port, *destination, *destination_port);
+            self._connectionDefinitions.push_back([source = &source, source_port = &port, destination = &destination, destinationPort = &destinationPort](Graph &graph) {
+                return graph.connectImpl<sourcePortIndex, sourcePortSubIndex, destinationPortIndex, destinationPortSubIndex>(*source, *source_port, *destination, *destinationPort);
             });
             return ConnectionResult::SUCCESS;
         }
 
     public:
-        template<typename Destination, typename DestinationPort, std::size_t dst_port_index = meta::invalid_index>
-        [[nodiscard]] constexpr auto
-        to(Destination &destination, DestinationPort Destination::*member_ptr) {
-            return to<Destination, DestinationPort, dst_port_index>(destination, std::invoke(member_ptr, destination));
+        // connect using the port index
+
+        template<std::size_t destinationPortIndex, std::size_t destinationPortSubIndex, typename Destination>
+        [[nodiscard, deprecated("For internal use only, the the with the port name should be used")]] auto
+        to(Destination &destination) {
+            auto &destinationPort = inputPort<destinationPortIndex>(&destination);
+            return to<Destination, std::remove_cvref_t<decltype(destinationPort)>, destinationPortIndex, destinationPortSubIndex>(destination, destinationPort);
         }
 
-        template<std::size_t dst_port_index, typename Destination>
-        [[nodiscard]] constexpr auto
+        template<std::size_t destinationPortIndex, typename Destination>
+        [[nodiscard, deprecated("For internal use only, the the with the port name should be used")]] auto
         to(Destination &destination) {
-            auto &destination_port = inputPort<dst_port_index>(&destination);
-            return to<Destination, std::remove_cvref_t<decltype(destination_port)>, dst_port_index>(destination, destination_port);
+            return to<destinationPortIndex, meta::invalid_index, Destination>(destination);
         }
 
-        template<fixed_string dst_port_name, typename Destination>
+        // connect using the port name
+
+        template<fixed_string destinationPortName, std::size_t destinationPortSubIndex, typename Destination>
         [[nodiscard]] constexpr auto
         to(Destination &destination) {
-            using destination_input_ports        = typename traits::block::input_ports<Destination>;
-            constexpr std::size_t dst_port_index = meta::indexForName<dst_port_name, destination_input_ports>();
-            if constexpr (dst_port_index == meta::invalid_index) {
-                meta::print_types<meta::message_type<"There is no input port with the specified name in this destination node">, Destination, meta::message_type<dst_port_name>,
+            using destination_input_ports              = typename traits::block::input_ports<Destination>;
+            constexpr std::size_t destinationPortIndex = meta::indexForName<destinationPortName, destination_input_ports>();
+            if constexpr (destinationPortIndex == meta::invalid_index) {
+                meta::print_types<meta::message_type<"There is no input port with the specified name in this destination block">, Destination, meta::message_type<destinationPortName>,
                                   meta::message_type<"These are the known names:">, traits::block::input_port_names<Destination>, meta::message_type<"Full ports info:">, destination_input_ports>
                         port_not_found_error{};
             }
-            return to<dst_port_index, Destination>(destination);
+            return to<destinationPortIndex, destinationPortSubIndex, Destination>(destination);
+        }
+
+        template<fixed_string destinationPortName, typename Destination>
+        [[nodiscard]] constexpr auto
+        to(Destination &destination) {
+            return to<destinationPortName, meta::invalid_index, Destination>(destination);
         }
 
         SourceConnector(const SourceConnector &) = delete;
@@ -517,18 +649,6 @@ private:
         operator=(SourceConnector &&)
                 = delete;
     };
-
-    template<std::size_t src_port_index, typename Source>
-    friend auto
-    connect(Source &source);
-
-    template<fixed_string src_port_name, typename Source>
-    friend auto
-    connect(Source &source);
-
-    template<typename Source, typename Port>
-    friend auto
-    connect(Source &source, Port Source::*member_ptr);
 
 public:
     Graph(Graph &)  = delete;
@@ -586,54 +706,85 @@ public:
         return *raw_ref;
     }
 
-    template<std::size_t src_port_index, typename Source>
-    [[nodiscard]] auto
+    // connect using the port index
+
+    template<std::size_t sourcePortIndex, std::size_t sourcePortSubIndex, typename Source>
+    [[nodiscard, deprecated("For internal use only, the connect with the port name should be used")]] auto
     connect(Source &source) {
-        auto &port = outputPort<src_port_index>(&source);
-        return Graph::SourceConnector<Source, std::remove_cvref_t<decltype(port)>, src_port_index>(*this, source, port);
+        auto &port_or_collection = outputPort<sourcePortIndex>(&source);
+        return SourceConnector<Source, std::remove_cvref_t<decltype(port_or_collection)>, sourcePortIndex, sourcePortSubIndex>(*this, source, port_or_collection);
     }
 
-    template<fixed_string src_port_name, typename Source>
+    template<std::size_t sourcePortIndex, typename Source>
+    [[nodiscard, deprecated("For internal use only, the connect with the port name should be used")]] auto
+    connect(Source &source) {
+        return connect<sourcePortIndex, meta::invalid_index, Source>(source);
+    }
+
+    // connect using the port name
+
+    template<fixed_string sourcePortName, std::size_t sourcePortSubIndex, typename Source>
     [[nodiscard]] auto
     connect(Source &source) {
-        using source_output_ports            = typename traits::block::output_ports<Source>;
-        constexpr std::size_t src_port_index = meta::indexForName<src_port_name, source_output_ports>();
-        if constexpr (src_port_index == meta::invalid_index) {
-            meta::print_types<meta::message_type<"There is no output port with the specified name in this source node">, Source, meta::message_type<src_port_name>,
+        using source_output_ports             = typename traits::block::output_ports<Source>;
+        constexpr std::size_t sourcePortIndex = meta::indexForName<sourcePortName, source_output_ports>();
+        if constexpr (sourcePortIndex == meta::invalid_index) {
+            meta::print_types<meta::message_type<"There is no output port with the specified name in this source block">, Source, meta::message_type<sourcePortName>,
                               meta::message_type<"These are the known names:">, traits::block::output_port_names<Source>, meta::message_type<"Full ports info:">, source_output_ports>
                     port_not_found_error{};
         }
-        return connect<src_port_index, Source>(source);
+        return connect<sourcePortIndex, sourcePortSubIndex, Source>(source);
     }
 
-    template<typename Source, typename Port>
+    template<fixed_string sourcePortName, typename Source>
     [[nodiscard]] auto
-    connect(Source &source, Port Source::*member_ptr) {
-        return Graph::SourceConnector<Source, Port>(*this, source, std::invoke(member_ptr, source));
+    connect(Source &source) {
+        return connect<sourcePortName, meta::invalid_index, Source>(source);
+    }
+
+    template<typename T>
+    struct PortIndexDefinition {
+        T           topLevel;
+        std::size_t subIndex;
+
+        PortIndexDefinition(T _topLevel, std::size_t _subIndex = meta::invalid_index) : topLevel(std::move(_topLevel)), subIndex(_subIndex) {}
+    };
+
+    template<typename Source, typename Destination>
+        requires(!std::is_pointer_v<std::remove_cvref_t<Source>> && !std::is_pointer_v<std::remove_cvref_t<Destination>>)
+    ConnectionResult
+    connect(Source &sourceBlockRaw, PortIndexDefinition<std::size_t> sourcePortDefinition, Destination &destinationBlockRaw, PortIndexDefinition<std::size_t> destinationPortDefinition,
+            std::size_t minBufferSize = 65536, std::int32_t weight = 0, std::string_view name = "unnamed edge") {
+        auto result = findBlock(sourceBlockRaw)
+                              ->dynamicOutputPort(sourcePortDefinition.topLevel, sourcePortDefinition.subIndex)
+                              .connect(findBlock(destinationBlockRaw)->dynamicInputPort(destinationPortDefinition.topLevel, destinationPortDefinition.subIndex));
+        if (result == ConnectionResult::SUCCESS) {
+            auto *sourceBlock      = findBlock(sourceBlockRaw).get();
+            auto *destinationBlock = findBlock(destinationBlockRaw).get();
+            _edges.emplace_back(sourceBlock, sourcePortDefinition.topLevel, destinationBlock, destinationPortDefinition.topLevel, minBufferSize, weight, name);
+        }
+        return result;
     }
 
     template<typename Source, typename Destination>
         requires(!std::is_pointer_v<std::remove_cvref_t<Source>> && !std::is_pointer_v<std::remove_cvref_t<Destination>>)
     ConnectionResult
-    dynamic_connect(Source &src_block_raw, std::size_t src_port_index, Destination &dst_block_raw, std::size_t dst_port_index, std::size_t min_buffer_size = 65536, std::int32_t weight = 0,
-                    std::string_view name = "unnamed edge") {
-        auto result = dynamicOutputPort(src_block_raw, src_port_index).connect(dynamicInputPort(dst_block_raw, dst_port_index));
-        if (result == ConnectionResult::SUCCESS) {
-            auto *src_block = findBlock(src_block_raw).get();
-            auto *dst_block = findBlock(dst_block_raw).get();
-            _edges.emplace_back(src_block, src_port_index, dst_block, src_port_index, min_buffer_size, weight, name);
+    connect(Source &sourceBlockRaw, PortIndexDefinition<std::string> sourcePortDefinition, Destination &destinationBlockRaw, PortIndexDefinition<std::string> destinationPortDefinition,
+            std::size_t minBufferSize = 65536, std::int32_t weight = 0, std::string_view name = "unnamed edge") {
+        auto sourcePortIndex      = this->findBlock(sourceBlockRaw)->dynamicOutputPortIndex(sourcePortDefinition.topLevel);
+        auto destinationPortIndex = this->findBlock(destinationBlockRaw)->dynamicInputPortIndex(destinationPortDefinition.topLevel);
+        return connect(sourceBlockRaw, { sourcePortIndex, sourcePortDefinition.subIndex }, destinationBlockRaw, { destinationPortIndex, destinationPortDefinition.subIndex }, minBufferSize, weight,
+                       name);
+    }
+
+    bool
+    performConnections() {
+        auto result = std::all_of(_connectionDefinitions.begin(), _connectionDefinitions.end(),
+                                  [this](auto &connection_definition) { return connection_definition(*this) == ConnectionResult::SUCCESS; });
+        if (result) {
+            _connectionDefinitions.clear();
         }
         return result;
-    }
-
-    const std::vector<std::function<ConnectionResult(Graph &)>> &
-    connections() {
-        return _connection_definitions;
-    }
-
-    void
-    clearConnections() {
-        _connection_definitions.clear();
     }
 
     template<typename F> // TODO: F must be constraint by a descriptive concept
@@ -776,7 +927,7 @@ public:
 
     constexpr MergedGraph(Left l, Right r) : left(std::move(l)), right(std::move(r)) {}
 
-    // if the left node (source) implements available_samples (a customization point), then pass the call through
+    // if the left block (source) implements available_samples (a customization point), then pass the call through
     friend constexpr std::size_t
     available_samples(const MergedGraph &self) noexcept
         requires requires(const Left &l) {
@@ -827,7 +978,7 @@ public:
         // the caller expects to process *one* sample (no inputs for the caller to explicitly
         // request simd), and we process more, we risk inconsistencies.
         if constexpr (traits::block::output_port_types<Left>::size == 1) {
-            // only the result from the right node needs to be returned
+            // only the result from the right block needs to be returned
             return apply_right<InId, traits::block::input_port_types<Right>::size() - InId - 1>(offset, std::forward_as_tuple(std::forward<Ts>(inputs)...),
                                                                                                 apply_left<traits::block::input_port_types<Left>::size()>(offset, std::forward_as_tuple(
                                                                                                                                                                           std::forward<Ts>(inputs)...)));

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -158,7 +158,7 @@ load_grc(plugin_loader &loader, const std::string &yaml_source) {
         auto src = parseBlock_port(connection[0], connection[1]);
         auto dst = parseBlock_port(connection[2], connection[3]);
 
-        testGraph.dynamic_connect(*src.block_it->second, src.port, *dst.block_it->second, dst.port);
+        testGraph.connect(*src.block_it->second, src.port, *dst.block_it->second, dst.port);
     }
 
     return testGraph;
@@ -215,8 +215,8 @@ save_grc(const gr::Graph &testGraph) {
             auto            write_edge = [&](const auto &edge) {
                 out << YAML::Flow;
                 detail::YamlSeq seq(out);
-                out << edge.src_block().name().data() << std::to_string(edge.src_port_index());
-                out << edge.dst_block().name().data() << std::to_string(edge.dst_port_index());
+                out << edge.sourceBlock().name().data() << std::to_string(edge.sourcePortIndex());
+                out << edge.destinationBlock().name().data() << std::to_string(edge.destinationPortIndex());
             };
 
             testGraph.forEachEdge(write_edge);

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -94,9 +94,8 @@ public:
         if (_state != IDLE) {
             return;
         }
-        auto result = std::all_of(_graph.connections().begin(), _graph.connections().end(), [this](auto &connection_definition) { return connection_definition(_graph) == ConnectionResult::SUCCESS; });
+        const auto result = _graph.performConnections();
         if (result) {
-            _graph.clearConnections();
             _state = INITIALISED;
         } else {
             _state = ERROR;
@@ -305,9 +304,9 @@ public:
         // compute the adjacency list
         std::set<block_t> block_reached;
         for (auto &e : this->_graph.edges()) {
-            _adjacency_list[e._src_block].push_back(e._dst_block);
-            _source_blocks.push_back(e._src_block);
-            block_reached.insert(e._dst_block);
+            _adjacency_list[e._sourceBlock].push_back(e._destinationBlock);
+            _source_blocks.push_back(e._sourceBlock);
+            block_reached.insert(e._destinationBlock);
         }
         _source_blocks.erase(std::remove_if(_source_blocks.begin(), _source_blocks.end(), [&block_reached](auto currentBlock) { return block_reached.contains(currentBlock); }), _source_blocks.end());
         // traverse graph

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -38,6 +38,7 @@ add_ut_test(qa_Scheduler)
 add_ut_test(qa_reader_writer_lock)
 add_ut_test(qa_Settings)
 add_ut_test(qa_Tags)
+add_ut_test(qa_port_array)
 add_ut_test(qa_thread_affinity)
 add_ut_test(qa_thread_pool)
 

--- a/core/test/app_grc.cpp
+++ b/core/test/app_grc.cpp
@@ -81,7 +81,9 @@ main(int argc, char *argv[]) {
 
         [[maybe_unused]] auto collect_edges = [](grg::Graph &graph) {
             std::set<std::string> result;
-            graph.forEachEdge([&](const auto &edge) { result.insert(fmt::format("{}#{} - {}#{}", edge.src_block().name(), edge.src_port_index(), edge.dst_block().name(), edge.dst_port_index())); });
+            graph.forEachEdge([&](const auto &edge) {
+                result.insert(fmt::format("{}#{} - {}#{}", edge.sourceBlock().name(), edge.sourcePortIndex(), edge.destinationBlock().name(), edge.destinationPortIndex()));
+            });
             return result;
         };
 

--- a/core/test/app_plugins_test.cpp
+++ b/core/test/app_plugins_test.cpp
@@ -88,10 +88,10 @@ main(int argc, char *argv[]) {
     assert(block_sink_load);
     auto &block_sink                    = testGraph.addBlock(std::move(block_sink_load));
 
-    auto  connection_1 [[maybe_unused]] = testGraph.dynamic_connect(block_source, 0, block_multiply_1, 0);
-    auto  connection_2 [[maybe_unused]] = testGraph.dynamic_connect(block_multiply_1, 0, block_multiply_2, 0);
-    auto  connection_3 [[maybe_unused]] = testGraph.dynamic_connect(block_multiply_2, 0, block_counter, 0);
-    auto  connection_4 [[maybe_unused]] = testGraph.dynamic_connect(block_counter, 0, block_sink, 0);
+    auto  connection_1 [[maybe_unused]] = testGraph.connect(block_source, 0, block_multiply_1, 0);
+    auto  connection_2 [[maybe_unused]] = testGraph.connect(block_multiply_1, 0, block_multiply_2, 0);
+    auto  connection_3 [[maybe_unused]] = testGraph.connect(block_multiply_2, 0, block_counter, 0);
+    auto  connection_4 [[maybe_unused]] = testGraph.connect(block_counter, 0, block_sink, 0);
 
     assert(connection_1 == grg::ConnectionResult::SUCCESS);
     assert(connection_2 == grg::ConnectionResult::SUCCESS);

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -118,8 +118,8 @@ interpolation_decimation_test(const IntDecTestData &data, std::shared_ptr<gr::th
     if (data.out_port_max >= 0) int_dec_block.out.max_samples = static_cast<size_t>(data.out_port_max);
     if (data.out_port_min >= 0) int_dec_block.out.min_samples = static_cast<size_t>(data.out_port_min);
 
-    std::ignore = flow.connect<"out">(source).to<"in">(int_dec_block);
-    auto sched  = scheduler(std::move(flow), thread_pool);
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(int_dec_block)));
+    auto sched = scheduler(std::move(flow), thread_pool);
     sched.runAndWait();
 
     expect(eq(int_dec_block.status.process_counter, data.exp_counter)) << "processBulk invokes counter, parameters = " << data.to_string();
@@ -146,8 +146,8 @@ stride_test(const StrideTestData &data, std::shared_ptr<gr::thread_pool::BasicTh
     if (data.in_port_max >= 0) int_dec_block.in.max_samples = static_cast<size_t>(data.in_port_max);
     if (data.in_port_min >= 0) int_dec_block.in.min_samples = static_cast<size_t>(data.in_port_min);
 
-    std::ignore = flow.connect<"out">(source).to<"in">(int_dec_block);
-    auto sched  = scheduler(std::move(flow), thread_pool);
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(int_dec_block)));
+    auto sched = scheduler(std::move(flow), thread_pool);
     sched.runAndWait();
 
     expect(eq(int_dec_block.status.process_counter, data.exp_counter)) << "processBulk invokes counter, parameters = " << data.to_string();

--- a/core/test/qa_DynamicBlock.cpp
+++ b/core/test/qa_DynamicBlock.cpp
@@ -26,6 +26,8 @@ struct fixed_source : public gr::Block<fixed_source<T>, gr::PortOutNamed<T, "out
 };
 
 static_assert(gr::BlockLike<fixed_source<int>>);
+static_assert(gr::traits::block::input_ports<fixed_source<int>>::size() == 0);
+static_assert(gr::traits::block::output_ports<fixed_source<int>>::size() == 1);
 
 template<typename T>
 struct cout_sink : public gr::Block<cout_sink<T>, gr::PortInNamed<T, "in">> {
@@ -66,10 +68,10 @@ main() {
     for (std::size_t i = 0; i < sources_count; ++i) {
         auto &source = testGraph.emplaceBlock<fixed_source<double>>();
         sources.push_back(&source);
-        testGraph.dynamic_connect(source, 0, adder, sources.size() - 1);
+        testGraph.connect(source, 0, adder, sources.size() - 1);
     }
 
-    testGraph.dynamic_connect(adder, 0, sink, 0);
+    testGraph.connect(adder, 0, sink, 0);
 
     for (std::size_t i = 0; i < events_count; ++i) {
         for (auto *source : sources) {

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -115,6 +115,7 @@ gr::Graph
 get_graph_linear(tracer &trace) {
     using gr::PortDirection::INPUT;
     using gr::PortDirection::OUTPUT;
+    using namespace boost::ut;
 
     // Blocks need to be alive for as long as the flow is
     gr::Graph flow;
@@ -124,9 +125,9 @@ get_graph_linear(tracer &trace) {
     auto &scale_block2 = flow.emplaceBlock<scale<int, 4>>(trace, "mult2");
     auto &sink         = flow.emplaceBlock<expect_sink<int, 100000>>(trace, "out", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 8 * count); });
 
-    std::ignore        = flow.connect<"scaled">(scale_block2).to<"in">(sink);
-    std::ignore        = flow.connect<"scaled">(scale_block1).to<"original">(scale_block2);
-    std::ignore        = flow.connect<"out">(source1).to<"original">(scale_block1);
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"scaled">(scale_block2).to<"in">(sink)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"scaled">(scale_block1).to<"original">(scale_block2)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source1).to<"original">(scale_block1)));
 
     return flow;
 }
@@ -135,6 +136,7 @@ gr::Graph
 get_graph_parallel(tracer &trace) {
     using gr::PortDirection::INPUT;
     using gr::PortDirection::OUTPUT;
+    using namespace boost::ut;
 
     // Blocks need to be alive for as long as the flow is
     gr::Graph flow;
@@ -147,12 +149,12 @@ get_graph_parallel(tracer &trace) {
     auto &scale_block2b = flow.emplaceBlock<scale<int, 5>>(trace, "mult2b");
     auto &sink_b        = flow.emplaceBlock<expect_sink<int, 100000>>(trace, "outb", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == 15 * count); });
 
-    std::ignore         = flow.connect<"scaled">(scale_block1a).to<"original">(scale_block2a);
-    std::ignore         = flow.connect<"scaled">(scale_block1b).to<"original">(scale_block2b);
-    std::ignore         = flow.connect<"scaled">(scale_block2b).to<"in">(sink_b);
-    std::ignore         = flow.connect<"out">(source1).to<"original">(scale_block1a);
-    std::ignore         = flow.connect<"scaled">(scale_block2a).to<"in">(sink_a);
-    std::ignore         = flow.connect<"out">(source1).to<"original">(scale_block1b);
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"scaled">(scale_block1a).to<"original">(scale_block2a)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"scaled">(scale_block1b).to<"original">(scale_block2b)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"scaled">(scale_block2b).to<"in">(sink_b)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source1).to<"original">(scale_block1a)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"scaled">(scale_block2a).to<"in">(sink_a)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source1).to<"original">(scale_block1b)));
 
     return flow;
 }
@@ -177,6 +179,7 @@ gr::Graph
 get_graph_scaled_sum(tracer &trace) {
     using gr::PortDirection::INPUT;
     using gr::PortDirection::OUTPUT;
+    using namespace boost::ut;
 
     // Blocks need to be alive for as long as the flow is
     gr::Graph flow;
@@ -188,10 +191,10 @@ get_graph_scaled_sum(tracer &trace) {
     auto &add_block   = flow.emplaceBlock<adder<int>>(trace, "add");
     auto &sink        = flow.emplaceBlock<expect_sink<int, 100000>>(trace, "out", [](std::uint64_t count, std::uint64_t data) { boost::ut::expect(boost::ut::that % data == (2 * count) + count); });
 
-    std::ignore       = flow.connect<"out">(source1).to<"original">(scale_block);
-    std::ignore       = flow.connect<"scaled">(scale_block).to<"addend0">(add_block);
-    std::ignore       = flow.connect<"out">(source2).to<"addend1">(add_block);
-    std::ignore       = flow.connect<"sum">(add_block).to<"in">(sink);
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source1).to<"original">(scale_block)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"scaled">(scale_block).to<"addend0">(add_block)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(source2).to<"addend1">(add_block)));
+    expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"sum">(add_block).to<"in">(sink)));
 
     return flow;
 }

--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -177,11 +177,11 @@ const boost::ut::suite BasicPluginBlocksConnectionTests = [] {
         auto  block_sink_load            = context().loader.instantiate(names::cout_sink, "double", block_sink_params);
         auto &block_sink                 = testGraph.addBlock(std::move(block_sink_load));
 
-        auto  connection_1               = testGraph.dynamic_connect(block_source, 0, block_multiply_double, 0);
-        auto  connection_2               = testGraph.dynamic_connect(block_multiply_double, 0, block_convert_to_float, 0);
-        auto  connection_3               = testGraph.dynamic_connect(block_convert_to_float, 0, block_multiply_float, 0);
-        auto  connection_4               = testGraph.dynamic_connect(block_multiply_float, 0, block_convert_to_double, 0);
-        auto  connection_5               = testGraph.dynamic_connect(block_convert_to_double, 0, block_sink, 0);
+        auto  connection_1               = testGraph.connect(block_source, 0, block_multiply_double, 0);
+        auto  connection_2               = testGraph.connect(block_multiply_double, 0, block_convert_to_float, 0);
+        auto  connection_3               = testGraph.connect(block_convert_to_float, 0, block_multiply_float, 0);
+        auto  connection_4               = testGraph.connect(block_multiply_float, 0, block_convert_to_double, 0);
+        auto  connection_5               = testGraph.connect(block_convert_to_double, 0, block_sink, 0);
 
         expect(connection_1 == grg::ConnectionResult::SUCCESS);
         expect(connection_2 == grg::ConnectionResult::SUCCESS);

--- a/core/test/qa_port_array.cpp
+++ b/core/test/qa_port_array.cpp
@@ -1,0 +1,241 @@
+#include <boost/ut.hpp>
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/meta/utils.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+
+#include <unordered_set>
+#include <vector>
+
+using namespace gr::literals;
+using namespace std::string_literals;
+
+template<typename T>
+struct RepeatedSource : public gr::Block<RepeatedSource<T>> {
+    std::uint32_t  identifier = 0;
+    std::uint32_t  remaining_events_count;
+    std::vector<T> values;
+    std::size_t    values_next = 0;
+
+    gr::PortOut<T> out;
+
+    void
+    settingsChanged(const gr::property_map & /*old_settings*/, const gr::property_map &new_settings) noexcept {}
+
+    gr::work::Result
+    work(std::size_t requested_work) {
+        if (values.empty()) {
+            fmt::print("Values vector is empty\n");
+            return { requested_work, 0UL, gr::work::Status::DONE };
+        }
+        if (values_next == values.size()) {
+            values_next = 0;
+        }
+
+        if (remaining_events_count != 0) {
+            auto &port   = gr::outputPort<0>(this);
+            auto &writer = port.streamWriter();
+            auto  data   = writer.reserve_output_range(1_UZ);
+
+            auto  value  = values[values_next];
+            data[0]      = value;
+            data.publish(1_UZ);
+
+            remaining_events_count--;
+            if (remaining_events_count == 0) {
+                fmt::print("{}: Last value sent was {}\n", static_cast<void *>(this), values[values_next]);
+            }
+
+            values_next++;
+
+            return { requested_work, 1UL, gr::work::Status::OK };
+        } else {
+            // TODO: Investigate what schedulers do when there is an event written, but we return DONE
+            return { requested_work, 1UL, gr::work::Status::DONE };
+        }
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE(RepeatedSource, identifier, remaining_events_count, values, out);
+
+template<typename T>
+struct ValidatorSink : public gr::Block<ValidatorSink<T>> {
+    std::uint32_t                  identifier = 0;
+    gr::PortIn<T>                  in;
+
+    std::vector<T>                 expected_values;
+    std::vector<T>::const_iterator expected_values_next;
+    bool                           all_ok = true;
+
+    bool
+    verify() const {
+        return all_ok && (expected_values_next == expected_values.cend());
+    }
+
+    void
+    settingsChanged(const gr::property_map & /*old_settings*/, const gr::property_map &new_settings) noexcept {
+        if (new_settings.contains("expected_values")) {
+            expected_values_next = expected_values.cbegin();
+        }
+    }
+
+    void
+    processOne(T value) {
+        if (expected_values_next == expected_values.cend()) {
+            all_ok = false;
+            fmt::print("Error: {}#{}: We got more values than expected\n", static_cast<void *>(this), identifier);
+
+        } else {
+            if (value != *expected_values_next) {
+                all_ok = false;
+                fmt::print("Error: {}#{}: Got a value {}, but wanted {} (position {})\n", static_cast<void *>(this), identifier, value, *expected_values_next,
+                           std::distance(expected_values.cbegin(), expected_values_next));
+            }
+
+            expected_values_next++;
+        }
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE(ValidatorSink, identifier, expected_values, in);
+
+template<typename T>
+struct ArrayPortsNode : gr::Block<ArrayPortsNode<T>> {
+    static constexpr std::size_t                      port_count = 4;
+    std::array<gr::PortIn<T, gr::Async>, port_count>  inputs;
+    std::array<gr::PortOut<T, gr::Async>, port_count> outputs;
+
+    gr::work::Status
+    processBulk(auto &...args) {
+        // When we don't write the correct signature for processBulk,
+        // this will print out the types we should have used:
+        gr::meta::print_types<decltype(args)...>{};
+        return gr::work::Status::OK;
+    }
+
+    using input_reader_t  = typename gr::PortIn<T, gr::Async>::ReaderType;
+    using output_writer_t = typename gr::PortOut<T, gr::Async>::WriterType;
+
+    gr::work::Status
+    processBulk(const std::vector<input_reader_t *> &ins, std::vector<output_writer_t *> &outs) {
+        for (std::size_t channelIndex = 0; channelIndex < ins.size(); ++channelIndex) {
+            auto *inputReader  = ins[channelIndex];
+            auto *outputWriter = outs[channelIndex];
+
+            auto  available    = std::min(inputReader->available(), outputWriter->available());
+            if (available == 0) return gr::work::Status::DONE;
+
+            auto inputSpan  = inputReader->get(available);
+            auto outputSpan = outputWriter->reserve_output_range(available);
+
+            for (std::size_t valueIndex = 0; valueIndex < available; ++valueIndex) {
+                outputSpan[valueIndex] = inputSpan[valueIndex];
+            }
+
+            inputReader->consume(available);
+            outputSpan.publish(available);
+        }
+        return gr::work::Status::OK;
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE(ArrayPortsNode, inputs, outputs);
+
+void
+execute_selector_test() {
+    using namespace boost::ut;
+
+    using TestNode                                      = ArrayPortsNode<double>;
+
+    const std::uint32_t                     value_count = 5;
+
+    gr::Graph                               graph;
+    std::array<RepeatedSource<double> *, 4> sources;
+    std::array<ValidatorSink<double> *, 4>  sinks;
+
+    auto                                   *testNode = std::addressof(graph.emplaceBlock<TestNode>());
+
+    sources[0]                                       = std::addressof(graph.emplaceBlock<RepeatedSource<double>>({ { "remaining_events_count", value_count }, //
+                                                                                                                   { "identifier", 0U },                      //
+                                                                                                                   { "values", std::vector{ 0.0 } } }));
+    sources[1]                                       = std::addressof(graph.emplaceBlock<RepeatedSource<double>>({ { "remaining_events_count", value_count }, //
+                                                                                                                   { "identifier", 1U },                      //
+                                                                                                                   { "values", std::vector{ 1.0 } } }));
+    sources[2]                                       = std::addressof(graph.emplaceBlock<RepeatedSource<double>>({ { "remaining_events_count", value_count }, //
+                                                                                                                   { "identifier", 2U },                      //
+                                                                                                                   { "values", std::vector{ 2.0 } } }));
+    sources[3]                                       = std::addressof(graph.emplaceBlock<RepeatedSource<double>>({ { "remaining_events_count", value_count }, //
+                                                                                                                   { "identifier", 3U },                      //
+                                                                                                                   { "values", std::vector{ 3.0 } } }));
+
+    sinks[0]                                         = std::addressof(graph.emplaceBlock<ValidatorSink<double>>({ { "identifier", 0U },
+                                                                                                                  { "expected_values", std::vector{
+                                                                                                       0.0,
+                                                                                                       0.0,
+                                                                                                       0.0,
+                                                                                                       0.0,
+                                                                                                       0.0,
+                                                                                               } } }));
+    sinks[1]                                         = std::addressof(graph.emplaceBlock<ValidatorSink<double>>({ { "identifier", 1U }, //
+                                                                                                                  { "expected_values", std::vector{
+                                                                                                       1.0,
+                                                                                                       1.0,
+                                                                                                       1.0,
+                                                                                                       1.0,
+                                                                                                       1.0,
+                                                                                               } } }));
+    sinks[2]                                         = std::addressof(graph.emplaceBlock<ValidatorSink<double>>({ { "identifier", 2U }, //
+                                                                                                                  { "expected_values", std::vector{
+                                                                                                       2.0,
+                                                                                                       2.0,
+                                                                                                       2.0,
+                                                                                                       2.0,
+                                                                                                       2.0,
+                                                                                               } } }));
+    sinks[3]                                         = std::addressof(graph.emplaceBlock<ValidatorSink<double>>({ { "identifier", 3U }, //
+                                                                                                                  { "expected_values", std::vector{
+                                                                                                       3.0,
+                                                                                                       3.0,
+                                                                                                       3.0,
+                                                                                                       3.0,
+                                                                                                       3.0,
+                                                                                               } } }));
+
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[0]).to<"inputs", 0_UZ>(*testNode)));
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[1]).to<0_UZ, 1_UZ>(*testNode)));
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"out">(*sources[2]).to<0_UZ, 2_UZ>(*testNode)));
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect(*sources[3], "out"s, *testNode, { "inputs", 3 })));
+
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<"outputs", 0_UZ>(*testNode).to<"in">(*sinks[0])));
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<0 /*"outputs"*/, 1_UZ>(*testNode).to<"in">(*sinks[1])));
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect<0 /* outputs */, 2_UZ>(*testNode).to<"in">(*sinks[2])));
+    expect(eq(gr::ConnectionResult::SUCCESS, graph.connect(*testNode, { "outputs", 3 }, *sinks[3], "in"s)));
+
+    expect(graph.performConnections());
+
+    for (std::size_t iterration = 0; iterration < value_count * sources.size(); ++iterration) {
+        const auto max = std::numeric_limits<std::size_t>::max();
+        for (auto *source : sources) {
+            source->work(max);
+        }
+        testNode->work(max);
+        for (auto *sink : sinks) {
+            sink->work(max);
+        }
+    }
+
+    for (auto *sink : sinks) {
+        assert(sink->verify());
+    }
+}
+
+const boost::ut::suite SelectorTest = [] {
+    using namespace boost::ut;
+
+    "basic ports in arrays"_test = [] { execute_selector_test(); };
+};
+
+int
+main() { /* not needed for UT */
+}


### PR DESCRIPTION
- Removed the connect syntax with pointers to members
- Added the support for vectors and arrays of ports to the static connect syntax
- Exposing static port names to dynamic ports
- Added syntax for dynamic_connect that works with port names, with the support for port collections