### PR TITLE
Support port collections in GRC YAML   

### DIFF
--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -439,7 +439,7 @@ struct PortIndexDefinition {
     constexpr PortIndexDefinition(T _topLevel, std::size_t _subIndex = meta::invalid_index) : topLevel(std::move(_topLevel)), subIndex(_subIndex) {}
 };
 
-class edge {
+class Edge {
 public: // TODO: consider making this private and to use accessors (that can be safely used by users)
     using PortDirection::INPUT;
     using PortDirection::OUTPUT;
@@ -453,21 +453,21 @@ public: // TODO: consider making this private and to use accessors (that can be 
     bool                             _connected;
 
 public:
-    edge()             = delete;
+    Edge()             = delete;
 
-    edge(const edge &) = delete;
+    Edge(const Edge &) = delete;
 
-    edge &
-    operator=(const edge &)
+    Edge &
+    operator=(const Edge &)
             = delete;
 
-    edge(edge &&) noexcept = default;
+    Edge(Edge &&) noexcept = default;
 
-    edge &
-    operator=(edge &&) noexcept
+    Edge &
+    operator=(Edge &&) noexcept
             = default;
 
-    edge(BlockModel *sourceBlock, PortIndexDefinition<std::size_t> sourcePortDefinition, BlockModel *destinationBlock, PortIndexDefinition<std::size_t> destinationPortDefinition,
+    Edge(BlockModel *sourceBlock, PortIndexDefinition<std::size_t> sourcePortDefinition, BlockModel *destinationBlock, PortIndexDefinition<std::size_t> destinationPortDefinition,
          std::size_t minBufferSize, std::int32_t weight, std::string_view name)
         : _sourceBlock(sourceBlock)
         , _destinationBlock(destinationBlock)
@@ -526,7 +526,7 @@ struct Graph {
 private:
     std::vector<std::function<ConnectionResult(Graph &)>> _connectionDefinitions;
     std::vector<std::unique_ptr<BlockModel>>              _blocks;
-    std::vector<edge>                                     _edges;
+    std::vector<Edge>                                     _edges;
 
     template<typename TBlock>
     std::unique_ptr<BlockModel> &
@@ -687,7 +687,7 @@ public:
     /**
      * @return a list of all edges in this graph connecting blocks
      */
-    [[nodiscard]] std::span<edge>
+    [[nodiscard]] std::span<Edge>
     edges() noexcept {
         return { _edges };
     }

--- a/core/test/app_grc.cpp
+++ b/core/test/app_grc.cpp
@@ -11,39 +11,37 @@
 #include <build_configure.hpp>
 #include <gnuradio-4.0/basic/common_blocks.hpp>
 
-namespace grg = gr;
-
 template<typename T>
-struct ArraySource : public grg::Block<ArraySource<T>> {
-    std::array<grg::PortOut<T>, 2> outA;
-    std::array<grg::PortOut<T>, 2> outB;
+struct ArraySource : public gr::Block<ArraySource<T>> {
+    std::array<gr::PortOut<T>, 2> outA;
+    std::array<gr::PortOut<T>, 2> outB;
 };
 
 ENABLE_REFLECTION_FOR_TEMPLATE(ArraySource, outA, outB);
 
 template<typename T>
-struct ArraySink : public grg::Block<ArraySink<T>> {
-    std::array<grg::PortIn<T>, 2> inA;
-    std::array<grg::PortIn<T>, 2> inB;
+struct ArraySink : public gr::Block<ArraySink<T>> {
+    std::array<gr::PortIn<T>, 2> inA;
+    std::array<gr::PortIn<T>, 2> inB;
 };
 
 ENABLE_REFLECTION_FOR_TEMPLATE(ArraySink, inA, inB);
 
-struct test_context {
-    test_context(std::vector<std::filesystem::path> paths) : registry(), loader(&registry, std::move(paths)) {}
+struct TestContext {
+    TestContext(std::vector<std::filesystem::path> paths) : registry(), loader(&registry, std::move(paths)) {}
 
-    grg::BlockRegistry registry;
-    grg::plugin_loader loader;
+    gr::BlockRegistry registry;
+    gr::plugin_loader loader;
 };
 
 namespace {
-    auto collectBlocks(const grg::Graph &graph) {
+    auto collectBlocks(const gr::Graph &graph) {
         std::set<std::string> result;
         graph.forEachBlock([&](const auto &node) { result.insert(fmt::format("{}-{}", node.name(), node.typeName())); });
         return result;
     };
 
-    auto collectEdges(const grg::Graph &graph) {
+    auto collectEdges(const gr::Graph &graph) {
         std::set<std::string> result;
         graph.forEachEdge([&](const auto &edge) {
             result.insert(fmt::format("{}#{}#{} - {}#{}#{}", edge.sourceBlock().name(), edge.sourcePortDefinition().topLevel, edge.sourcePortDefinition().subIndex, edge.destinationBlock().name(), edge.destinationPortDefinition().topLevel, edge.destinationPortDefinition().subIndex));
@@ -70,7 +68,7 @@ main(int argc, char *argv[]) {
         return buffer.str();
     };
 
-    test_context context(std::move(paths));
+    TestContext context(std::move(paths));
 
     // Test the basic graph loading and storing
     {
@@ -79,8 +77,8 @@ main(int argc, char *argv[]) {
 
         auto graph_source          = read_file(TESTS_SOURCE_PATH "/grc/test.grc");
 
-        auto graph                 = grg::load_grc(context.loader, graph_source);
-        auto graph_saved_source    = grg::save_grc(graph);
+        auto graph                 = gr::load_grc(context.loader, graph_source);
+        auto graph_saved_source    = gr::save_grc(graph);
 
         auto graph_expected_source = read_file(TESTS_SOURCE_PATH "/grc/test.grc.expected");
         assert(graph_saved_source + "\n"
@@ -98,10 +96,10 @@ main(int argc, char *argv[]) {
 
         auto                  graph_source       = read_file(TESTS_SOURCE_PATH "/grc/test.grc");
 
-        auto                  graph_1            = grg::load_grc(context.loader, graph_source);
-        auto                  graph_saved_source = grg::save_grc(graph_1);
+        auto                  graph_1            = gr::load_grc(context.loader, graph_source);
+        auto                  graph_saved_source = gr::save_grc(graph_1);
 
-        auto                  graph_2            = grg::load_grc(context.loader, graph_saved_source);
+        auto                  graph_2            = gr::load_grc(context.loader, graph_saved_source);
 
         assert(collectBlocks(graph_1) == collectBlocks(graph_2));
         assert(collectEdges(graph_1) == collectEdges(graph_2));
@@ -126,8 +124,8 @@ main(int argc, char *argv[]) {
 
         assert(graph_1.performConnections());
 
-        const auto graph_1_saved = grg::save_grc(graph_1);
-        const auto graph_2       = grg::load_grc(context.loader, graph_1_saved);
+        const auto graph_1_saved = gr::save_grc(graph_1);
+        const auto graph_2       = gr::load_grc(context.loader, graph_1_saved);
 
         assert(collectBlocks(graph_1) == collectBlocks(graph_2));
         assert(collectEdges(graph_1) == collectEdges(graph_2));

--- a/core/test/app_plugins_test.cpp
+++ b/core/test/app_plugins_test.cpp
@@ -16,8 +16,8 @@ using namespace gr::literals;
 
 namespace grg = gr;
 
-struct test_context {
-    explicit test_context(std::vector<std::filesystem::path> paths) : registry(), loader(&registry, std::move(paths)) {}
+struct TestContext {
+    explicit TestContext(std::vector<std::filesystem::path> paths) : registry(), loader(&registry, std::move(paths)) {}
 
     grg::BlockRegistry registry;
     grg::plugin_loader loader;
@@ -44,7 +44,7 @@ main(int argc, char *argv[]) {
         }
     }
 
-    test_context context(std::move(paths));
+    TestContext context(std::move(paths));
     registerBuiltinBlocks(&context.registry);
 
     fmt::print("PluginLoaderTests\n");

--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -21,16 +21,16 @@ using namespace gr::literals;
 
 namespace grg = gr;
 
-struct test_context {
+struct TestContext {
     grg::BlockRegistry registry;
     grg::plugin_loader loader;
 
-    test_context() : loader(&registry, std::vector<std::filesystem::path>{ "test/plugins", "plugins" }) {}
+    TestContext() : loader(&registry, std::vector<std::filesystem::path>{ "test/plugins", "plugins" }) {}
 };
 
-test_context &
+TestContext &
 context() {
-    static test_context instance;
+    static TestContext instance;
     return instance;
 }
 


### PR DESCRIPTION
Make sure we can load/save connections involving port collections, i.e. serialize a connection from block1, port collection 0, sub-index 1 to block2, port collection 0, sub-index 2 as
    
```
 connections:
   - [block1, [0, 1], block2, [0, 2]]
```