### PR TITLE
CI: upgrade sonar-scanner action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install sonar-scanner and build-wrapper
         if: matrix.configurations.compiler == 'gcc13' && matrix.cmake-build-type == 'Debug'
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
+        uses: SonarSource/sonarcloud-github-c-cpp@v2
 
       - name: Configure CMake
         if: matrix.configurations.compiler != 'emscripten'


### PR DESCRIPTION
Should handle the warning on the sonar-scanner github action.
See: https://community.sonarsource.com/t/java-11-is-deprecated-as-a-runtime-env-to-scan-your-projects/96597/11