### PR TITLE
CI: configure sonarclound coverage paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,12 +153,12 @@ if (ENABLE_TESTING AND UNIX AND NOT APPLE)
                 NAME coverage
                 EXECUTABLE ctest
                 DEPENDENCIES qa_buffer qa_data_sink qa_DynamicPort qa_DynamicBlock qa_HierBlock qa_filter qa_Settings qa_Tags qa_Scheduler qa_thread_pool qa_thread_affinity
-                EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/.*" ".*/test/.*")
+                EXCLUDE "$CMAKE_BUILD_DIR/*")
         setup_target_for_coverage_gcovr_html(
                 NAME coverage_html
                 EXECUTABLE ctest
                 DEPENDENCIES qa_buffer qa_data_sink qa_DynamicPort qa_DynamicBlock qa_HierBlock qa_filter qa_Settings qa_Tags qa_Scheduler qa_thread_pool qa_thread_affinity
-                EXCLUDE "$CMAKE_BUILD_DIR/*" "concepts/.*" ".*/test/.*")
+                EXCLUDE "$CMAKE_BUILD_DIR/*")
     endif ()
     message("Building Tests and benchmarks.")
 endif ()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,6 +11,8 @@ sonar.organization=fair-acc
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-# exclude benchmark which crashes the Analysis
-sonar.exclusions=core/benchmarks/bm_node_api.cpp
 sonar.coverageReportPaths=/home/runner/work/graph-prototype/build/coverage.xml
+sonar.exclusions=**/test/**/*,**/benchmark/*
+sonar.test=.
+sonar.test.inclusions=**/test/**/*,**/benchmark/*
+sonar.test.exclusions=core/benchmarks/bm_node_api.cpp # excludes benchmark which crashes the Analysis


### PR DESCRIPTION
Define coverage paths s.t. tests and benchmarks are not counted towards general coverage and line counts, but still analyzed in the test scope. see: https://docs.sonarcloud.io/advanced-setup/analysis-scope/