### PR TITLE
Use vir-simd 0.3.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -17,8 +17,8 @@
 Language: Cpp
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: AcrossEmptyLines
-AlignConsecutiveDeclarations: AcrossEmptyLines
+AlignConsecutiveAssignments: Consecutive
+AlignConsecutiveDeclarations: Consecutive
 AlignEscapedNewlines: DontAlign
 AlignOperands: AlignAfterOperator
 AlignTrailingComments: true
@@ -60,7 +60,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeComma
 BreakAfterJavaFieldAnnotations: true
 BreakStringLiterals: true
-ColumnLimit: 200
+ColumnLimit: 0
 CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ FetchContent_Declare(
 FetchContent_Declare(
         vir-simd
         GIT_REPOSITORY https://github.com/mattkretz/vir-simd.git
-        GIT_TAG v0.2.0
+        GIT_TAG v0.3.0
 )
 
 FetchContent_MakeAvailable(fmt refl-cpp pmt ut yaml-cpp vir-simd)

--- a/blocks/testing/include/gnuradio-4.0/testing/bm_test_helper.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/bm_test_helper.hpp
@@ -34,9 +34,9 @@ public:
     }
 
     [[nodiscard]] constexpr auto
-    processOne_simd(auto N) const noexcept -> gr::meta::simdize<T, decltype(N)::value> {
+    processOne_simd(auto N) const noexcept -> vir::simdize<T, decltype(N)::value> {
         n_samples_produced += N;
-        gr::meta::simdize<T, N> x{};
+        vir::simdize<T, N> x{};
         benchmark::force_to_memory(x);
         return x;
     }

--- a/core/benchmarks/bm-nosonar_node_api.cpp
+++ b/core/benchmarks/bm-nosonar_node_api.cpp
@@ -92,6 +92,11 @@ public:
         // C++20 ranges
         // std::ranges::transform(input, output.begin(), [this](const T& elem) { return processOne(elem); });
 
+        // vir-simd execution policy
+        // vir::transform(vir::execution::simd, input, output, [this](const auto &elem) {
+        //     return processOne(elem);
+        // });
+
         return gr::work::Status::OK;
     }
 };

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -7,8 +7,13 @@
 #include "PortTraits.hpp"
 #include "reflection.hpp"
 
-#include <algorithm> // TODO: simd misses the algorithm dependency for std::clamp(...) -> add to simd
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <vir/simd.h>
+#include <vir/simdize.h>
+#pragma GCC diagnostic pop
 
 namespace gr::work {
 enum class Status;
@@ -215,7 +220,19 @@ auto
 can_processOne_with_offset_invoke_test(auto &node, const auto &input, std::index_sequence<Is...>) -> decltype(node.processOne(exact_argument_type<std::size_t>(), std::get<Is>(input)...));
 
 template<typename TBlock>
-using simd_return_type_of_can_processOne = meta::simdize<return_type<TBlock>, meta::simdize_size_v<meta::simdize<input_port_types_tuple<TBlock>>>>;
+struct simd_return_type_of_can_processOne {
+    using type = vir::simdize<return_type<TBlock>, vir::simdize<input_port_types_tuple<TBlock>>::size()>;
+};
+
+template<typename TBlock>
+    requires std::is_void_v<return_type<TBlock>>
+struct simd_return_type_of_can_processOne<TBlock> {
+    using type = void;
+};
+
+template<typename TBlock>
+using simd_return_type_of_can_processOne_t
+        = typename simd_return_type_of_can_processOne<TBlock>::type;
 } // namespace detail
 
 /* A node "can process simd" if its `processOne` function takes at least one argument and all
@@ -232,12 +249,14 @@ concept can_processOne_simd =
 #if DISABLE_SIMD
         false;
 #else
-        traits::block::input_ports<TBlock>::template all_of<port::is_port> and // checks we don't have port collections inside
-        traits::block::input_port_types<TBlock>::size() > 0 and requires(TBlock &node, const meta::simdize<input_port_types_tuple<TBlock>> &input_simds) {
-            {
-                detail::can_processOne_invoke_test(node, input_simds, std::make_index_sequence<traits::block::input_ports<TBlock>::size()>())
-            } -> std::same_as<detail::simd_return_type_of_can_processOne<TBlock>>;
-        };
+        traits::block::input_ports<TBlock>::template all_of<port::is_port> // checks we don't have port collections inside
+        and traits::block::input_port_types<TBlock>::size() > 0
+        and requires(TBlock &node, const vir::simdize<input_port_types_tuple<TBlock>> &input_simds) {
+                {
+                    detail::can_processOne_invoke_test(
+                            node, input_simds, std::make_index_sequence<traits::block::input_ports<TBlock>::size()>())
+                } -> std::same_as<detail::simd_return_type_of_can_processOne_t<TBlock>>;
+            };
 #endif
 
 template<typename TBlock>
@@ -245,12 +264,14 @@ concept can_processOne_simd_with_offset =
 #if DISABLE_SIMD
         false;
 #else
-        traits::block::input_ports<TBlock>::template all_of<port::is_port> and // checks we don't have port collections inside
-        traits::block::input_port_types<TBlock>::size() > 0 && requires(TBlock &node, const meta::simdize<input_port_types_tuple<TBlock>> &input_simds) {
-            {
-                detail::can_processOne_with_offset_invoke_test(node, input_simds, std::make_index_sequence<traits::block::input_ports<TBlock>::size()>())
-            } -> std::same_as<detail::simd_return_type_of_can_processOne<TBlock>>;
-        };
+        traits::block::input_ports<TBlock>::template all_of<port::is_port> // checks we don't have port collections inside
+        and traits::block::input_port_types<TBlock>::size() > 0
+        and requires(TBlock &node, const vir::simdize<input_port_types_tuple<TBlock>> &input_simds) {
+                {
+                    detail::can_processOne_with_offset_invoke_test(
+                            node, input_simds, std::make_index_sequence<traits::block::input_ports<TBlock>::size()>())
+                } -> std::same_as<detail::simd_return_type_of_can_processOne_t<TBlock>>;
+            };
 #endif
 
 template<typename TBlock>

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -12,8 +12,12 @@
 #include <tuple>
 #include <unordered_map>
 
-#include <algorithm> // TODO: simd misses the algorithm dependency for std::clamp(...) -> add to simd
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <vir/simd.h>
+#pragma GCC diagnostic pop
 
 #include "typelist.hpp"
 
@@ -248,87 +252,7 @@ template<typename V, typename T>
 concept t_or_simd = std::same_as<V, T> || any_simd<V, T>;
 
 template<typename T>
-concept vectorizable_v = std::constructible_from<stdx::simd<T>>;
-
-template<typename T>
-using vectorizable = std::integral_constant<bool, vectorizable_v<T>>;
-
-template<typename T>
 concept complex_like = std::is_same_v<T, std::complex<float>> || std::is_same_v<T, std::complex<double>>;
-
-/**
- * Determines the SIMD width of the given structure. This can either be a stdx::simd object or a
- * tuple-like of stdx::simd (recursively). The latter requires that the SIMD width is homogeneous.
- * If T is not a simd (or tuple thereof), value is 0.
- */
-template<typename T>
-struct simdize_size : std::integral_constant<std::size_t, 0> {};
-
-template<typename T, typename A>
-struct simdize_size<stdx::simd<T, A>> : stdx::simd_size<T, A> {};
-
-template<tuple_like Tup>
-struct simdize_size<Tup> : simdize_size<std::tuple_element_t<0, Tup>> {
-    static_assert([]<std::size_t... Is>(std::index_sequence<Is...>) {
-        return ((simdize_size<std::tuple_element_t<0, Tup>>::value == simdize_size<std::tuple_element_t<Is, Tup>>::value) && ...);
-    }(std::make_index_sequence<std::tuple_size_v<Tup>>()));
-};
-
-template<typename T>
-inline constexpr std::size_t simdize_size_v = simdize_size<T>::value;
-
-namespace detail {
-/**
- * Shortcut to determine the stdx::simd specialization with the most efficient ABI tag for the
- * requested element type T and width N.
- */
-template<typename T, std::size_t N>
-using deduced_simd = stdx::simd<T, stdx::simd_abi::deduce_t<T, N>>;
-
-template<typename T, std::size_t N>
-struct simdize_impl {
-    using type = T;
-};
-
-template<vectorizable_v T, std::size_t N>
-    requires requires { typename stdx::native_simd<T>; }
-struct simdize_impl<T, N> {
-    using type = deduced_simd<T, N == 0 ? stdx::native_simd<T>::size() : N>;
-};
-
-template<std::size_t N>
-struct simdize_impl<std::tuple<>, N> {
-    using type = std::tuple<>;
-};
-
-template<tuple_like Tup, std::size_t N>
-    requires requires { typename simdize_impl<std::tuple_element_t<0, Tup>, N>::type; }
-struct simdize_impl<Tup, N> {
-    static inline constexpr std::size_t size
-            = N > 0 ? N
-                    : []<std::size_t... Is>(std::index_sequence<Is...>) constexpr { return std::max({ simdize_size_v<typename simdize_impl<std::tuple_element_t<Is, Tup>, 0>::type>... }); }
-
-                      (std::make_index_sequence<std::tuple_size_v<Tup>>());
-
-    using type = decltype([]<std::size_t... Is>(std::index_sequence<Is...>) -> std::tuple<typename simdize_impl<std::tuple_element_t<Is, Tup>, size>::type...> {
-        return {};
-    }(std::make_index_sequence<std::tuple_size_v<Tup>>()));
-};
-} // namespace detail
-
-/**
- * Meta-function that turns a vectorizable type or a tuple-like (recursively) of vectorizable types
- * into a stdx::simd or std::tuple (recursively) of stdx::simd. If N is non-zero, N determines the
- * resulting SIMD width. Otherwise, of all vectorizable types U the maximum
- * stdx::native_simd<U>::size() determines the resulting SIMD width.
- * If T is neither vectorizable nor a std::tuple with at least one member, simdize produces T.
- */
-template<typename T, std::size_t N = 0>
-using simdize = typename detail::simdize_impl<T, N>::type;
-
-static_assert(std::same_as<simdize<std::tuple<std::tuple<int, double>, short, std::tuple<float>>>,
-                           std::tuple<std::tuple<detail::deduced_simd<int, stdx::native_simd<short>::size()>, detail::deduced_simd<double, stdx::native_simd<short>::size()>>, stdx::native_simd<short>,
-                                      std::tuple<detail::deduced_simd<float, stdx::native_simd<short>::size()>>>>);
 
 template<fixed_string Name, typename PortList>
 consteval int


### PR DESCRIPTION
* `qa_thread_affinity` fails on my system

The goal of this PR is to remove the code from GR that exists in vir-simd (`meta::simdize -> vir::simdize`). `vir::simdize<tuple<>>` and `vir::simdize<void>` are ill-formed whereas `meta::simdize<tuple<>>` produced a `tuple<>` (and `void` for `void`). I still believe this is the correct behavior for `simdize<T>` (if it can't be SIMD-ified, don't act as if it worked). This required a few adjustments in the GR code.