### PR TITLE
Frank/scheduler fixes

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -191,6 +191,10 @@ public:
                     const profiling::Options &profiling_options = {})
         : SchedulerBase<TProfiler>(std::move(graph), thread_pool, profiling_options) {}
 
+    bool isProcessing() const requires (executionPolicy == multiThreaded) {
+        return this->_running_threads.load() > 0;
+    }
+
     void
     init() {
         SchedulerBase<TProfiler>::init();
@@ -294,6 +298,10 @@ public:
     explicit BreadthFirst(gr::Graph &&graph, std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("breadth-first-pool", thread_pool::CPU_BOUND),
                           const profiling::Options &profiling_options = {})
         : SchedulerBase<TProfiler>(std::move(graph), thread_pool, profiling_options) {}
+
+    bool isProcessing() const requires (executionPolicy == multiThreaded) {
+        return this->_running_threads.load() > 0;
+    }
 
     void
     init() {

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -138,10 +138,10 @@ public:
 
     void
     poolWorker(const std::function<work::Result()> &work, std::size_t n_batches) {
-        auto    &profiler_handler = _profiler.forThisThread();
+        auto &profiler_handler = _profiler.forThisThread();
 
-        uint32_t done             = 0;
-        uint32_t progress_count   = 0;
+        uint32_t done           = 0;
+        uint32_t progress_count = 0;
         while (done < n_batches && !_stop_requested) {
             auto pe                 = profiler_handler.startCompleteEvent("scheduler_base.work");
             bool something_happened = work().status == work::Status::OK;
@@ -272,6 +272,7 @@ public:
                 this->_state = STOPPED;
             }
         } else if (executionPolicy == multiThreaded) {
+            this->_state = RUNNING;
             this->runOnPool(this->_job_lists, [this](auto &job) { return this->workOnce(job); });
         } else {
             throw std::invalid_argument("Unknown execution Policy");
@@ -410,6 +411,7 @@ public:
             }
             this->_state = STOPPED;
         } else if (executionPolicy == multiThreaded) {
+            this->_state = RUNNING;
             this->runOnPool(this->_job_lists, [this](auto &job) { return this->workOnce(job); });
         } else {
             throw std::invalid_argument("Unknown execution Policy");

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -440,6 +440,16 @@ const boost::ut::suite SchedulerTests = [] {
         expect(boost::ut::that % t.size() >= 10u);
     };
 
+    "SimpleScheduler_scaled_sum_multi_threaded_default_thread_pool"_test = [] {
+        using scheduler = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>;
+        // construct an example graph and get an adjacency list for it
+        tracer trace{};
+        auto   sched = scheduler{ get_graph_scaled_sum(trace) };
+        sched.runAndWait();
+        auto t = trace.get_vec();
+        expect(boost::ut::that % t.size() >= 10u);
+    };
+
     "BreadthFirstScheduler_scaled_sum_multi_threaded"_test = [&thread_pool] {
         using scheduler = gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>;
         tracer trace{};


### PR DESCRIPTION
- Fixes terminating of multithreaded running graphs via stop() when the graphs wouldn't terminate by itself.
- Add test demonstrating issues when using more than two threads:
When using the default threadpool, the worker threads of dependent
blocks might all report that nothing happened and increase the
progress/ "done" count (in poolWorker()), before the producing blocks
have any chance to produce anything. That makes the dependent blocks
"shutdown", while the producing node produces something and then sleeps
forever.
- Fix by @wirew0rm for above issue
- Small feature: Add isProcessing() to test if a multithreaded scheduler finished processing.