### PR TITLE
IIR and FIR coefficient generator and time-domain filter (<800 SLOCs!)

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/filter/FilterTool.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/filter/FilterTool.hpp
@@ -1,0 +1,890 @@
+#ifndef GNURADIO_FILTERTOOL_HPP
+#define GNURADIO_FILTERTOOL_HPP
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <execution>
+#include <iterator>
+#include <numbers>
+#include <numeric>
+#include <ranges>
+#include <unordered_set>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <fmt/std.h>
+#include <magic_enum.hpp>
+#include <magic_enum_utility.hpp>
+
+#include <gnuradio-4.0/algorithm/fourier/window.hpp>
+#include <gnuradio-4.0/HistoryBuffer.hpp>
+#include <gnuradio-4.0/meta/formatter.hpp>
+
+// this mocks the execution policy until Emscripten's libc++ does support this (Clang already does)
+#if defined(__EMSCRIPTEN__)
+
+namespace std {
+
+namespace execution {
+class mock_execution_policy {};
+
+inline constexpr mock_execution_policy seq{};
+inline constexpr mock_execution_policy unseq{};
+inline constexpr mock_execution_policy par{};
+} // namespace execution
+
+template<typename InputIt1, typename InputIt2, typename T, typename BinaryOp1, typename BinaryOp2>
+inline T
+transform_reduce(auto, InputIt1 first1, InputIt1 last1, InputIt2 first2, T init, BinaryOp1 binary_op1, BinaryOp2 binary_op2) {
+    return std::transform_reduce(first1, last1, first2, init, binary_op1, binary_op2);
+}
+
+} // namespace std
+#endif
+
+namespace gr::filter {
+
+enum class Frequency {
+    Hertz,        /// frequency in cycles per second. Standard unit for frequency.
+    RadianPerSec, /// angular frequency, indicating the rate of change per second in radians.
+    Normalised    /// frequency as a fraction of the sampling rate, typically in the range [0, 0.5].
+};
+
+enum class Type { LOWPASS, HIGHPASS, BANDPASS, BANDSTOP };
+
+struct FilterParameters {
+    std::size_t order{ 4UZ };                                      /// default filter order
+    double      fLow{ std::numeric_limits<double>::quiet_NaN() };  /// Lower cutoff frequency [Hertz].
+    double      fHigh{ std::numeric_limits<double>::quiet_NaN() }; /// Upper cutoff frequency [Hertz].
+    double      gain{ 1.0 };                                       /// required total filter gain
+    double      rippleDb{ 0.1 };                                   /// Maximum allowed ripple in the pass-band [dB].
+    double      attenuationDb{ 40 };                               /// Minimum required attenuation in the stop-band [dB].
+    double      beta{ 1.6 };                                       /// default beta for Kaiser-type windowing
+    double      fs{ std::numeric_limits<double>::quiet_NaN() };    /// Sampling frequency for digital filters [Hertz].
+};
+
+/**
+ * @brief Filter coefficients of a digital transfer function H(z) = B(z)/A(z) in the z-domain with:
+ *   B(z) = b[0] + b[1]·z^{-1} + b[2]·z^{-2} + …
+ *   A(z) = a[0] + a[1]·z^{-1} + a[2]·z^{-2} + …
+ *
+ * The difference equation representing the filter is:
+ * y[n] = b[0]·x[n] + b[1]·x[n-1] + … - (a[1]·y[n-1] + a[2]·y[n-2] + …)
+ *
+ * @note Typically, a[0] is 1 for causal systems and a{
+ */
+template<typename T>
+struct FilterCoefficients {
+    using value_type = T;
+    std::vector<T> b{};                    /// numerator coefficients
+    std::vector<T> a{ static_cast<T>(1) }; /// denominator coefficients
+};
+
+template<typename T>
+concept HasFilterCoefficients = requires(T t) {
+    typename T::value_type;
+    { t.a } -> std::convertible_to<std::vector<typename T::value_type> &>;
+    { t.b } -> std::convertible_to<std::vector<typename T::value_type> &>;
+};
+
+static_assert(HasFilterCoefficients<FilterCoefficients<double>>);
+static_assert(HasFilterCoefficients<FilterCoefficients<float>>);
+
+enum class Form {
+    DF_I,  /// direct form I: preferred for fixed-point arithmetics (e.g. no overflow)
+    DF_II, /// direct form II: preferred for floating-point arithmetics (less operations)
+    DF_I_TRANSPOSED,
+    DF_II_TRANSPOSED
+};
+
+/**
+ * @brief: Infinite-Impulse-Response (IIR) as well as Finite-Impulse-Response (FIR) filter based on a single or set of biquad filter coefficients.
+ *
+ * usage example:
+ * Filter<double> myFilter(filterSections);
+ * double outputSample = myFilter.processOne(inputSample);
+ */
+template<typename T, std::size_t bufferSize = std::dynamic_extent, Form form = std::is_floating_point_v<T> ? Form::DF_II : Form::DF_I, auto execPolicy = std::execution::seq>
+struct Filter {
+    struct Section : public FilterCoefficients<T> {
+        // note: bufferSize as upper maximum, since most IIR filter sections will have to be much smaller (for numerical stability reasons)
+        HistoryBuffer<T, bufferSize> inputHistory{};
+        HistoryBuffer<T, bufferSize> outputHistory{};
+
+        explicit Section(const FilterCoefficients<T> &section)
+            requires(bufferSize == std::dynamic_extent)
+            : FilterCoefficients<T>(section), inputHistory(section.b.size()), outputHistory(section.a.size()) {}
+
+        explicit Section(const FilterCoefficients<T> &section)
+            requires(bufferSize != std::dynamic_extent)
+            : FilterCoefficients<T>(section) {}
+    };
+
+    alignas(64UZ) std::vector<Section> _sections;
+
+public:
+    template<typename... TFilterCoefficients>
+    explicit Filter(TFilterCoefficients &&...filterSections) noexcept {
+        std::vector<FilterCoefficients<T>> filterSections_{ std::forward<TFilterCoefficients>(filterSections)... };
+        _sections.reserve(filterSections_.size());
+        for (const auto &section : filterSections_) {
+            _sections.emplace_back(section);
+        }
+    }
+
+    inline constexpr T
+    processOne(T inputSample) noexcept {
+        T output = inputSample;
+        for (auto &section : _sections) {
+            const T     input         = output; // input to this section is the output of the previous section
+            const auto &a             = section.a;
+            const auto &b             = section.b;
+            auto       &inputHistory  = section.inputHistory;
+            auto       &outputHistory = section.outputHistory;
+            if constexpr (form == Form::DF_I) {
+                // y[n] = b[0]·x[n]   + b[1]·x[n-1] + … + b[N]·x[n-N]
+                //      - a[1]·y[n-1] - a[2]·y[n-2] - … - a[M]·y[n-M]
+                inputHistory.push_back(input);
+                output = std::transform_reduce(execPolicy, b.cbegin(), b.cend(), inputHistory.cbegin(), static_cast<T>(0), std::plus<>(), std::multiplies<>())              // feed-forward path
+                       - std::transform_reduce(execPolicy, std::next(a.cbegin()), a.cend(), outputHistory.cbegin(), static_cast<T>(0), std::plus<>(), std::multiplies<>()); // feedback path
+                outputHistory.push_back(output);
+            } else if constexpr (form == Form::DF_II) {
+                // w[n] = x[n] - a[1]·w[n-1] - a[2]·w[n-2] - … - a[M]·w[n-M]
+                // y[n] =        b[0]·w[n]   + b[1]·w[n-1] + … + b[N]·w[n-N]
+                if (a.size() > 1) {
+                    const T w = input - std::transform_reduce(execPolicy, std::next(a.cbegin()), a.cend(), inputHistory.cbegin(), T{ 0 }, std::plus<>(), std::multiplies<>());
+                    inputHistory.push_back(w);
+                    output = std::transform_reduce(execPolicy, b.cbegin(), b.cend(), inputHistory.cbegin(), T{ 0 }, std::plus<>(), std::multiplies<>());
+                } else {
+                    inputHistory.push_back(input);
+                    output = std::transform_reduce(execPolicy, b.cbegin(), b.cend(), inputHistory.cbegin(), T{ 0 }, std::plus<>(), std::multiplies<>());
+                }
+            } else if constexpr (form == Form::DF_I_TRANSPOSED) {
+                // w_1[n] = x[n] - a[1]·w_2[n-1] - a[2]·w_2[n-2] - … - a[M]·w_2[n-M]
+                // y[n]   = b[0]·w_2[n] + b[1]·w_2[n-1] + … + b[N]·w_2[n-N]
+                T v0 = input - std::transform_reduce(execPolicy, std::next(a.cbegin()), a.cend(), outputHistory.cbegin(), static_cast<T>(0), std::plus<>(), std::multiplies<>());
+                outputHistory.push_back(v0);
+                output = std::transform_reduce(execPolicy, b.cbegin(), b.cend(), outputHistory.cbegin(), T{ 0 }, std::plus<>(), std::multiplies<>());
+            } else if constexpr (form == Form::DF_II_TRANSPOSED) {
+                // y[n] = b_0·f[n] + \sum_(k=1)^N(b_k·f[n−k] − a_k·y[n−k])
+                output = b[0] * input                                                                                                                                     //
+                       + std::transform_reduce(execPolicy, std::next(b.cbegin()), b.cend(), inputHistory.cbegin(), static_cast<T>(0), std::plus<>(), std::multiplies<>()) //
+                       - std::transform_reduce(execPolicy, std::next(a.cbegin()), a.cend(), outputHistory.cbegin(), static_cast<T>(0), std::plus<>(), std::multiplies<>());
+                inputHistory.push_back(input);
+                outputHistory.push_back(output);
+            }
+        }
+        return output; // the output of the last section is the output of the filter
+    }
+};
+
+template<typename... Coeffs>
+[[nodiscard]] inline constexpr std::size_t
+countFilterCoefficients(const Coeffs &...coeffs) {
+    std::size_t count   = 0;
+    auto        counter = [&count](const auto &filter) mutable {
+        if constexpr (std::is_same_v<std::decay_t<decltype(filter)>, FilterCoefficients<typename std::decay_t<decltype(filter)>::value_type>>) {
+            // It's a single FilterCoefficients object
+            count += filter.b.size() + filter.a.size() - 1;
+        } else {
+            // It's a std::vector of FilterCoefficients objects
+            for (const auto &fc : filter) {
+                count += fc.b.size() + fc.a.size() - 1;
+            }
+        }
+    };
+    (counter(coeffs), ...);
+    return count;
+}
+
+enum class ResponseType { Magnitude, MagnitudeDB, Phase, PhaseDegrees };
+
+template<Frequency frequencyType, ResponseType responseType, std::floating_point T, typename... TFilterCoefficients>
+[[nodiscard]] inline T
+calculateResponse(T normalisedDigitalFrequency, TFilterCoefficients... filterCoefficients) {
+    using C = std::complex<T>;
+    static_assert(frequencyType == Frequency::Normalised, "Frequency::Hertz not applicable for digital filters");
+    std::vector<FilterCoefficients<T>> filterCoefficients_{ std::forward<TFilterCoefficients>(filterCoefficients)... };
+
+    // e^(i*omega) term for the frequency
+    const std::complex<T> iOmega   = std::polar(static_cast<T>(1),
+                                              frequencyType == Frequency::RadianPerSec ? normalisedDigitalFrequency : (static_cast<T>(2) * std::numbers::pi_v<T> * normalisedDigitalFrequency));
+    T                     response = responseType == ResponseType::Magnitude ? static_cast<T>(1) : static_cast<T>(0);
+
+    for (const auto &filter : filterCoefficients_) {
+        // calculates numerator and denominator of the transfer function H(z) = B(z)/A(z)
+        const auto power       = [iOmega, n = 0UZ](C acc, T coefficient) mutable { return acc + coefficient * static_cast<C>(std::pow(iOmega, -static_cast<int>(n++))); };
+        C          numerator   = std::accumulate(filter.b.begin(), filter.b.end(), C(0), power);
+        C          denominator = std::accumulate(filter.a.begin(), filter.a.end(), C(0), power);
+
+        if constexpr (responseType == ResponseType::Magnitude) {
+            response *= std::abs(numerator / denominator);
+        } else if constexpr (responseType == ResponseType::MagnitudeDB) {
+            response += static_cast<T>(20) * std::log10(std::abs(numerator / denominator));
+        } else if constexpr (responseType == ResponseType::Phase) {
+            response += (std::arg(numerator) - std::arg(denominator));
+        } else if constexpr (responseType == ResponseType::PhaseDegrees) {
+            response += (std::arg(numerator) - std::arg(denominator)) * 180. / std::numbers::pi;
+        }
+    }
+
+    if constexpr (responseType == ResponseType::Phase) {
+        return std::fmod(response + std::numbers::pi, 2 * std::numbers::pi) - std::numbers::pi; // [-pi, +pi]
+    } else if constexpr (responseType == ResponseType::PhaseDegrees) {
+        return std::fmod(response + 180.0, 360.) - 180.0; // [-180°, +180°]
+    } else {
+        return response;
+    }
+}
+
+template<typename T>
+[[nodiscard]] inline constexpr std::pair<bool, T>
+normaliseFilterCoefficients(FilterCoefficients<T> &coefficients, T normalisedFrequency, T targetGain = static_cast<T>(1)) {
+    const T magnitude = calculateResponse<Frequency::Normalised, ResponseType::Magnitude>(normalisedFrequency, coefficients);
+    if (magnitude == 0) {
+        return { false, magnitude };
+    }
+    std::ranges::transform(coefficients.b, coefficients.b.begin(), [magnitude, targetGain](T coeff) { return coeff * targetGain / magnitude; });
+    return { true, magnitude };
+}
+
+namespace iir {
+
+enum class Design {
+    BUTTERWORTH = 0, /// Maximally flat pass-band magnitude response without ripples, commonly used for its smooth response.
+    BESSEL      = 1, /// Linear phase response with a gentle roll-off, ideal for preserving time-domain wave shapes.
+    CHEBYSHEV1  = 2, /// Equi-ripple pass-band with a steeper roll-off than Butterworth, at the expense of pass-band ripple.
+    CHEBYSHEV2  = 3  /// Equi-ripple stop-band with a steeper roll-off, but with ripple only in the stop-band.
+};
+
+/**
+ * @brief Transfer function H(s) (analog) or H(z) (digitialy) represented in terms of its poles and zeros, with
+ *   H(s) = gain·(s - zero[0])·(s - zero[1])· … / ((s - pole[0])·(s - pole[1])· …), or
+ *   H(z) = gain·(1 - zero[0]·z^{-1})·(1 - zero[1]·z^{-1})· … / ((1 - pole[0]·z^{-1})·(1 - pole[1]·z^{-1})· …)
+ *
+ * @note poles and zeros are complex numbers!
+ */
+struct PoleZeroLocations {
+    using value_type = double;
+    std::vector<std::complex<double>> poles{};     /// locations in the s- or z-plane where the transfer function goes to infinity.
+    std::vector<std::complex<double>> zeros{};     /// locations in the s- or z-plane where the transfer function becomes zero.
+    double                            gain{ 1.0 }; /// scaling factor applied to the transfer function
+};
+
+template<typename T>
+concept HasPoleZeroLocations = requires(T t) {
+    typename T::value_type;
+    { t.zeros } -> std::convertible_to<std::vector<std::complex<typename T::value_type>> &>;
+    { t.poles } -> std::convertible_to<std::vector<std::complex<typename T::value_type>> &>;
+};
+
+static_assert(HasPoleZeroLocations<PoleZeroLocations>);
+
+template<Frequency frequencyType, ResponseType responseType>
+[[nodiscard]] inline constexpr double
+calculateResponse(double frequency, const PoleZeroLocations &value) {
+    using C = std::complex<double>;
+    static_assert(frequencyType != Frequency::Normalised, "Frequency::Normalised not applicable for analog filters");
+
+    // s -> i·ω
+    const C    iOmega{ 0, frequencyType == Frequency::RadianPerSec ? frequency : (2. * std::numbers::pi * frequency) };
+    const auto product_over_range = [&iOmega](const auto &range) {
+        return std::accumulate(range.begin(), range.end(), C{ 1.0 }, [&iOmega](const C &acc, const C &val) { return acc * (iOmega - val); });
+    };
+    if constexpr (responseType == ResponseType::Magnitude) {
+        return value.gain * std::abs(product_over_range(value.zeros) / product_over_range(value.poles));
+    } else if constexpr (responseType == ResponseType::MagnitudeDB) {
+        return 20.0 * std::log10(std::abs(value.gain * std::abs(product_over_range(value.zeros) / product_over_range(value.poles))));
+    } else if (responseType == ResponseType::Phase) {
+        return (std::arg(value.gain * std::abs(product_over_range(value.zeros))) - std::arg(product_over_range(value.poles)));
+    } else if (responseType == ResponseType::PhaseDegrees) {
+        return (std::arg(value.gain * std::abs(product_over_range(value.zeros))) - std::arg(product_over_range(value.poles))) * 180. / std::numbers::pi;
+    }
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+calculateFilterButterworth(std::size_t order) {
+    // Butterworth design criteria: https://en.wikipedia.org/wiki/Butterworth_filter
+    // place poles equally spaced along the lhs unit half-circle starting with
+    // the real-pole at -1 if needed and then continue adding complex conjugate pairs
+    PoleZeroLocations ret;
+    ret.poles.reserve(order);
+    if (order % 2 != 0) {
+        ret.poles.emplace_back(-1.0); // real pole for odd orders
+    }
+
+    for (std::size_t i = 0UZ; i < order / 2; ++i) {
+        double                     theta = std::numbers::pi * (1.0 - static_cast<double>(i * 2 + 1 + order % 2) / (2.0 * static_cast<double>(order)));
+        const std::complex<double> pole  = std::polar(1.0, theta);
+        ret.poles.emplace_back(pole.real(), +pole.imag());
+        ret.poles.emplace_back(pole.real(), -pole.imag()); // conjugate pair, for numerical precision
+    }
+
+    return ret;
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+calculateFilterBessel(std::size_t order) {
+    // pole location data: Steve Winder, "Filter Design," Newnes Press, 1998.
+    using C = std::complex<double>;
+    switch (order) {
+    case 0: [[fallthrough]];
+    case 1: return { .poles = { C{ -1.0000 } }, .gain = 1.0 };
+    case 2: return { .poles = { C{ -1.1030, 0.6368 }, C{ -1.1030, -0.6368 } }, .gain = 1.6221 };
+    case 3: return { .poles = { C{ -1.0509 }, C{ -1.3270, 1.0025 }, C{ -1.3270, -1.0025 } }, .gain = 2.9067 };
+    case 4: return { .poles = { C{ -1.3596, 0.4071 }, C{ -1.3596, -0.4071 }, C{ -0.9877, 1.2476 }, C{ -0.9877, -1.2476 } }, .gain = 5.1002 };
+    case 5: return { .poles = { C{ -1.3851 }, C{ -0.9606, 1.4756 }, C{ -0.9606, -1.4756 }, C{ -1.5069, 0.7201 }, C{ -1.5069, -0.7201 } }, .gain = 11.9773 };
+    case 6: return { .poles = { C{ -1.5735, 0.3213 }, C{ -1.5735, -0.3213 }, C{ -1.3836, 0.9727 }, C{ -1.3836, -0.9727 }, C{ -0.9318, 1.6640 }, C{ -0.9318, -1.6640 } }, .gain = 26.8334 };
+    case 7:
+        return { .poles = { C{ -1.6130 }, C{ -1.3797, 0.5896 }, C{ -1.3797, -0.5896 }, C{ -1.1397, 1.1923 }, C{ -1.1397, -1.1923 }, C{ -0.9104, 1.8375 }, C{ -0.9104, -1.8375 } }, .gain = 41.5419 };
+    case 8:
+        return { .poles = { C{ -1.7627, 0.2737 }, C{ -1.7627, -0.2737 }, C{ -0.8955, 2.0044 }, C{ -0.8955, -2.0044 }, C{ -1.3780, 0.8253 }, C{ -1.3780, -0.8253 }, C{ -1.6419, 1.3926 },
+                            C{ -1.6419, -1.3926 } },
+                 .gain  = 183.3982 };
+    case 9:
+        return { .poles = { C{ -1.8081 }, C{ -1.6532, 0.5126 }, C{ -1.6532, -0.5126 }, C{ -1.16532, 1.0319 }, C{ -1.16532, -1.0319 }, C{ -1.3683, 1.5685 }, C{ -1.3683, -1.5685 }, C{ -0.8788, 2.1509 },
+                            C{ -0.8788, -2.1509 } },
+                 .gain  = 306.9539 };
+    case 10:
+        return { .poles = { C{ -1.9335, 0.2424 }, C{ -1.9335, -0.2424 }, C{ -0.8684, 2.2996 }, C{ -0.8684, -2.2996 }, C{ -1.8478, 0.7295 }, C{ -1.8478, -0.7295 }, C{ -1.6669, 1.2248 },
+                            C{ -1.6669, -1.2248 }, C{ -1.3649, 1.7388 }, C{ -1.3649, -1.7388 } },
+                 .gain  = 1893.1098 };
+    default: throw std::out_of_range("supported orders are 1 to 10");
+    }
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+calculateFilterChebyshevType1(std::size_t order, double rippleDb = 0.1) {
+    // Cauer, W. "The realization of impedances of prescribed frequency dependence." Annalen der Physik 401.2 (1930): 157-229.
+    // see also: https://en.wikipedia.org/wiki/Chebyshev_filter
+
+    // calculate the epsilon value based on the pass-band ripple
+    const double epsilon = std::sqrt(std::pow(10, rippleDb / 10.0) - 1);
+    // calculate the shifter value based on epsilon and the filter order
+    const double shifter = std::asinh(1 / epsilon) / static_cast<double>(order);
+
+    PoleZeroLocations value;
+    for (std::size_t k = 0; k < order; ++k) {
+        double angle = std::numbers::pi * (static_cast<double>(k) + 0.5) / static_cast<double>(order);
+        value.poles.emplace_back(-std::sinh(shifter) * std::sin(angle), std::cosh(shifter) * std::cos(angle));
+    }
+    value.gain = 1.0 / calculateResponse<Frequency::RadianPerSec, ResponseType::Magnitude>(0.0, value);
+    return value;
+}
+
+[[nodiscard]] inline PoleZeroLocations
+calculateFilterChebyshevType2(std::size_t numPoles, double stopBandDb = 40) {
+    // Cauer, W. "The realization of impedances of prescribed frequency dependence." Annalen der Physik 401.2 (1930): 157-229.
+    // see also: https://en.wikipedia.org/wiki/Chebyshev_filter#Poles_and_zeroes_2
+    const double epsilon = 1.0 / std::sqrt(std::pow(10, stopBandDb / 10.0) - 1);
+    const double v0      = std::asinh(1.0 / epsilon) / static_cast<double>(numPoles);
+    const double sinh_v0 = -std::sinh(v0);
+    const double cosh_v0 = std::cosh(v0);
+
+    PoleZeroLocations ret;
+    for (std::size_t k = 1UZ; k < numPoles; k += 2) {
+        const double theta = 0.5 * (static_cast<double>(k) - static_cast<double>(numPoles)) / static_cast<double>(numPoles);
+        const double a     = sinh_v0 * std::cos(std::numbers::pi * theta);
+        const double b     = cosh_v0 * std::sin(std::numbers::pi * theta);
+        const double d2    = a * a + b * b;
+
+        ret.poles.emplace_back(a / d2, +b / d2);
+        ret.poles.emplace_back(a / d2, -b / d2); // add conjugate pole pair
+
+        const double im = 1.0 / std::cos(0.5 * std::numbers::pi * static_cast<double>(k) / static_cast<double>(numPoles));
+        ret.zeros.emplace_back(0, +im);
+        ret.zeros.emplace_back(0, -im); // add conjugate zero pair
+    }
+
+    if (numPoles & 1) {
+        ret.poles.emplace_back(1.0 / sinh_v0, 0); // add single real-valued pole
+        // a zero at infinity is implicitly represented and doesn't need to be stored in 'zeros' vector.
+    }
+    ret.gain = 1.0 / calculateResponse<Frequency::RadianPerSec, ResponseType::Magnitude>(0.0, ret);
+    return ret;
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+analogToDigitalTransform(const PoleZeroLocations &analogPoleZeros, double samplingRate) {
+    // see: https://en.wikipedia.org/wiki/Bilinear_transform#Discrete-time_approximation
+    const double twoFs             = 2. * samplingRate;
+    auto         bilinearTransform = [twoFs](std::complex<double> s) {
+        return (twoFs + s) / (twoFs - s); // using Tustin's default method
+    };
+
+    PoleZeroLocations digitalPoleZeros;
+    digitalPoleZeros.poles.reserve(analogPoleZeros.poles.size());
+    digitalPoleZeros.zeros.reserve(analogPoleZeros.zeros.size());
+
+    std::transform(analogPoleZeros.poles.begin(), analogPoleZeros.poles.end(), std::back_inserter(digitalPoleZeros.poles), bilinearTransform);
+    std::transform(analogPoleZeros.zeros.begin(), analogPoleZeros.zeros.end(), std::back_inserter(digitalPoleZeros.zeros), bilinearTransform);
+    digitalPoleZeros.gain = analogPoleZeros.gain;
+
+    return digitalPoleZeros;
+}
+
+namespace details {
+
+template<std::floating_point T>
+std::vector<std::complex<T>>
+sortComplexWithConjugates(const std::vector<std::complex<T>> &numbers) {
+    constexpr T epsilon = 1e-10;
+
+    // Separate the numbers into three groups: positive imaginary, negative imaginary, and real-only
+    std::vector<std::complex<T>> positiveImag, negativeImag, realOnly;
+    for (const auto &num : numbers) {
+        if (num.imag() > epsilon) {
+            positiveImag.push_back(num);
+        } else if (num.imag() < -epsilon) {
+            negativeImag.push_back(num);
+        } else {
+            realOnly.push_back(num);
+        }
+    }
+
+    // Sort each group based on the real part
+    auto realComparator = [](const std::complex<T> &a, const std::complex<T> &b) { return a.real() < b.real(); };
+    std::sort(positiveImag.begin(), positiveImag.end(), realComparator);
+    std::sort(negativeImag.begin(), negativeImag.end(), realComparator);
+    std::sort(realOnly.begin(), realOnly.end(), realComparator);
+
+    // Merge the two groups of complex numbers
+    std::vector<std::complex<T>> sorted;
+    for (size_t i = 0; i < negativeImag.size(); ++i) {
+        sorted.push_back(negativeImag[i]);
+        if (i < positiveImag.size()) {
+            sorted.push_back(positiveImag[i]);
+        }
+    }
+
+    // If there are any remaining numbers in the positiveImag group, append them
+    for (size_t i = negativeImag.size(); i < positiveImag.size(); ++i) {
+        sorted.push_back(positiveImag[i]);
+    }
+
+    // Append the real-only numbers at the end
+    sorted.insert(sorted.end(), realOnly.begin(), realOnly.end());
+
+    return sorted;
+}
+
+} // namespace details
+
+template<typename T, std::ranges::input_range Range>
+[[nodiscard]] inline std::vector<T>
+expandRootsToPolynomial(Range &&roots, std::size_t desiredOrder) {
+    if (roots.empty()) {
+        std::vector<T> coefficients(desiredOrder + 1UZ, static_cast<T>(0));
+        coefficients[0] = 1.0;
+        return coefficients;
+    }
+
+    constexpr T    epsilon      = static_cast<T>(1e-10);
+    std::vector<T> coefficients = { static_cast<T>(1) }; // Starts with "x^0" coefficient (1.0)
+
+    auto convolve = [](const std::vector<T> &a, const std::vector<T> &b) {
+        std::vector<T> result(a.size() + b.size() - 1, static_cast<T>(0));
+        for (std::size_t i = 0UZ; i < a.size(); ++i) {
+            for (std::size_t j = 0UZ; j < b.size(); ++j) {
+                result[i + j] += a[i] * b[j];
+            }
+        }
+        return result;
+    };
+
+    for (size_t i = 0; i < roots.size(); ++i) {
+        const auto &root = roots[i];
+
+        if (static_cast<T>(std::abs(root.imag())) > epsilon) { // complex root
+            if (i + 1 >= roots.size()) {
+                throw std::runtime_error(fmt::format("Unmatched complex root at i={}: {}", i, root)); // Unpaired complex root.
+            }
+
+            // ensure the next root is the conjugate pair.
+            const auto &next_root = roots[i + 1];
+            if (static_cast<T>(std::abs(root.real() - next_root.real())) > epsilon || static_cast<T>(std::abs(root.imag() + next_root.imag())) > epsilon) {
+                throw std::runtime_error(fmt::format("Complex roots {} vs. {} are not conjugate pairs.\nroots:\n{}", root, next_root, roots));
+            }
+
+            // use the quadratic factor for the complex root and its conjugate.
+            coefficients = convolve(coefficients, { static_cast<T>(1), -static_cast<T>(2 * root.real()), static_cast<T>(std::norm(root)) });
+            ++i; // skip the next root since it's the conjugate pair.
+        } else { // real root
+            coefficients = convolve(coefficients, { static_cast<T>(1), -static_cast<T>(root.real()) });
+        }
+    }
+
+    return coefficients;
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+lowPassProtoToLowPass(const PoleZeroLocations &lowPassProto, FilterParameters parameters) {
+    PoleZeroLocations lowPass = lowPassProto;
+
+    std::ranges::for_each(lowPass.poles, [fLow = parameters.fLow](std::complex<double> &pole) { pole *= 2. * std::numbers::pi * fLow; });
+    std::ranges::for_each(lowPass.zeros, [fLow = parameters.fLow](std::complex<double> &zero) { zero *= 2. * std::numbers::pi * fLow; });
+
+    lowPass.gain = parameters.gain * lowPassProto.gain / calculateResponse<Frequency::RadianPerSec, ResponseType::Magnitude>(0., lowPass); // normalise at DC
+    return lowPass;
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+lowPassProtoToHighPass(const PoleZeroLocations &lowPassProto, FilterParameters parameters) {
+    PoleZeroLocations highPass = lowPassProto;
+
+    std::ranges::for_each(highPass.poles, [freqHigh = parameters.fHigh](auto &pole) { pole = 2. * std::numbers::pi * freqHigh / pole; });
+    if (highPass.zeros.empty()) {
+        highPass.zeros.resize(lowPassProto.poles.size()); // zeros at infinity (represented as explicit zeros here)
+    } else {
+        std::ranges::for_each(highPass.zeros, [freqHigh = parameters.fHigh](auto &zeros) { zeros = 2. * std::numbers::pi * freqHigh / zeros; });
+        if (lowPassProto.poles.size() > highPass.zeros.size()) {
+            const std::size_t missingZeros = lowPassProto.poles.size() - highPass.zeros.size();
+            highPass.zeros.resize(highPass.zeros.size() + missingZeros); // zeros at infinity (represented as explicit zeros here)
+        }
+    }
+
+    const double normFreq = std::isfinite(parameters.fs) ? parameters.fs : 10 * parameters.fHigh;
+    highPass.gain         = parameters.gain * lowPassProto.gain / calculateResponse<Frequency::RadianPerSec, ResponseType::Magnitude>(std::numbers::pi * normFreq, highPass); // gain == 1.0 at Nyquist
+    return highPass;
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+lowPassProtoToBandPass(const PoleZeroLocations &lowPassProto, FilterParameters parameters) {
+    constexpr double epsilon   = 1e-10;
+    const double     omega0    = 2. * std::numbers::pi * std::sqrt(parameters.fLow * parameters.fHigh); // centre frequency
+    const double     bandWidth = 2. * std::numbers::pi * std::abs(parameters.fHigh - parameters.fLow);
+    const double     Q         = omega0 / bandWidth; // quality factor
+
+    const auto transform = [Q, omega0](const std::complex<double> &s) -> std::pair<std::complex<double>, std::complex<double>> {
+        // https://en.wikipedia.org/wiki/Prototype_filter
+        // using Zobel transform: s' <- Q(s/ω₀ + ω₀/s)
+        // -> 0 = s² - (ω₀/Q)s'·s + ω₀² -> p := -(ω₀/Q)/2·s', q := ω₀²  -> s = -½p ± √[(½p)² - q]
+        // s =  ½ω₀/Q·s' ± √[¼(ω₀/Q)²s'² - ω₀²]
+        // s =  ½(ω₀/Q·s' ± 2·ω₀√[¼s'²/Q² - 4·Q²])
+        // The transformation creates two poles for each original pole
+        const std::complex<double> discriminant = 2.0 * omega0 * std::sqrt(s * s / (4.0 * Q * Q) - 1.0);
+        const std::complex<double> base         = (omega0 / Q) * s;
+
+        const std::complex<double> s1 = 0.5 * (base + discriminant);
+        const std::complex<double> s2 = 0.5 * (base - discriminant);
+
+        return { s1, s2 };
+    };
+
+    PoleZeroLocations bandPass;
+    bandPass.poles.reserve(2UZ * lowPassProto.poles.size());
+    bandPass.zeros.reserve(2UZ * lowPassProto.zeros.size());
+
+    for (const auto &pole : lowPassProto.poles) {
+        auto [bpPole1, bpPole2] = transform(pole);
+        bandPass.poles.push_back(bpPole1);
+        bandPass.poles.push_back(bpPole2);
+    }
+
+    // In LP to BP transformation, zeros at the origin in the LPF become poles at infinity (or at the cutoff frequencies) in the BPF.
+    // additionally, for each zero in LPF, we add two zeros at +/- ω₀ in BPF.
+    for (const auto &zero : lowPassProto.zeros) {
+        if (std::norm(zero) < epsilon) {
+            // for zeros at the origin, we add zeros at +/- omega0 for the BPF.
+            bandPass.zeros.emplace_back(0., +omega0);
+            bandPass.zeros.emplace_back(0., -omega0);
+        } else {
+            auto [bpZero1, bpZero2] = transform(zero);
+            bandPass.zeros.push_back(bpZero1);
+            bandPass.zeros.push_back(bpZero2);
+        }
+    }
+
+    if (lowPassProto.poles.size() > lowPassProto.zeros.size()) {
+        // need to place additional zeros - implicit zeros at infinity in the LPF become zeros at ω₀ in the BPF
+        const std::size_t additionalZeros = lowPassProto.poles.size() - lowPassProto.zeros.size();
+        for (std::size_t i = 0UZ; i < additionalZeros; ++i) {
+            bandPass.zeros.emplace_back(0., 0.);
+        }
+    }
+
+    bandPass.gain = parameters.gain / calculateResponse<Frequency::RadianPerSec, ResponseType::Magnitude>(omega0, bandPass); // normalise at centre frequency ω₀
+    return bandPass;
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+lowPassProtoToBandStop(const PoleZeroLocations &lowPassProto, FilterParameters parameters) {
+    constexpr double epsilon   = 1e-10;
+    const double     omega0    = 2. * std::numbers::pi * std::sqrt(parameters.fLow * parameters.fHigh); // centre frequency
+    const double     bandWidth = 2. * std::numbers::pi * std::abs(parameters.fHigh - parameters.fLow);
+    const double     Q         = omega0 / bandWidth; // quality factor
+
+    auto transform = [omega0, Q](const std::complex<double> &s) -> std::pair<std::complex<double>, std::complex<double>> {
+        // https://en.wikipedia.org/wiki/Prototype_filter
+        // using Zobel transform: 1/s' <- Q(s/ω₀ + ω₀/s)
+        // -> 0 = s² - ω₀/(Q·s')·s + ω₀² -> p := -ω₀/(Q·s'), q := ω₀²  -> s = -½p ± √[(½p)² - q]
+        // s =  ½ω₀/(Q·s') ± √[¼(ω₀²/(Q²·s'²) - ω₀²]
+        // s =  ½ω₀/(Q·s') ± ½ω₀·√[1/(Q·s')² - 4]
+        // The transformation creates two poles for each original pole
+        std::complex<double> discriminant = 0.5 * omega0 * std::sqrt(1.0 / (Q * Q * s * s) - 4.0);
+        std::complex<double> base         = 0.5 * omega0 / (Q * s);
+
+        std::complex<double> s1 = base + discriminant;
+        std::complex<double> s2 = base - discriminant;
+
+        return { s1, s2 };
+    };
+
+    PoleZeroLocations bandStop;
+    bandStop.poles.reserve(2UZ * lowPassProto.poles.size());
+    bandStop.zeros.reserve(2UZ * lowPassProto.zeros.size());
+    for (const auto &pole : lowPassProto.poles) {
+        auto [bpPole1, bpPole2] = transform(pole);
+        bandStop.poles.push_back(bpPole1);
+        bandStop.poles.push_back(bpPole2);
+    }
+
+    // In LP to BP transformation, zeros at the origin in the LPF become poles at infinity (or at the cutoff frequencies) in the BPF.
+    // Additionally, for each zero in LPF, we add two zeros at +/- omega0 in BPF.
+    for (const auto &zero : lowPassProto.zeros) {
+        if (std::norm(zero) < epsilon) {
+            // For zeros at the origin, we add zeros at +/- omega0 for the BPF.
+            bandStop.zeros.emplace_back(0., +omega0);
+            bandStop.zeros.emplace_back(0., -omega0);
+        } else {
+            auto [bpZero1, bpZero2] = transform(zero);
+            bandStop.zeros.push_back(bpZero1);
+            bandStop.zeros.push_back(bpZero2);
+        }
+    }
+
+    // if there are implicit zeros at infinity in the LPF, these become zeros at ω₀ in the BPF.
+    const std::size_t additionalZeros = lowPassProto.poles.size() - lowPassProto.zeros.size();
+    for (std::size_t i = 0UZ; i < additionalZeros; ++i) {
+        bandStop.zeros.emplace_back(0., +omega0);
+        bandStop.zeros.emplace_back(0., -omega0);
+    }
+
+    bandStop.gain = parameters.gain / calculateResponse<Frequency::RadianPerSec, ResponseType::Magnitude>(0., bandStop); // normalise at DC
+    return bandStop;
+}
+
+[[nodiscard]] inline constexpr PoleZeroLocations
+designAnalogFilter(const Type filterType, FilterParameters params, const Design filterDesign = Design::BUTTERWORTH) {
+    // step 1: continuous-time analog prototype
+    PoleZeroLocations analogPoleZeros;
+    switch (filterDesign) { // only the Elliptic and inverse Chebyshev (Type II) filters have zeros.
+    case Design::BUTTERWORTH: analogPoleZeros = calculateFilterButterworth(params.order); break;
+    case Design::CHEBYSHEV1: analogPoleZeros = calculateFilterChebyshevType1(params.order, params.rippleDb); break;
+    case Design::CHEBYSHEV2: analogPoleZeros = calculateFilterChebyshevType2(params.order, params.attenuationDb); break;
+    case Design::BESSEL: analogPoleZeros = calculateFilterBessel(params.order); break;
+    }
+
+    // step 2: frequency transformation (s to analog filter with desired cutoff frequencies)
+    if (filterType != Type::HIGHPASS && !std::isfinite(params.fLow)) {
+        throw std::invalid_argument("FilterParameters::fLow is NaN -> please set");
+    }
+    if (filterType != Type::LOWPASS && !std::isfinite(params.fHigh)) {
+        throw std::invalid_argument("FilterParameters::fHigh is NaN -> please set");
+    }
+
+    switch (filterType) {
+    case Type::BANDPASS: analogPoleZeros = lowPassProtoToBandPass(analogPoleZeros, params); break;
+    case Type::BANDSTOP: analogPoleZeros = lowPassProtoToBandStop(analogPoleZeros, params); break;
+    case Type::HIGHPASS: analogPoleZeros = lowPassProtoToHighPass(analogPoleZeros, params); break;
+    case Type::LOWPASS: analogPoleZeros = lowPassProtoToLowPass(analogPoleZeros, params); break;
+    }
+    return analogPoleZeros;
+}
+
+template<std::floating_point T, std::size_t maxSectionSize = std::is_same_v<std::remove_cvref_t<T>, double> ? 4UZ : 2UZ /* == 2 -> aka. 'biquads' */>
+    requires((maxSectionSize & 1) == 0) // to handle complex conjugate pole-zero pairs
+[[nodiscard]] inline constexpr auto
+designFilter(const Type filterType, FilterParameters params, const Design filterDesign = Design::BUTTERWORTH) {
+    PoleZeroLocations analogPoleZeros = designAnalogFilter(filterType, params, filterDesign);
+
+    T referenceFrequency;
+    switch (filterType) {
+    case Type::BANDPASS: referenceFrequency = std::sqrt(static_cast<T>(params.fLow * params.fHigh)); break;
+    case Type::BANDSTOP: referenceFrequency = static_cast<T>(0); break;
+    case Type::HIGHPASS: referenceFrequency = static_cast<T>(0.49 * params.fs); break;
+    case Type::LOWPASS: referenceFrequency = static_cast<T>(0); break;
+    }
+
+    if (!std::isfinite(params.fs)) {
+        throw std::invalid_argument("FilterParameters::fs is NaN -> please set");
+    }
+    // Step 3: discretisation using bi-linear transform (s -> z)
+    PoleZeroLocations digitalPoleZeros = analogToDigitalTransform(analogPoleZeros, params.fs);
+    // sort poles and zeros because the low-pass-prototype to high-/band-/stop transformation may create additional poles/zeros
+    // that are not necessary sorted according to match complex-conjugate pairs
+    digitalPoleZeros.poles = details::sortComplexWithConjugates(digitalPoleZeros.poles);
+    digitalPoleZeros.zeros = details::sortComplexWithConjugates(digitalPoleZeros.zeros);
+
+    if constexpr (maxSectionSize == 0) {
+        // Step 4: Coefficient Calculation and Gain Adjustment
+        FilterCoefficients<T> singleSection;
+        singleSection.a = expandRootsToPolynomial<T>(digitalPoleZeros.poles, params.order); // 'a' coefficients (denominator)
+        singleSection.b = expandRootsToPolynomial<T>(digitalPoleZeros.zeros, params.order); // 'b' coefficients (numerator)
+
+        const auto [ok, actualGain] = normaliseFilterCoefficients(singleSection, referenceFrequency / static_cast<T>(params.fs), static_cast<T>(params.gain));
+        if (ok) {
+            return singleSection;
+        }
+        throw std::invalid_argument(fmt::format("({}, {}, {}) gain correction {} for target gain {} too small for fs = {} f = [{},{}]", //
+                                                magic_enum::enum_name(filterDesign), magic_enum::enum_name(filterType), params.order, actualGain, params.gain, params.fs, params.fLow, params.fHigh));
+    } else { // Step 4: convert the poles and zeros into biquad sections.
+        constexpr T epsilon = static_cast<T>(1e-10);
+
+        std::vector<FilterCoefficients<T>> sections;
+        while (!digitalPoleZeros.poles.empty()) {
+            // extract and remove poles from the front
+            const std::size_t            numPoles = static_cast<T>(std::abs(digitalPoleZeros.poles.front().imag()) > epsilon) ? std::min(maxSectionSize, digitalPoleZeros.poles.size()) : 1UZ;
+            std::vector<std::complex<T>> sectionPoles(digitalPoleZeros.poles.begin(), digitalPoleZeros.poles.begin() + static_cast<ptrdiff_t>(numPoles));
+            digitalPoleZeros.poles.erase(digitalPoleZeros.poles.begin(), digitalPoleZeros.poles.begin() + static_cast<ptrdiff_t>(numPoles));
+
+            // extract and remove zeros from the front
+            const std::size_t            numZeros = std::min(maxSectionSize, digitalPoleZeros.zeros.size());
+            std::vector<std::complex<T>> sectionZeros;
+            if (!digitalPoleZeros.zeros.empty()) { // ensure we have zeros to pair with the pole
+                sectionZeros.assign(digitalPoleZeros.zeros.begin(), digitalPoleZeros.zeros.begin() + static_cast<ptrdiff_t>(numZeros));
+                digitalPoleZeros.zeros.erase(digitalPoleZeros.zeros.begin(), digitalPoleZeros.zeros.begin() + static_cast<ptrdiff_t>(numZeros));
+            }
+
+            // calculate the coefficients from these poles and zeros
+            FilterCoefficients<T> section;
+            section.a = expandRootsToPolynomial<T>(sectionPoles, numPoles);
+            section.b = expandRootsToPolynomial<T>(sectionZeros, numPoles); // Ensure it's the same order as the denominator
+
+            // Adjust the gain for each section if necessary
+            const auto [ok, actualGain] = normaliseFilterCoefficients(section, referenceFrequency / static_cast<T>(params.fs), static_cast<T>(params.gain));
+            if (ok) {
+                sections.push_back(section);
+            } else {
+                throw std::invalid_argument(fmt::format("({}, {}, {}) biquad gain correction {} for target gain {} too small for fs = {} f = [{},{}]", //
+                                                        magic_enum::enum_name(filterDesign), magic_enum::enum_name(filterType), params.order, actualGain, params.gain, params.fs, params.fLow,
+                                                        params.fHigh));
+            }
+        }
+        return sections;
+    }
+}
+
+} // namespace iir
+
+namespace fir {
+
+template<std::floating_point T>
+[[nodiscard]] inline constexpr FilterCoefficients<T>
+generateCoefficients(std::size_t N, gr::algorithm::window::Type window, T fc, T beta = static_cast<T>(1.6)) {
+    const T    M    = static_cast<T>(N - 1) / static_cast<T>(2);
+    const auto sinc = [](T x, T a = std::numbers::pi_v<T>) noexcept -> T { return x == static_cast<T>(0) ? static_cast<T>(1) : std::sin(a * x) / (a * x); };
+
+    std::vector<T> coefficients(N);
+    gr::algorithm::window::create(coefficients, window, beta);
+
+    std::size_t index = 0; // Index variable to keep track of the current index
+    std::ranges::transform(coefficients, coefficients.begin(),
+                           [&index, M, fc, &sinc](T coeff) { return coeff * static_cast<T>(2) * fc * sinc(static_cast<T>(2) * fc * (static_cast<T>(index++) - M)); });
+
+    return { coefficients };
+}
+
+/**
+ * @brief Kaiser-window based formula to estimate the number of FIR taps
+ *
+ * @param attenuationStopBand attenuation in the stopband (in dB),
+ * @param transitionWidth Δω is the width of the transition band (normalised to radians/sample).
+ * @return always returns odd-number of required taps
+ */
+[[nodiscard]] inline constexpr std::size_t
+estimateNumberOfTapsKaiser(double attenuationStopBand, double transitionWidth) {
+    auto N = static_cast<std::size_t>(std::ceil((attenuationStopBand - 8.0) / (2.285 * transitionWidth)));
+    if (N % 2 == 0) {
+        N++;
+    }
+    return N;
+}
+
+[[nodiscard]] inline constexpr double
+estimateRequiredTransitionWidth(const Type filterType, FilterParameters params) {
+    // assumption: increase #taps to achieve the required filter corner frequencies and pass-band attenuation targets
+    const double minWidthFromOrder  = 0.1 / static_cast<double>(params.order); // N.B. Butterworth approximation: 20 dB attenuation per decade and order
+    double       minTransitionWidth = minWidthFromOrder;
+    switch (filterType) {
+    case Type::LOWPASS: return std::min(minTransitionWidth, std::min(std::abs(params.fLow / params.fs), std::abs(0.5 - params.fLow / params.fs))); // attenuation at Nyquist and corner frequencies
+    case Type::HIGHPASS: return std::min(minTransitionWidth, std::abs(params.fHigh / params.fs));                                                  // attenuation at DC
+    case Type::BANDPASS: return std::min(minTransitionWidth, std::min(std::abs(params.fLow / params.fs), std::abs(0.5 - params.fHigh / params.fs)));
+    case Type::BANDSTOP: return std::min(minTransitionWidth, std::min(std::abs(0.5 - params.fHigh / params.fs), std::min(params.fLow, 0.5 * std::abs(params.fHigh - params.fLow)) / params.fs));
+    }
+}
+
+template<std::floating_point T>
+[[nodiscard]] inline constexpr FilterCoefficients<T>
+designFilter(const Type filterType, FilterParameters params, gr::algorithm::window::Type window = algorithm::window::Type::Kaiser) {
+    const std::size_t N = estimateNumberOfTapsKaiser(params.attenuationDb, 2. * std::numbers::pi * estimateRequiredTransitionWidth(filterType, params));
+
+    // design high-pass FIR filter using the window method
+    switch (filterType) {
+    case Type::LOWPASS: {
+        auto lowPassCoefficients    = generateCoefficients<T>(N, window, static_cast<T>(params.fLow / params.fs), static_cast<T>(params.beta));
+        const auto [ok, actualGain] = normaliseFilterCoefficients(lowPassCoefficients, static_cast<T>(0), static_cast<T>(params.gain));
+        if (ok) {
+            return lowPassCoefficients;
+        }
+        throw std::invalid_argument(fmt::format("({}, {}, {}) gain correction {} for target gain {} too small for fs = {} f = [{},{}]", //
+                                                magic_enum::enum_name(filterType), params.order, magic_enum::enum_name(window), actualGain, params.gain, params.fs, params.fLow, params.fHigh));
+    }
+    case Type::HIGHPASS: {
+        // generate low-pass filter coefficients with "mirror" frequency (f_s/2 - f_c)
+        auto highPassCoefficients = generateCoefficients<T>(N, window, static_cast<T>((0.5 - params.fHigh / params.fs)), static_cast<T>(params.beta));
+
+        for (std::size_t n = 0UZ; n < N; ++n) {
+            // apply spectral inversion by multiplying each coefficient with (-1)^n
+            highPassCoefficients.b[n] *= (n % 2 == 0 ? 1 : -1);
+        }
+
+        const auto [ok, actualGain] = normaliseFilterCoefficients<T>(highPassCoefficients, static_cast<T>(0.48), static_cast<T>(params.gain));
+        if (ok) {
+            return highPassCoefficients;
+        }
+        throw std::invalid_argument(fmt::format("({}, {}, {}) gain correction {} for target gain {} too small for fs = {} f = [{},{}]", //
+                                                magic_enum::enum_name(filterType), params.order, magic_enum::enum_name(window), actualGain, params.gain, params.fs, params.fLow, params.fHigh));
+    }
+    case Type::BANDPASS: {
+        auto bandPassCoefficients = generateCoefficients<T>(N, window, static_cast<T>(params.fLow / params.fs), static_cast<T>(params.beta));
+        auto highPassCoefficients = generateCoefficients<T>(N, window, static_cast<T>(params.fHigh / params.fs), static_cast<T>(params.beta));
+
+        std::transform(bandPassCoefficients.b.begin(), bandPassCoefficients.b.end(), highPassCoefficients.b.begin(), bandPassCoefficients.b.begin(), std::minus<>());
+
+        const auto [ok, actualGain] = normaliseFilterCoefficients(bandPassCoefficients, static_cast<T>(sqrt(params.fHigh * params.fLow) / params.fs), static_cast<T>(params.gain));
+        if (ok) {
+            return bandPassCoefficients;
+        }
+        throw std::invalid_argument(fmt::format("({}, {}, {}) gain correction {} for target gain {} too small for fs = {} f = [{},{}]", //
+                                                magic_enum::enum_name(filterType), params.order, magic_enum::enum_name(window), actualGain, params.gain, params.fs, params.fLow, params.fHigh));
+    }
+    case Type::BANDSTOP: {
+        auto       bandStopCoefficients = generateCoefficients<T>(N, window, static_cast<T>(params.fLow / params.fs), static_cast<T>(params.beta));
+        const auto highPassCoefficients = generateCoefficients<T>(N, window, static_cast<T>(params.fHigh / params.fs), static_cast<T>(params.beta));
+
+        for (std::size_t n = 0; n < N; ++n) {
+            bandStopCoefficients.b[n] -= highPassCoefficients.b[n];
+
+            if (N % 2 != 0 && n == (N - 1) / 2) { // adjust the centre tap if N is odd. even N are not handled here
+                bandStopCoefficients.b[n] = 1 - bandStopCoefficients.b[n];
+            }
+        }
+
+        const auto [ok, actualGain] = normaliseFilterCoefficients(bandStopCoefficients, static_cast<T>(0), static_cast<T>(params.gain));
+        if (ok) {
+            return bandStopCoefficients;
+        }
+        throw std::invalid_argument(fmt::format("({}, {}, {}) gain correction {} for target gain {} too small for fs = {} f = [{},{}]", //
+                                                magic_enum::enum_name(filterType), params.order, magic_enum::enum_name(window), actualGain, params.gain, params.fs, params.fLow, params.fHigh));
+    }
+    }
+    throw std::runtime_error("unexpectedly reached this end");
+}
+
+} // namespace fir
+} // namespace gr::filter
+
+#endif // GNURADIO_FILTERTOOL_HPP

--- a/algorithm/include/gnuradio-4.0/algorithm/fourier/window.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/fourier/window.hpp
@@ -77,7 +77,7 @@ create(ContainerType &container, Type windowFunction, const T beta = static_cast
     case Hamming: {
         // formula: w(n) = 0.54 - 0.46 * cos((2 * pi * n) / (N - 1))
         // reference: Hamming, R. W. (1977). Digital filters. Prentice-Hall.
-        const T a = pi2 / static_cast<T>(n);
+        const T a = pi2 / static_cast<T>(n - 1);
         std::ranges::transform(std::views::iota(0UL, n), container.begin(), [a](const auto i) { return static_cast<T>(0.53836) - static_cast<T>(0.46164) * std::cos(a * static_cast<T>(i)); });
         return;
     }

--- a/algorithm/test/CMakeLists.txt
+++ b/algorithm/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_ut_test(qa_algorithm_fourier)
+add_ut_test(qa_FilterTool)
 add_ut_test(qa_ImChart)
 target_link_libraries(qa_algorithm_fourier PRIVATE gnuradio-algorithm)
+target_link_libraries(qa_FilterTool PRIVATE gnuradio-algorithm)
 target_link_libraries(qa_ImChart PRIVATE gnuradio-algorithm)
 
 add_executable(example_ImChart example_ImChart.cpp)

--- a/algorithm/test/qa_FilterTool.cpp
+++ b/algorithm/test/qa_FilterTool.cpp
@@ -1,0 +1,719 @@
+#include <boost/ut.hpp>
+
+#include <benchmark.hpp>
+
+#include <algorithm>
+#include <numeric>
+#include <ranges>
+#include <vector>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <gnuradio-4.0/algorithm/filter/FilterTool.hpp>
+#include <gnuradio-4.0/algorithm/ImChart.hpp>
+
+template<gr::filter::ResponseType responseType, std::floating_point T>
+[[nodiscard]] std::vector<T>
+calculateFrequencyResponse(const std::vector<T> &frequencies, const gr::filter::iir::PoleZeroLocations &value) {
+    using namespace gr::filter;
+    std::vector<double> response(frequencies.size());
+    std::ranges::transform(frequencies, response.begin(), [&](const double &frequency) { return calculateResponse<Frequency::Hertz, responseType>(frequency, value); });
+    return response;
+}
+
+template<gr::filter::ResponseType responseType, std::floating_point T, typename... TFilterCoefficients>
+std::vector<double>
+calculateFrequencyResponse(const std::vector<double> &frequencies, T fs, TFilterCoefficients &&...filterCoefficients) {
+    std::vector<gr::filter::FilterCoefficients<T>> collection{ std::forward<TFilterCoefficients>(filterCoefficients)... };
+
+    std::vector<double> response;
+    response.reserve(frequencies.size());
+    for (auto freq : frequencies) {
+        auto transform = [normDigitalFrequency = static_cast<T>(freq) / fs](auto &filterSection) {
+            return calculateResponse<gr::filter::Frequency::Normalised, responseType>(normDigitalFrequency, filterSection);
+        };
+
+        if constexpr (responseType == gr::filter::ResponseType::Magnitude) {
+            // Magnitude combines multiplicative
+            response.emplace_back(std::transform_reduce(collection.cbegin(), collection.cend(), static_cast<T>(1), std::multiplies{}, transform));
+        } else {
+            // MagnitudeDB, Phase, PhaseDegrees combine additive
+            response.emplace_back(std::transform_reduce(collection.cbegin(), collection.cend(), static_cast<T>(0), std::plus{}, transform));
+        }
+    }
+    return response;
+}
+
+template<typename Container>
+void
+printFilter(std::string_view name, const Container &filters) {
+    if constexpr (gr::filter::iir::HasPoleZeroLocations<Container>) {
+        fmt::print("{}-section:{{ zero({}):{}, pole({}):{} }}\n", name, filters.zeros.size(), filters.zeros, filters.poles.size(), filters.poles);
+    } else if constexpr (gr::filter::HasFilterCoefficients<Container>) {
+        fmt::print("{}(1): a({}):{}, b({}):{}\n", name, filters.a.size(), filters.a, filters.b.size(), filters.b);
+    } else if constexpr (std::ranges::range<Container> && gr::filter::HasFilterCoefficients<std::ranges::range_value_t<Container>>) {
+        fmt::print("{}({}):", name, std::ranges::size(filters));
+        for (const auto &filter : filters) {
+            fmt::print("-section:{{ a({}):{}, b({}):{} }}\n", filter.a.size(), filter.a, filter.b.size(), filter.b);
+        }
+        fmt::print("\n");
+    } else {
+        static_assert(false, "container does not meet requirements for any known filter type.");
+    }
+}
+
+template<std::size_t width = 51, std::size_t height = 21>
+void
+poleZeroPlot(const gr::filter::iir::PoleZeroLocations &value, double radius = 2.0) {
+    constexpr std::size_t samples = 360Z;
+    std::vector<double>   xCircle(samples);
+    std::vector<double>   yCircle(samples);
+
+    auto angles = std::views::iota(0UZ, samples) | std::views::transform([](auto i) { return 2. * std::numbers::pi * static_cast<double>(i) / static_cast<double>(samples); });
+    std::ranges::transform(angles, xCircle.begin(), [](double angle) { return std::cos(angle); });
+    std::ranges::transform(angles, yCircle.begin(), [](double angle) { return std::sin(angle); });
+
+    std::vector<double> xPoles(value.poles.size());
+    std::vector<double> yPoles(value.poles.size());
+    std::ranges::transform(value.poles, xPoles.begin(), [](auto pole) { return pole.real(); });
+    std::ranges::transform(value.poles, yPoles.begin(), [](auto pole) { return pole.imag(); });
+
+    std::vector<double> xZeros(value.zeros.size());
+    std::vector<double> yZeros(value.zeros.size());
+    std::ranges::transform(value.zeros, xZeros.begin(), [](auto pole) { return pole.real(); });
+    std::ranges::transform(value.zeros, yZeros.begin(), [](auto pole) { return pole.imag(); });
+
+    radius = std::max(radius, std::max(*std::max_element(xPoles.begin(), xPoles.end()), *std::max_element(yPoles.begin(), yPoles.end())));
+
+    radius            = std::ceil(15 * radius) / 10.0;
+    auto chart        = gr::graphs::ImChart<width, height>({ { -radius, +radius }, { -radius, +radius } });
+    chart.axis_name_x = "Re";
+    chart.axis_name_y = "Im";
+    chart.drawAxes();
+
+    chart._lastColor = gr::graphs::Color::Type::White;
+    chart.draw(xCircle, yCircle);
+    chart._lastColor  = chart.kFirstColor;
+    chart._n_datasets = 0;
+    chart._datasets   = {};
+
+    chart.template draw<gr::graphs::Style::Marker>(xPoles, yPoles, "poles");
+    chart.template draw<gr::graphs::Style::Marker>(xZeros, yZeros, "zeros");
+
+    chart.drawLegend();
+    chart.printScreen();
+}
+
+const boost::ut::suite<"IIR FilterTool"> iirFilterToolTests = [] {
+    using namespace boost::ut;
+    using namespace gr::filter;
+    using enum Frequency;
+    using enum ResponseType;
+    using enum iir::Design;
+    using magic_enum::enum_name;
+
+    if (std::getenv("DISABLE_SENSITIVE_TESTS") == nullptr) {
+        // conditionally enable visual tests outside the CI
+        boost::ext::ut::cfg<override> = { .tag = { "visual", "benchmarks" } };
+    }
+
+    "IIR filter"_test = [](iir::Design filterDesign) {
+        using namespace gr::filter::iir;
+
+        "IIR prototype filter"_test = [&filterDesign] {
+            for (std::size_t order = 0UZ; order <= 10UZ; ++order) {
+                PoleZeroLocations analogPoleZeros;
+                switch (filterDesign) { // only the Elliptic and inverse Chebyshev (Type II) filters have zeros.
+                case BUTTERWORTH: analogPoleZeros = calculateFilterButterworth(order); break;
+                case CHEBYSHEV1: analogPoleZeros = calculateFilterChebyshevType1(order); break;
+                case CHEBYSHEV2: analogPoleZeros = calculateFilterChebyshevType2(order); break;
+                case BESSEL: analogPoleZeros = calculateFilterBessel(order); break;
+                default: throw std::invalid_argument("unknown filterType");
+                }
+
+                for (const auto &zero : analogPoleZeros.zeros) {
+                    expect(le(zero.real(), 0.)) << fmt::format("{}::zero{} is not on the left-half plane", enum_name(filterDesign), zero);
+                }
+
+                for (const auto &pole : analogPoleZeros.poles) {
+                    expect(le(pole.real(), 0.)) << fmt::format("{}::pole{} is not on the left-half plane", enum_name(filterDesign), pole);
+                }
+
+                expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(0.0, analogPoleZeros), 0.001))
+                        << fmt::format("{} - order {} has non-unity gain at DC: {:.4f}", enum_name(filterDesign), order, 1.0 / iir::calculateResponse<Hertz, Magnitude>(0.0, analogPoleZeros));
+            }
+        };
+
+        "IIR analog filter missing parameters"_test = [&filterDesign] {
+            expect(throws([&] { std::ignore = iir::designAnalogFilter(Type::LOWPASS, {}, filterDesign); })) << "undefined fLow should throw";
+            expect(throws([&] { std::ignore = iir::designAnalogFilter(Type::HIGHPASS, {}, filterDesign); })) << "undefined fLow should throw";
+            expect(throws([&] { std::ignore = iir::designAnalogFilter(Type::BANDPASS, {}, filterDesign); })) << "undefined fLow should throw";
+            expect(throws([&] { std::ignore = iir::designFilter<double>(Type::LOWPASS, { .fLow = 1.0 }, filterDesign); })) << "undefined fs should throw";
+        };
+
+        using enum Type;
+        "IIR analog filter"_test = [&filterDesign](Type filterType) {
+            for (std::size_t order = 2UZ; order <= 10UZ; ++order) {
+                constexpr double kDC           = 0.0;
+                constexpr double kFreqLow      = 1.0;
+                constexpr double kFreqHigh     = 10.0;
+                const double     kOmega0       = std::sqrt(kFreqLow * kFreqHigh);
+                constexpr double kSampling     = 1000.0;
+                constexpr double kNyquist      = kSampling / 2.0;
+                const double     kTolerance    = ((filterDesign == CHEBYSHEV2) ? 10 : 1) * 0.01;
+                const auto       kFilterParams = FilterParameters{ .order = order, .fLow = kFreqLow, .fHigh = kFreqHigh, .attenuationDb = 30, .fs = kSampling };
+
+                // compute analog filter
+                expect(nothrow([&filterDesign, &filterType, &kFilterParams]() { std::ignore = iir::designAnalogFilter(filterType, kFilterParams, filterDesign); })) //
+                        << fmt::format("{}({}) - order {} unexpectedly throws", enum_name(filterDesign), enum_name(filterType), order);
+                PoleZeroLocations analogPoleZeros = iir::designAnalogFilter(filterType, kFilterParams, filterDesign);
+
+                switch (filterType) {
+                case BANDSTOP:
+                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros), kTolerance))
+                            << fmt::format("{}({}) - order {} insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros));
+                    [[fallthrough]];
+                case LOWPASS:
+                    expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance))
+                            << fmt::format("{}({}) - order {} has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros));
+
+                    break;
+                case HIGHPASS:
+                    expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros), kTolerance))
+                            << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros));
+                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance))
+                            << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros));
+                    break;
+                case BANDPASS:
+                    expect(approx(1.0, iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros), kTolerance))
+                            << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           iir::calculateResponse<Hertz, Magnitude>(kOmega0, analogPoleZeros));
+                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros), kTolerance))
+                            << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           iir::calculateResponse<Hertz, Magnitude>(kDC, analogPoleZeros));
+                    expect(le(iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros), kTolerance))
+                            << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           iir::calculateResponse<Hertz, Magnitude>(kNyquist, analogPoleZeros));
+                    break;
+                }
+            }
+        } | std::vector{ LOWPASS, HIGHPASS, BANDSTOP, BANDPASS };
+
+        "IIR digital filter"_test = [&filterDesign](Type filterType) {
+            const std::size_t startingOrder = filterDesign == CHEBYSHEV2 ? 3UZ : 1UZ; // Chebyshev with order <=2 has notorious poor performance for band-pass/stop and <=3 for high-pass at NQ
+            for (std::size_t order = startingOrder; order <= 5UZ; ++order) {
+                constexpr double kDC           = 0.0;
+                constexpr double kFreqLow      = 1.0;
+                constexpr double kFreqHigh     = 10.0;
+                const double     kOmega0       = std::sqrt(kFreqLow * kFreqHigh);
+                constexpr double kSampling     = 1000.0;
+                constexpr double kNyquist      = kSampling / 2.0;
+                constexpr double kTolerance    = 0.01;
+                const auto       kFilterParams = FilterParameters{ .order = order, .fLow = kFreqLow, .fHigh = kFreqHigh, .attenuationDb = 50, .fs = kSampling };
+                // compute analog and digital filters
+                const PoleZeroLocations analogPoleZeros = iir::designAnalogFilter(filterType, kFilterParams, filterDesign);
+                expect(nothrow([&filterDesign, &filterType, &kFilterParams]() { std::ignore = iir::designFilter<double>(filterType, kFilterParams, filterDesign); })) //
+                        << fmt::format("({}, {}, {}) creating digital unbound filter unexpectedly throws", enum_name(filterDesign), order, enum_name(filterType));
+                const auto digitalPoleZerosFull = iir::designFilter<double>(filterType, kFilterParams, filterDesign);
+                expect(nothrow([&filterDesign, &filterType, &kFilterParams]() { std::ignore = iir::designFilter<double, 2UZ>(filterType, kFilterParams, filterDesign); })) //
+                        << fmt::format("({}, {}, {}) creating digital biquad filter unexpectedly throws", enum_name(filterDesign), enum_name(filterType), order);
+                const auto digitalPoleZerosBiquads = iir::designFilter<double, 2UZ>(filterType, kFilterParams, filterDesign);
+
+                // coarse response test
+                switch (filterType) {
+                case BANDSTOP:
+                    expect(le(calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads), kTolerance))
+                            << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           calculateResponse<Normalised, Magnitude>(kOmega0, digitalPoleZerosBiquads));
+                    [[fallthrough]];
+                case LOWPASS:
+                    expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance))
+                            << fmt::format("({}, {}, {}) has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads));
+
+                    break;
+                case HIGHPASS:
+                    expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads), kTolerance))
+                            << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads));
+                    expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance))
+                            << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads));
+                    break;
+                case BANDPASS:
+                    expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads), kTolerance))
+                            << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           calculateResponse<Normalised, Magnitude>(kOmega0 / kSampling, digitalPoleZerosBiquads));
+                    expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads), kTolerance))
+                            << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           calculateResponse<Normalised, Magnitude>(kDC, digitalPoleZerosBiquads));
+                    const double relaxFactor = filterDesign == CHEBYSHEV1 ? 20 : (order <= 2 ? 3.0 : 1.0);
+                    expect(le(calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads), relaxFactor * kTolerance))
+                            << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), order,
+                                           calculateResponse<Normalised, Magnitude>(kNyquist / kSampling, digitalPoleZerosBiquads));
+                    break;
+                }
+
+                // generate test frequency range
+                auto sequence_range = [](auto start, auto end, auto step) {
+                    using namespace std::views; // for iota and transform
+                    return iota(1, (end - start) / step + 2) | transform([=](auto i) { return start + step * (i - 1); });
+                };
+                std::vector<double> frequencies;
+                for (auto subrange : { sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.1), sequence_range(10.0, 90.0, 1.0), sequence_range(100.0, 490.0, 10.0) }) {
+                    std::ranges::move(subrange, std::back_inserter(frequencies));
+                }
+                std::vector<double> filterResponse   = calculateFrequencyResponse<Magnitude>(frequencies, analogPoleZeros);                    // provide in absolute values
+                std::vector<double> responseDigital1 = calculateFrequencyResponse<Magnitude>(frequencies, kSampling, digitalPoleZerosFull);    // provide in absolute values
+                std::vector<double> responseDigital2 = calculateFrequencyResponse<Magnitude>(frequencies, kSampling, digitalPoleZerosBiquads); // provide in absolute values
+
+                //
+                for (std::size_t i = 0UZ; i < frequencies.size(); ++i) {
+                    const double reference = filterResponse[i]; // N.B in [1]
+                    // non-biquad representation is known to be numerically unstable for order > ~4 (N.B. order: 2 -> band-[pass,stop] order: 4
+                    if (order <= 2 && reference > 0.01) {
+                        expect(le(std::abs(responseDigital1[i] - reference), (filterDesign == BESSEL || filterDesign == CHEBYSHEV2 || order <= 1UZ ? 10 : 1) * kTolerance)) //
+                                << fmt::format("({}, {}, {})@f={}Hz analog-digital mismatch: {:.2f} vs {:.2f}",                                                             //
+                                               enum_name(filterDesign), enum_name(filterType), order, frequencies[i], reference, responseDigital1[i]);
+                    }
+
+                    // biquad style filter
+                    if (reference > 0.01) { // BESSEL and CHEBYSHEV1 do not preserve the magnitude response perfectly (visually checked OK)
+                        const double relaxFactor = (filterDesign == BESSEL || order <= 1UZ || (filterDesign == CHEBYSHEV1 && filterType == HIGHPASS)
+                                                    || (filterDesign == CHEBYSHEV2 && filterType == BANDSTOP))
+                                                         ? 10
+                                                         : 1;
+                        expect(le(std::abs(responseDigital2[i] - reference), relaxFactor * kTolerance))
+                                << fmt::format("({}, {}, {})@f={}Hz analog-digital biquad mismatch: {:.2f} vs {:.2f}", //
+                                               enum_name(filterDesign), enum_name(filterType), order, frequencies[i], reference, responseDigital2[i]);
+                    }
+                }
+            }
+        } | std::vector{ LOWPASS, HIGHPASS, BANDPASS, BANDSTOP };
+    } | std::vector{ BUTTERWORTH, BESSEL, CHEBYSHEV1, CHEBYSHEV2 };
+
+    "IIR low-pass filter"_test = []<typename FilterType>(FilterType) {
+        using namespace gr::filter::iir;
+        constexpr double      fs           = 1000.;
+        constexpr Design      filterDesign = Design::BUTTERWORTH;
+        constexpr std::size_t order        = 4UZ;
+
+        constexpr std::array frequencies{ 3.0, 3.5, 5., 6.5, 7.0 };
+        const auto           digitalBandPass = iir::designFilter<double>(Type::BANDPASS, { .order = order, .fLow = 4., .fHigh = 6., .fs = fs }, filterDesign);
+        for (const auto &frequency : frequencies) {
+            auto         filter       = FilterType(digitalBandPass);
+            const double expectedGain = calculateResponse<Normalised, Magnitude>(frequency / fs, digitalBandPass);
+            double       actualGain   = 0.0;
+            for (std::size_t i = 0UZ; i < 10'000; ++i) {
+                double value = filter.processOne(std::sin(2. * std::numbers::pi * frequency / fs * static_cast<double>(i)));
+                if (i > 5'000UZ) { // skip initial transient
+                    actualGain = std::max(actualGain, std::abs(value));
+                }
+            }
+#if not defined(__EMSCRIPTEN__) // TODO: check why Emscripten fails to compute using float (old libc++) while gcc/clang do work
+            expect(approx(expectedGain, actualGain, 0.01)) << fmt::format("frequency: {} Hz, expected {} vs. actual gain {} differs", frequency, expectedGain, actualGain);
+#endif
+        }
+    } | std::tuple{Filter<double, 32UZ, Form::DF_I>(), Filter<double, 32UZ, Form::DF_II>(), Filter<double, 32UZ, Form::DF_I_TRANSPOSED>(), Filter<double, 32UZ, Form::DF_II_TRANSPOSED>()};;
+
+    tag("visual") / "basic analog low-/high-/band-pass filter - frequency"_test = []() {
+        using namespace gr::graphs;
+        using T                 = float;
+        using PoleZeroLocations = gr::filter::iir::PoleZeroLocations;
+        constexpr double fMin   = 0.1;
+        constexpr double fMax   = 1'000.0;
+
+        auto sequence_range = [](auto start, auto end, auto step) {
+            using namespace std::views; // for iota and transform
+            return iota(1, (end - start) / step + 2) | transform([=](auto i) { return start + step * (i - 1); });
+        };
+
+        std::vector<double> frequencies;
+        for (auto subrange : { sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.1), sequence_range(10.0, 90.0, 1.0), sequence_range(100.0, 1000.0, 10.0) }) {
+            std::ranges::move(subrange, std::back_inserter(frequencies));
+        }
+
+        constexpr iir::Design   filterDesign     = BUTTERWORTH;
+        constexpr std::size_t   order            = 5UZ;
+        const PoleZeroLocations filter1          = iir::designAnalogFilter(Type::LOWPASS, { .order = order, .fLow = 1., .attenuationDb = 40 }, filterDesign);
+        const auto              digitalFilter1   = iir::designFilter<T>(Type::LOWPASS, { .order = order, .fLow = 1., .attenuationDb = 40, .fs = fMax }, filterDesign);
+        std::vector<double>     lowPassResponse  = calculateFrequencyResponse<MagnitudeDB>(frequencies, filter1);
+        std::vector<double>     lowPassDigital   = calculateFrequencyResponse<MagnitudeDB>(frequencies, static_cast<T>(fMax), digitalFilter1);
+        const PoleZeroLocations filter2          = iir::designAnalogFilter(Type::HIGHPASS, { .order = order, .fHigh = 10., .attenuationDb = 40 }, filterDesign);
+        const auto              digitalFilter2   = iir::designFilter<T>(Type::HIGHPASS, { .order = order, .fHigh = 10., .attenuationDb = 40, .fs = fMax }, filterDesign);
+        std::vector<double>     highPassResponse = calculateFrequencyResponse<MagnitudeDB>(frequencies, filter2);
+        std::vector<double>     highPassDigital  = calculateFrequencyResponse<MagnitudeDB>(frequencies, static_cast<T>(fMax), digitalFilter2);
+        const PoleZeroLocations filter3          = iir::designAnalogFilter(Type::BANDPASS, { .order = order, .fLow = 1., .fHigh = 10., .attenuationDb = 40 }, filterDesign);
+        const auto              digitalFilter3   = iir::designFilter<T>(Type::BANDPASS, { .order = order, .fLow = 1., .fHigh = 10., .attenuationDb = 40, .fs = fMax }, filterDesign);
+        std::vector<double>     bandPassResponse = calculateFrequencyResponse<MagnitudeDB>(frequencies, filter3);
+        std::vector<double>     bandPassDigital  = calculateFrequencyResponse<MagnitudeDB>(frequencies, static_cast<T>(fMax), digitalFilter3);
+
+        expect(ge(frequencies.size(), 1UZ));
+        expect(eq(frequencies.size(), lowPassResponse.size()));
+        // pole-zero plots:
+        poleZeroPlot(iir::calculateFilterButterworth(order), 1.2);
+        poleZeroPlot(iir::calculateFilterChebyshevType2(order), 2.2);
+        poleZeroPlot(iir::lowPassProtoToBandPass(iir::calculateFilterChebyshevType2(order, 40.), { .fLow = 10., .fHigh = 20. }), order);
+
+        // plot
+        auto chart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({ { fMin, fMax }, { -45., +5 } });
+        chart.axis_name_x = "[Hz]";
+        chart.axis_name_y = "[dB]";
+        chart.draw(frequencies, lowPassResponse, "low");
+        chart.draw(frequencies, highPassResponse, "high");
+        chart.draw(frequencies, bandPassResponse, "band-pass");
+
+        chart.draw(frequencies, lowPassDigital, fmt::format("IIR low(N={})", countFilterCoefficients(digitalFilter1)));
+        chart.draw(frequencies, highPassDigital, fmt::format("high({})", countFilterCoefficients(digitalFilter2)));
+        chart.draw(frequencies, bandPassDigital, fmt::format("band-pass({})", countFilterCoefficients(digitalFilter3)));
+        chart.draw();
+    };
+
+    tag("visual") / "basic IIR band-pass filter frequency"_test = []() {
+        using namespace gr::filter::iir;
+        using T                       = float;
+        constexpr double fs           = 1000.;
+        constexpr Design filterDesign = BUTTERWORTH;
+        constexpr double xMin         = 0.0;
+        constexpr double xMax         = 2.01;
+
+        std::vector<double> xValues(static_cast<std::size_t>((xMax - xMin) * fs));
+        for (std::size_t i = 0UZ; i < xValues.size(); ++i) {
+            xValues[i] = xMin + static_cast<double>(i) / fs;
+        }
+
+        auto chart        = gr::graphs::ImChart<120, 16>({ { xMin, xMax }, { -5.0, +5.0 } });
+        chart.axis_name_x = "time [s]";
+        chart.axis_name_y = "IIR filter amplitude [a.u.]";
+
+        const auto digitalBandPass = iir::designFilter<T>(Type::BANDPASS, { .order = 4UZ, .fLow = 4., .fHigh = 6., .fs = fs }, filterDesign);
+
+        const auto secondOrderLowPass = FilterCoefficients<T>{ { static_cast<T>(1. / 6474.5), static_cast<T>(2. / 6474.5), static_cast<T>(1. / 6474.5) },
+                                                               { 1, static_cast<T>(-1.96454), static_cast<T>(0.96515) } };
+        printFilter("secondOrderLowPass", secondOrderLowPass);
+
+        for (const auto &frequency : { 3.0, 3.5, 5., 6.5, 7.0 }) {
+            auto filter = Filter<T, 32UZ>(digitalBandPass);
+            // auto filter = Filter<double>(secondOrderLowPass);
+            // auto filter = Filter<double>(simpleLowPass);
+            std::vector<double> yValue(xValues.size());
+            std::vector<double> yFiltered(xValues.size());
+            std::transform(xValues.cbegin(), xValues.cend(), yValue.begin(), [frequency](double t) { return 3.0 * std::sin(2. * std::numbers::pi * frequency * t); });
+            std::transform(yValue.cbegin(), yValue.cend(), yFiltered.begin(), [&filter](double y) { return filter.processOne(static_cast<T>(y)); });
+            chart.draw(xValues, yFiltered, fmt::format("filtered@{}Hz", frequency));
+        }
+
+        chart.draw();
+    };
+};
+
+const boost::ut::suite<"FIR FilterTool"> firFilterToolTests = [] {
+    using namespace boost::ut;
+    using namespace gr::filter;
+    using enum Frequency;
+    using enum ResponseType;
+    using magic_enum::enum_name;
+
+    if (std::getenv("DISABLE_SENSITIVE_TESTS") == nullptr) {
+        // conditionally enable visual tests outside the CI
+        boost::ext::ut::cfg<override> = { .tag = { "visual", "benchmarks" } };
+    }
+
+    using enum gr::algorithm::window::Type;
+    "IIR digital filter"_test = [](gr::algorithm::window::Type filterDesign) {
+        using enum gr::filter::Type;
+
+        "IIR digital filter"_test = [&filterDesign](Type filterType) {
+            constexpr auto kFilterParams = FilterParameters{ .order = 4UZ, .fLow = 1.0, .fHigh = 10.0, .attenuationDb = 60, .fs = 1000.0 };
+
+            // compute analog and digital filters
+
+            expect(nothrow([&filterDesign, &filterType, &kFilterParams]() { std::ignore = fir::designFilter<double>(filterType, kFilterParams, filterDesign); })) //
+                    << fmt::format("({}, {}, {}) creating digital unbound filter unexpectedly throws", enum_name(filterDesign), kFilterParams.order, enum_name(filterType));
+            const FilterCoefficients<double> digitalFilter = fir::designFilter<double>(filterType, kFilterParams, filterDesign);
+
+            // coarse response test
+            constexpr double kTolerance = 0.01;
+            constexpr double kDC        = 0.0;
+            constexpr double kNyquist   = 0.48;
+            const double     kOmega0    = std::sqrt(kFilterParams.fLow * kFilterParams.fHigh) / kFilterParams.fs;
+            switch (filterType) {
+            case BANDSTOP:
+                expect(le(calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter), 5. * kTolerance))
+                        << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
+                                       calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter));
+                [[fallthrough]];
+            case LOWPASS:
+                expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance))
+                        << fmt::format("({}, {}, {}) has non-unity gain at DC: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
+                                       calculateResponse<Normalised, Magnitude>(kDC, digitalFilter));
+
+                break;
+            case HIGHPASS:
+                expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter), kTolerance))
+                        << fmt::format("({}, {}, {}) has non-unity gain at NQ: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
+                                       calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter));
+                expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance))
+                        << fmt::format("({}, {}, {}) insufficient gain in stop-band: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
+                                       calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter));
+                break;
+            case BANDPASS:
+                expect(approx(1.0, calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter), kTolerance))
+                        << fmt::format("({}, {}, {}) has non-unity gain at omega0: {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
+                                       calculateResponse<Normalised, Magnitude>(kOmega0, digitalFilter));
+                expect(le(calculateResponse<Normalised, Magnitude>(kDC, digitalFilter), kTolerance))
+                        << fmt::format("({}, {}, {}) insufficient gain in stop-band (DC): {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
+                                       calculateResponse<Normalised, Magnitude>(kDC, digitalFilter));
+                expect(le(calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter), kTolerance))
+                        << fmt::format("({}, {}, {}) insufficient gain in stop-band (NQ): {:.4f}", enum_name(filterDesign), enum_name(filterType), kFilterParams.order,
+                                       calculateResponse<Normalised, Magnitude>(kNyquist, digitalFilter));
+                break;
+            }
+
+            // N.B. cannot test magnitude response shape since there are not analog-vs-digital equivalents to compare
+        } | std::vector{ LOWPASS, HIGHPASS, BANDPASS, BANDSTOP }; //
+    } | std::vector{ Kaiser, Hamming, Hann };
+
+    tag("visual") / "basic fir tests"_test = []() {
+        using namespace gr::graphs;
+        constexpr auto kFilterParams = FilterParameters{ .order = 4UZ, .fLow = 1.0, .fHigh = 10.0, .gain = 0.5, .attenuationDb = 50., .fs = 1000.0 };
+
+        using enum gr::algorithm::window::Type;
+        const auto window = Kaiser;
+        using enum gr::filter::Type;
+
+        // generate test frequency range
+        auto sequence_range = [](auto start, auto end, auto step) {
+            using namespace std::views; // for iota and transform
+            return iota(1, (end - start) / step + 2) | transform([=](auto i) { return start + step * (i - 1); });
+        };
+        std::vector<double> frequencies;
+        for (auto subrange : { sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.01), sequence_range(10.0, 90.0, 0.1), sequence_range(100.0, 490.0, 10.0) }) {
+            std::ranges::move(subrange, std::back_inserter(frequencies));
+        }
+        const auto          lowPassFilter    = fir::designFilter<double>(LOWPASS, kFilterParams, window);
+        const auto          highPassFilter   = fir::designFilter<double>(HIGHPASS, kFilterParams, window);
+        const auto          bandPassFilter   = fir::designFilter<double>(BANDPASS, kFilterParams, window);
+        std::vector<double> lowPassResponse  = calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParams.fs, lowPassFilter);
+        std::vector<double> highPassResponse = calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParams.fs, highPassFilter);
+        std::vector<double> bandPassResponse = calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParams.fs, bandPassFilter);
+
+        // plots
+        auto chart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({ { 0.1, kFilterParams.fs }, { -45., +5 } });
+        chart.axis_name_x = "[Hz]";
+        chart.axis_name_y = "[dB]";
+        chart.draw(frequencies, lowPassResponse, fmt::format("FIR low(N={})", countFilterCoefficients(lowPassFilter)));
+        chart.draw(frequencies, highPassResponse, fmt::format("high({})", countFilterCoefficients(highPassFilter)));
+        chart.draw(frequencies, bandPassResponse, fmt::format("band-pass({})", countFilterCoefficients(bandPassFilter)));
+        chart.draw();
+
+        auto highPassResponses        = gr::graphs::ImChart<119, 21, LogAxisTransform>({ { 0.1, kFilterParams.fs }, { -45., +5 } });
+        highPassResponses.axis_name_x = "[Hz]";
+        highPassResponses.axis_name_y = "band-stop response [dB]";
+        for (auto &windowType : { Kaiser, Hamming, Rectangular, Hann, BlackmanNuttall }) {
+            auto                filter   = fir::designFilter<double>(BANDSTOP, kFilterParams, windowType);
+            std::vector<double> response = calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParams.fs, filter);
+            highPassResponses.draw(frequencies, response, fmt::format("{}({})", enum_name(windowType), filter.b.size()));
+        }
+        highPassResponses.draw();
+    };
+
+    tag("visual") / "basic FIR band-pass filter frequency"_test = []() {
+        constexpr auto   kFilterParams = FilterParameters{ .order = 2UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50, .fs = 1000.0 };
+        constexpr double xMin          = 0.0;
+        constexpr double xMax          = 2.01;
+
+        std::vector<double> xValues(static_cast<std::size_t>((xMax - xMin) * kFilterParams.fs));
+        for (std::size_t i = 0UZ; i < xValues.size(); ++i) {
+            xValues[i] = xMin + static_cast<double>(i) / kFilterParams.fs;
+        }
+
+        auto chart        = gr::graphs::ImChart<120, 16>({ { xMin, xMax }, { -5.0, +5.0 } });
+        chart.axis_name_x = "time [s]";
+        chart.axis_name_y = "FIR filter amplitude [a.u.]";
+
+        const auto window          = gr::algorithm::window::Type::Kaiser;
+        const auto digitalBandPass = fir::designFilter<double>(Type::BANDPASS, kFilterParams, window);
+        // printFilter("digitalBandPass", digitalBandPass);
+        for (const auto &frequency : { 3.0, 3.5, 5., 6.5, 7.0 }) {
+            auto                filter = Filter<double>(digitalBandPass);
+            std::vector<double> yValue(xValues.size());
+            std::vector<double> yFiltered(xValues.size());
+            std::transform(xValues.cbegin(), xValues.cend(), yValue.begin(), [frequency](double t) { return 3.0 * std::sin(2. * std::numbers::pi * frequency * t); });
+            std::transform(yValue.cbegin(), yValue.cend(), yFiltered.begin(), [&filter](double y) { return filter.processOne(y); });
+            expect(nothrow([&] { chart.draw(xValues, yFiltered, fmt::format("filtered@{}Hz", frequency)); })) << fmt::format("filtered@{}Hz does not throw", frequency);
+        }
+
+        expect(nothrow([&] { chart.draw(); }));
+    };
+};
+
+const boost::ut::suite<"IIR & FIR Benchmarks"> filterBenchmarks = [] {
+    using namespace boost::ut;
+    using namespace gr::filter;
+    using enum Frequency;
+    using enum ResponseType;
+    using enum gr::filter::Type;
+    using enum iir::Design;
+    using magic_enum::enum_name;
+
+    "IIR vs. FIR coefficients"_test = [](Type filterType) {
+        constexpr FilterParameters kFilterParameter{ .order = 4UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50., .fs = 1000. };
+        const auto                 iirFilter = iir::designFilter<double>(filterType, kFilterParameter);
+        const auto                 firFilter = fir::designFilter<double>(filterType, kFilterParameter);
+        std::size_t                nIIR      = countFilterCoefficients(iirFilter);
+        std::size_t                nFIR      = countFilterCoefficients(firFilter);
+        expect(le(nIIR, nFIR)) << fmt::format("{} complexity: #IIR {} vs. #FIR {}", enum_name(filterType), nIIR, nFIR);
+        tag("visual") / "filter benchmarks"_test = [&] { fmt::print("{} complexity: #IIR {} vs. #FIR {}\n", enum_name(filterType), nIIR, nFIR); };
+    } | std::vector{ LOWPASS, HIGHPASS, BANDPASS, BANDSTOP };
+
+    "IIR vs. FIR magnitude and phase"_test = []() {
+        using namespace gr::graphs;
+        using enum gr::algorithm::window::Type;
+
+        constexpr FilterParameters kFilterParameter{ .order = 4UZ, .fLow = 10., .gain = 0.5, .fs = 1000. };
+        const auto                 iirFilter1 = iir::designFilter<double>(LOWPASS, kFilterParameter, BUTTERWORTH);
+        const auto                 iirFilter2 = iir::designFilter<double>(LOWPASS, kFilterParameter, BESSEL);
+        const auto                 firFilter1 = fir::designFilter<double>(LOWPASS, kFilterParameter, Kaiser);
+        const auto                 firFilter2 = fir::designFilter<double>(LOWPASS, kFilterParameter, Hamming);
+
+        // generate test frequency range
+        auto sequence_range = [](auto start, auto end, auto step) {
+            using namespace std::views; // for iota and transform
+            return iota(1, (end - start) / step + 2) | transform([=](auto i) { return start + step * (i - 1); });
+        };
+        std::vector<double> frequencies;
+        for (auto subrange : { sequence_range(0.1, 0.9, 0.01), sequence_range(1.0, 9.0, 0.01), sequence_range(10.0, 90.0, 0.1), sequence_range(100.0, 490.0, 10.0) }) {
+            std::ranges::move(subrange, std::back_inserter(frequencies));
+        }
+
+        //
+        const auto magResponse = [&frequencies, &kFilterParameter](auto &filter) { return calculateFrequencyResponse<MagnitudeDB>(frequencies, kFilterParameter.fs, filter); };
+
+        auto magnitudeChart        = gr::graphs::ImChart<119, 21, LogAxisTransform>({ { 0.1, kFilterParameter.fs }, { -45., +5 } });
+        magnitudeChart.axis_name_x = "[Hz]";
+        magnitudeChart.axis_name_y = "IIR vs. FIR response [dB]";
+        magnitudeChart.draw(frequencies, magResponse(iirFilter1), fmt::format("Butterworth(N={})", countFilterCoefficients(iirFilter1)));
+        magnitudeChart.draw(frequencies, magResponse(iirFilter2), fmt::format("Bessel({})", countFilterCoefficients(iirFilter1)));
+        magnitudeChart.draw(frequencies, magResponse(firFilter1), fmt::format("Kaiser({})", countFilterCoefficients(firFilter1)));
+        magnitudeChart.draw(frequencies, magResponse(firFilter2), fmt::format("Hamming({})", countFilterCoefficients(firFilter2)));
+
+        magnitudeChart.draw();
+
+        const auto phaseResponse = [&frequencies, &kFilterParameter](auto &filter, double corr = 0UZ, double offset = 0.) {
+            const auto groupDelay = (corr + static_cast<double>(countFilterCoefficients(filter)) - 1.0) / 2.0 / kFilterParameter.fs; // just a coarse estimate
+
+            auto normalisedPhase = calculateFrequencyResponse<PhaseDegrees>(frequencies, kFilterParameter.fs, filter);
+            std::transform(normalisedPhase.begin(), normalisedPhase.end(), frequencies.begin(), normalisedPhase.begin(),                                                   //
+                           [groupDelay, offset](auto phase, auto frequency) { return std::fmod(offset + phase + groupDelay * frequency * 360.0 + 180.0, 360.) - 180.0; }); // [-180°, 180°]
+            return normalisedPhase;
+        };
+
+        auto phaseChart        = gr::graphs::ImChart<130, 33, LogAxisTransform>({ { 0.1, kFilterParameter.fs }, { -.5, +.5 } });
+        phaseChart.axis_name_x = "[Hz]";
+        phaseChart.axis_name_y = "IIR vs. FIR rel. non-linear phase response [°]";
+        phaseChart.draw(frequencies, phaseResponse(iirFilter1, 72.5), fmt::format("Butterworth(N={})", countFilterCoefficients(iirFilter1)));
+        phaseChart.draw(frequencies, phaseResponse(iirFilter2, 55.8), fmt::format("Bessel({})", countFilterCoefficients(iirFilter1)));
+        phaseChart.draw(frequencies, phaseResponse(firFilter1, 0., -0.1), fmt::format("Kaiser({}) -0.1°", countFilterCoefficients(firFilter1)));
+        phaseChart.draw(frequencies, phaseResponse(firFilter2, 0., -0.05), fmt::format("Hamming({}) -0.05°", countFilterCoefficients(firFilter2)));
+
+        phaseChart.draw();
+    };
+
+#if not defined(__EMSCRIPTEN__) // TODO: check why Emscripten fails to compute using float (old libc++) while gcc/clang do work
+    tag("benchmarks") / "filter benchmarks"_test = []<typename T>(T) {
+        using namespace benchmark;
+        using namespace gr::filter::iir;
+        constexpr FilterParameters kFilterParameter{ .order = 4UZ, .fLow = 4., .fHigh = 6., .attenuationDb = 50., .fs = 1000. };
+        constexpr Design           filterDesign = BUTTERWORTH;
+
+        constexpr std::size_t nSamples = 100'000;
+        std::vector<T>        yValues(nSamples);
+        const T               centreFrequency = std::sqrt(static_cast<T>(kFilterParameter.fLow * kFilterParameter.fHigh));
+        for (std::size_t i = 0UZ; i < yValues.size(); ++i) {
+            yValues[i] = std::sin(static_cast<T>(2) * std::numbers::pi_v<T> * centreFrequency / static_cast<T>(kFilterParameter.fs) * static_cast<T>(i));
+        }
+
+        auto processSignal = [](auto &filter, const std::vector<T> &yValues) -> T {
+            T           actualGain       = 0.0;
+            std::size_t processedSamples = 0UZ;
+            for (auto &yValue : yValues) {
+                T filteredValue = filter.processOne(yValue);
+                processedSamples++;
+                if (processedSamples > yValues.size() / 2UZ) { // ignore initial transient
+                    actualGain = std::max(actualGain, std::abs(filteredValue));
+                }
+            }
+            return actualGain;
+        };
+
+        {
+            T                       actualGain = 0.0;
+            gr::HistoryBuffer<T, 8> buffer;
+            ::benchmark::benchmark<10>(fmt::format("HistoryBuffer<{}>", gr::meta::type_name<T>()), nSamples) = [&actualGain, &buffer, &yValues] {
+                for (auto &yValue : yValues) {
+                    buffer.push_back(yValue);
+                    actualGain = std::max(actualGain, buffer[0]);
+                }
+            };
+            expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1)));
+        }
+        const auto digitalBandPass = iir::designFilter<T>(Type::BANDPASS, kFilterParameter, filterDesign);
+        {
+            T    actualGain                                       = 0.0;
+            auto filter                                           = Filter<T, 32UZ, Form::DF_I, std::execution::unseq>(digitalBandPass);
+            "IIR DF_I exec::unseq"_benchmark.repeat<10>(nSamples) = [&processSignal, &actualGain, &filter, &yValues] { actualGain = processSignal(filter, yValues); };
+            expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1))) << std::format("IIR DF_I exec::unseq approx settling gain threshold for {}", gr::meta::type_name<T>());
+        }
+        {
+            T    actualGain                                     = 0.0;
+            auto filter                                         = Filter<T, 32UZ, Form::DF_I, std::execution::par>(digitalBandPass);
+            "IIR DF_I exec::par"_benchmark.repeat<10>(nSamples) = [&processSignal, &actualGain, &filter, &yValues] { actualGain = processSignal(filter, yValues); };
+            expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1))) << std::format("IIR DF_I exec::par approx settling gain threshold for {}", gr::meta::type_name<T>());
+        }
+        {
+            T    actualGain                                     = 0.0;
+            auto filter                                         = Filter<T, 32UZ, Form::DF_I>(digitalBandPass);
+            "IIR DF_I exec::seq"_benchmark.repeat<10>(nSamples) = [&processSignal, &actualGain, &filter, &yValues] { actualGain = processSignal(filter, yValues); };
+            expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1))) << std::format("IIR DF_I exec::sec approx settling gain threshold for {}", gr::meta::type_name<T>());
+        }
+        {
+            T    actualGain                                      = 0.0;
+            auto filter                                          = Filter<T, 32UZ, Form::DF_II>(digitalBandPass);
+            "IIR DF_II exec::seq"_benchmark.repeat<10>(nSamples) = [&processSignal, &actualGain, &filter, &yValues] { actualGain = processSignal(filter, yValues); };
+            expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1))) << std::format("DF_II exec::seq approx settling gain threshold for {}", gr::meta::type_name<T>());
+        }
+        {
+            T    actualGain                                                 = 0.0;
+            auto filter                                                     = Filter<T, 32UZ, Form::DF_I_TRANSPOSED>(digitalBandPass);
+            "IIR DF_I_TRANSPOSED exec::seq "_benchmark.repeat<10>(nSamples) = [&processSignal, &actualGain, &filter, &yValues] { actualGain = processSignal(filter, yValues); };
+            expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1))) << std::format("DF_I_TRANSPOSED exec::seq approx settling gain threshold for {}", gr::meta::type_name<T>());
+        }
+#if not defined(__EMSCRIPTEN__)
+        {
+            T    actualGain                                                 = 0.0;
+            auto filter                                                     = Filter<T, 32UZ, Form::DF_II_TRANSPOSED>(digitalBandPass);
+            "IIR DF_II_TRANSPOSED exec::seq"_benchmark.repeat<10>(nSamples) = [&processSignal, &actualGain, &filter, &yValues] { actualGain = processSignal(filter, yValues); };
+            expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1))) << std::format("DF_II_TRANSPOSED exec::seq approx settling gain threshold for {}", gr::meta::type_name<T>());
+        }
+#endif
+        const auto digitalBandPassFir = fir::designFilter<T>(Type::BANDPASS, kFilterParameter);
+        {
+            T    actualGain                              = 0.0;
+            auto filter                                  = Filter<T>(digitalBandPassFir);
+            "FIR default"_benchmark.repeat<10>(nSamples) = [&processSignal, &actualGain, &filter, &yValues] { actualGain = processSignal(filter, yValues); };
+            expect(approx(actualGain, static_cast<T>(1), static_cast<T>(0.1))) << std::format("FIR approx settling gain threshold for {}", gr::meta::type_name<T>());
+        }
+        ::benchmark::results::add_separator();
+    } | std::tuple<double, float>{ 1.0, 1.0f };
+#endif
+};
+
+int
+main() { /* not needed for UT */
+}

--- a/algorithm/test/qa_algorithm_fourier.cpp
+++ b/algorithm/test/qa_algorithm_fourier.cpp
@@ -193,7 +193,7 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
     "window pre-computed array tests"_test = []<typename T>() { // this tests regression w.r.t. changed implementations
         // Expected value for size 8
         std::array RectangularRef{ 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f, 1.f };
-        std::array HammingRef{ 0.07672f, 0.2119312255f, 0.53836f, 0.8647887745f, 1.0f, 0.8647887745f, 0.53836f, 0.2119312255f };
+        std::array HammingRef{ 0.07672f, 0.25053218f, 0.64108455f, 0.9542833f, 0.95428324f, 0.6410846f, 0.25053206f, 0.07672f };
         std::array HannRef{ 0.f, 0.1882550991f, 0.611260467f, 0.950484434f, 0.950484434f, 0.611260467f, 0.1882550991f, 0.f };
         std::array BlackmanRef{ 0.f, 0.09045342435f, 0.4591829575f, 0.9203636181f, 0.9203636181f, 0.4591829575f, 0.09045342435f, 0.f };
         std::array BlackmanHarrisRef{ 0.00006f, 0.03339172348f, 0.3328335043f, 0.8893697722f, 0.8893697722f, 0.3328335043f, 0.03339172348f, 0.00006f };

--- a/blocks/filter/include/gnuradio-4.0/filter/time_domain_filter.hpp
+++ b/blocks/filter/include/gnuradio-4.0/filter/time_domain_filter.hpp
@@ -32,7 +32,7 @@ H(z) = b[0] + b[1]*z^-1 + b[2]*z^-2 + ... + b[N]*z^-N
     constexpr T
     processOne(T input) noexcept {
         inputHistory.push_back(input);
-        return std::inner_product(b.begin(), b.end(), inputHistory.rbegin(), static_cast<T>(0));
+        return std::inner_product(b.cbegin(), b.cend(), inputHistory.cbegin(), static_cast<T>(0));
     }
 };
 
@@ -73,27 +73,27 @@ a are the feedback coefficients
             // y[n] = b[0] * x[n]   + b[1] * x[n-1] + ... + b[N] * x[n-N]
             //      - a[1] * y[n-1] - a[2] * y[n-2] - ... - a[M] * y[n-M]
             inputHistory.push_back(input);
-            const T output = std::inner_product(b.begin(), b.end(), inputHistory.rbegin(), static_cast<T>(0))       // feed-forward path
-                           - std::inner_product(a.begin() + 1, a.end(), outputHistory.rbegin(), static_cast<T>(0)); // feedback path
+            const T output = std::inner_product(b.cbegin(), b.cend(), inputHistory.cbegin(), static_cast<T>(0))       // feed-forward path
+                           - std::inner_product(a.cbegin() + 1, a.cend(), outputHistory.cbegin(), static_cast<T>(0)); // feedback path
             outputHistory.push_back(output);
             return output;
         } else if constexpr (form == IIRForm::DF_II) {
             // w[n] = x[n] - a[1] * w[n-1] - a[2] * w[n-2] - ... - a[M] * w[n-M]
             // y[n] =        b[0] * w[n]   + b[1] * w[n-1] + ... + b[N] * w[n-N]
-            const T w = input - std::inner_product(a.begin() + 1, a.end(), inputHistory.rbegin(), T{ 0 });
+            const T w = input - std::inner_product(a.cbegin() + 1, a.cend(), inputHistory.cbegin(), T{ 0 });
             inputHistory.push_back(w);
-            return std::inner_product(b.begin(), b.end(), inputHistory.rbegin(), T{ 0 });
+            return std::inner_product(b.cbegin(), b.cend(), inputHistory.cbegin(), T{ 0 });
         } else if constexpr (form == IIRForm::DF_I_TRANSPOSED) {
             // w_1[n] = x[n] - a[1] * w_2[n-1] - a[2] * w_2[n-2] - ... - a[M] * w_2[n-M]
             // y[n]   = b[0] * w_2[n] + b[1] * w_2[n-1] + ... + b[N] * w_2[n-N]
-            T v0 = input - std::inner_product(a.begin() + 1, a.end(), outputHistory.rbegin(), static_cast<T>(0));
+            T v0 = input - std::inner_product(a.cbegin() + 1, a.cend(), outputHistory.cbegin(), static_cast<T>(0));
             outputHistory.push_back(v0);
-            return std::inner_product(b.begin(), b.end(), outputHistory.rbegin(), static_cast<T>(0));
+            return std::inner_product(b.cbegin(), b.cend(), outputHistory.cbegin(), static_cast<T>(0));
         } else if constexpr (form == IIRForm::DF_II_TRANSPOSED) {
             // y[n] = b_0*f[n] + \sum_(k=1)^N(b_k*f[n−k] − a_k*y[n−k])
             const T output = b[0] * input                                                                         //
-                           + std::inner_product(b.begin() + 1, b.end(), inputHistory.rbegin(), static_cast<T>(0)) //
-                           - std::inner_product(a.begin() + 1, a.end(), outputHistory.rbegin(), static_cast<T>(0));
+                           + std::inner_product(b.cbegin() + 1, b.cend(), inputHistory.cbegin(), static_cast<T>(0)) //
+                           - std::inner_product(a.cbegin() + 1, a.cend(), outputHistory.cbegin(), static_cast<T>(0));
 
             inputHistory.push_back(input);
             outputHistory.push_back(output);

--- a/core/include/gnuradio-4.0/HistoryBuffer.hpp
+++ b/core/include/gnuradio-4.0/HistoryBuffer.hpp
@@ -23,51 +23,58 @@ namespace gr {
  * Example usage:
  * gr::history_buffer<int, 5> buffer;
  * buffer.push_back(1);  // buffer: [1] (size: 1, capacity: 5)
- * buffer.push_back(2);  // buffer: [1, 2] (size: 2, capacity: 5)
- * buffer.push_back(3);  // buffer: [1, 2, 3] (size: 3, capacity: 5)
- * buffer.push_back(4);  // buffer: [1, 2, 3, 4] (size: 4, capacity: 5)
- * buffer.push_back(5);  // buffer: [1, 2, 3, 4, 5] (size: 5, capacity: 5)
- * buffer.push_back(6);  // buffer: [2, 3, 4, 5, 6] (size: 5, capacity: 5)
+ * buffer.push_back(2);  // buffer: [2, 1] (size: 2, capacity: 5)
+ * buffer.push_back(3);  // buffer: [3, 2, 1] (size: 3, capacity: 5)
+ * buffer.push_back(4);  // buffer: [4, 3, 2, 1] (size: 4, capacity: 5)
+ * buffer.push_back(5);  // buffer: [5, 4, 3, 2, 1] (size: 5, capacity: 5)
+ * buffer.push_back(6);  // buffer: [6, 5, 4, 3, 2] (size: 5, capacity: 5)
  *
  * // :
  * buffer[0];     // value: 6 - unchecked access of last/actual sample
- * buffer[-1];    // value: 5 - unchecked access of previous sample
+ * buffer[1];     // value: 5 - unchecked access of previous sample
  * ...
  * buffer.at(0);  // value: 6 - checked access of last/actual sample
- * buffer.at(-1); // value: 5 - checked access of last/actual sample
+ * buffer.at(1); // value: 5 - checked access of last/actual sample
  * ...
- * buffer.get_span(0, 3);  // span: [4, 5, 6]
- * buffer.get_span(1, 3);  // span: [3, 4, 5]
- * buffer.get_span(0);     // span: [2, 3, 4, 5, 6]
- * buffer.get_span(1);     // span: [2, 3, 4, 5]
+ * buffer.get_span(0, 3);  // span: [6, 5, 4]
+ * buffer.get_span(1, 3);  // span: [6, 3]
+ * buffer.get_span(0);     // span: [6, 5, 4, 3, 2]
+ * buffer.get_span(1);     // span: [5, 4, 3, 2s]
  */
 template<typename T, std::size_t N = std::dynamic_extent, typename Allocator = std::allocator<T>>
 class HistoryBuffer {
     using signed_index_type = std::make_signed_t<std::size_t>;
     using buffer_type       = typename std::conditional_t<N == std::dynamic_extent, std::vector<T, Allocator>, std::array<T, N * 2>>;
-    using size_type         = typename std::conditional_t<N == std::dynamic_extent, std::size_t, std::size_t>;
 
-    buffer_type _buffer;
+    buffer_type _buffer{};
     std::size_t _capacity = N;
     std::size_t _write_position{ 0 };
-    std::size_t _size{ 0 };
+    std::size_t _size{ 0UZ };
 
     /**
      * @brief maps the logical index to the physical index in the buffer.
      */
     constexpr inline std::size_t
-    map_index(signed_index_type index) const noexcept {
-        if constexpr (N == std::dynamic_extent) {
-            return static_cast<std::size_t>((static_cast<signed_index_type>(_write_position + _capacity - 1) + index)) % _capacity;
-        } else {
-            return static_cast<std::size_t>((static_cast<signed_index_type>(_write_position + N - 1) + index)) % N;
+    map_index(std::size_t index) const noexcept {
+        if constexpr (N == std::dynamic_extent) { // runtime checks
+            if (std::has_single_bit(_capacity)) { // _capacity is a power of two
+                return (_write_position + index) & (_capacity - 1UZ);
+            } else { // fallback
+                return (_write_position + index) % _capacity;
+            }
+        } else {                                    // compile-time checks
+            if constexpr (std::has_single_bit(N)) { // N is a power of two
+                return (_write_position + index) & (N - 1UZ);
+            } else { // fallback to modulo operation if not a power of two
+                return (_write_position + index) % N;
+            }
         }
     }
 
 public:
     constexpr explicit HistoryBuffer() noexcept { static_assert(N != std::dynamic_extent, "need to specify capacity"); }
 
-    constexpr explicit HistoryBuffer(size_t capacity) : _buffer(capacity * 2), _capacity(capacity) {
+    constexpr explicit HistoryBuffer(std::size_t capacity) : _buffer(capacity * 2), _capacity(capacity) {
         if (capacity == 0) {
             throw std::out_of_range("capacity is zero");
         }
@@ -79,11 +86,15 @@ public:
      */
     constexpr void
     push_back(const T &value) noexcept {
+        if (_size < _capacity) [[unlikely]] {
+            ++_size;
+        }
+        if (_write_position == 0) [[unlikely]] {
+            _write_position = _capacity;
+        }
+        --_write_position;
         _buffer[_write_position]             = value;
-        _buffer[_write_position + _capacity] = _buffer[_write_position];
-        ++_write_position;
-        [[unlikely]] if (_write_position == _capacity) { _write_position = 0; }
-        _size = std::min(_size + 1, _capacity);
+        _buffer[_write_position + _capacity] = value;
     }
 
     /**
@@ -112,29 +123,27 @@ public:
      * @brief unchecked accesses of the element at the specified logical index.
      */
     constexpr T &
-    operator[](signed_index_type index) noexcept {
+    operator[](std::size_t index) noexcept {
         return _buffer[map_index(index)];
     }
 
     [[nodiscard]] constexpr const T &
-    operator[](signed_index_type index) const noexcept {
+    operator[](std::size_t index) const noexcept {
         return _buffer[map_index(index)];
     }
 
     [[nodiscard]] constexpr T &
-    at(signed_index_type index) {
-        const auto signed_size = static_cast<signed_index_type>(_size);
-        if (index > 0 || index <= -signed_size) {
-            throw std::out_of_range(fmt::format("index {} out of range ]{}, {}]", index, -signed_size, 0));
+    at(std::size_t index) noexcept(false) {
+        if (index >= _size) {
+            throw std::out_of_range(fmt::format("index {} out of range [0, {})", index, _size));
         }
         return _buffer[map_index(index)];
     }
 
     [[nodiscard]] constexpr const T &
-    at(signed_index_type index) const {
-        const auto signed_size = static_cast<signed_index_type>(_size);
-        if (index > 0 || index <= -signed_size) {
-            throw std::out_of_range(fmt::format("index {} out of range ]{}, {}]", index, -signed_size, 0));
+    at(std::size_t index) const noexcept(false) {
+        if (index >= _size) {
+            throw std::out_of_range(fmt::format("index {} out of range [0, {})", index, _size));
         }
         return _buffer[map_index(index)];
     }
@@ -149,53 +158,63 @@ public:
         return _capacity;
     }
 
+    [[nodiscard]] constexpr T *
+    data() noexcept {
+        return _buffer.data();
+    }
+
+    [[nodiscard]] constexpr const T *
+    data() const noexcept {
+        return _buffer.data();
+    }
+
     /**
      * @brief Returns a span of elements with given (optional) length with the last element being the newest
      */
     [[nodiscard]] constexpr std::span<const T>
-    get_span(signed_index_type index, std::size_t length = std::dynamic_extent) const /*noexcept*/ {
-        length = std::clamp(length, 0LU, std::max(0UL, static_cast<std::size_t>(static_cast<signed_index_type>(size()) + index)));
-        return std::span<const T>(cend() + static_cast<typename buffer_type::difference_type>(index - static_cast<signed_index_type>(length)), length);
+    get_span(std::size_t index, std::size_t length = std::dynamic_extent) const {
+        length = std::clamp(length, 0LU, std::min(_size - index, length));
+        return std::span<const T>(&_buffer[map_index(index)], length);
     }
 
     [[nodiscard]] auto
     begin() noexcept {
-        return _buffer.begin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity - _size);
+        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position));
     }
 
     [[nodiscard]] constexpr auto
-    begin() const {
-        return _buffer.begin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity - _size);
+    begin() const noexcept {
+        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position));
     }
 
     [[nodiscard]] constexpr auto
-    cbegin() const {
-        return _buffer.cbegin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity - _size);
+    cbegin() const noexcept {
+        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position));
     }
 
     [[nodiscard]] auto
     end() noexcept {
-        return _buffer.begin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity);
+        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position + _size));
     }
 
     [[nodiscard]] constexpr auto
     end() const noexcept {
-        return _buffer.begin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity);
+        return std::next(_buffer.begin(), static_cast<signed_index_type>(_write_position + _size));
     }
 
     [[nodiscard]] constexpr auto
     cend() const noexcept {
-        return _buffer.cbegin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity);
+        return end();
     }
 
     [[nodiscard]] auto
     rbegin() noexcept {
-        return std::make_reverse_iterator(_buffer.begin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity));
+        return std::make_reverse_iterator(end());
     }
 
     [[nodiscard]] constexpr auto
     rbegin() const noexcept {
-        return std::make_reverse_iterator(_buffer.begin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity));
+        return std::make_reverse_iterator(cend());
     }
 
     [[nodiscard]] constexpr auto
@@ -205,12 +224,12 @@ public:
 
     [[nodiscard]] auto
     rend() noexcept {
-        return std::make_reverse_iterator(_buffer.begin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity - _size));
+        return std::make_reverse_iterator(begin());
     }
 
     [[nodiscard]] constexpr auto
     rend() const noexcept {
-        return std::make_reverse_iterator(_buffer.begin() + static_cast<typename buffer_type::difference_type>(_write_position + _capacity - _size));
+        return std::make_reverse_iterator(cbegin());
     }
 
     [[nodiscard]] constexpr auto

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -9,6 +9,7 @@
 #include <gnuradio-4.0/Block.hpp>
 #include <gnuradio-4.0/Buffer.hpp>
 #include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/meta/formatter.hpp>
 #include <gnuradio-4.0/reflection.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <gnuradio-4.0/Tag.hpp>
@@ -21,21 +22,6 @@ using namespace std::string_literals;
 template<>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
 #endif
-
-template<typename T>
-struct fmt::formatter<std::complex<T>> {
-    template<typename ParseContext>
-    constexpr auto
-    parse(ParseContext &ctx) {
-        return std::begin(ctx);
-    }
-
-    template<typename FormatContext>
-    constexpr auto
-    format(const std::complex<T> value, FormatContext &ctx) const {
-        return fmt::format_to(ctx.out(), "({}+{}i)", value.real(), value.imag());
-    }
-};
 
 namespace gr::setting_test {
 

--- a/meta/include/gnuradio-4.0/meta/formatter.hpp
+++ b/meta/include/gnuradio-4.0/meta/formatter.hpp
@@ -1,0 +1,65 @@
+#ifndef GNURADIO_FORMATTER_HPP
+#define GNURADIO_FORMATTER_HPP
+
+#include <complex>
+#include <fmt/format.h>
+
+template<typename T>
+struct fmt::formatter<std::complex<T>> {
+    char presentation = 'g'; // default format
+
+    template<typename ParseContext>
+    constexpr auto
+    parse(ParseContext &ctx) {
+        auto it = ctx.begin(), end = ctx.end();
+        if (it != end && (*it == 'f' || *it == 'F' || *it == 'e' || *it == 'E' || *it == 'g' || *it == 'G')) {
+            presentation = *it++;
+        }
+        if (it != end && *it != '}') {
+            throw fmt::format_error("invalid format");
+        }
+        return it;
+    }
+
+    template<typename FormatContext>
+    constexpr auto
+    format(const std::complex<T> &value, FormatContext &ctx) const {
+        // format according to: https://fmt.dev/papers/p2197r0.html#examples
+        const auto imag = value.imag();
+        switch (presentation) {
+        case 'e':
+            if (imag == 0) {
+                return fmt::format_to(ctx.out(), "{:e}", value.real());
+            }
+            return fmt::format_to(ctx.out(), "({:e}{:+e}i)", value.real(), imag);
+        case 'E':
+            if (imag == 0) {
+                return fmt::format_to(ctx.out(), "{:E}", value.real());
+            }
+            return fmt::format_to(ctx.out(), "({:E}{:+E}i)", value.real(), imag);
+        case 'f':
+            if (imag == 0) {
+                return fmt::format_to(ctx.out(), "{:f}", value.real());
+            }
+            return fmt::format_to(ctx.out(), "({:f}{:+f}i)", value.real(), imag);
+        case 'F':
+            if (imag == 0) {
+                return fmt::format_to(ctx.out(), "{:F}", value.real());
+            }
+            return fmt::format_to(ctx.out(), "({:F}{:+F}i)", value.real(), imag);
+        case 'G':
+            if (imag == 0) {
+                return fmt::format_to(ctx.out(), "{:G}", value.real());
+            }
+            return fmt::format_to(ctx.out(), "({:G}{:+G}i)", value.real(), imag);
+        case 'g':
+        default:
+            if (imag == 0) {
+                return fmt::format_to(ctx.out(), "{:g}", value.real());
+            }
+            return fmt::format_to(ctx.out(), "({:g}{:+g}i)", value.real(), imag);
+        }
+    }
+};
+
+#endif // GNURADIO_FORMATTER_HPP

--- a/meta/test/CMakeLists.txt
+++ b/meta/test/CMakeLists.txt
@@ -1,2 +1,4 @@
+add_ut_test(qa_formatter)
 add_ut_test(qa_traits)
+target_link_libraries(qa_formatter PRIVATE gnuradio-meta)
 target_link_libraries(qa_traits PRIVATE gnuradio-meta)

--- a/meta/test/qa_formatter.cpp
+++ b/meta/test/qa_formatter.cpp
@@ -1,0 +1,51 @@
+#include <boost/ut.hpp>
+
+#include <complex>
+
+#include <fmt/format.h>
+
+#include <gnuradio-4.0/meta/formatter.hpp>
+
+namespace gr::meta::test {
+
+const boost::ut::suite complexFormatter = [] {
+    using namespace boost::ut;
+    using namespace std::literals::complex_literals;
+    using C                = std::complex<double>;
+    "fmt::formatter<std::complex<T>>"_test = [] {
+        fmt::print("{}\n", C(1.234, 1123456789012));
+        expect("(1+1i)" == fmt::format("{}", C(1., +1.)));
+        expect("(1-1i)" == fmt::format("{}", C(1., -1.)));
+        expect("1" == fmt::format("{}", C(1., 0.)));
+        expect("(1.234+1.12346e+12i)" == fmt::format("{}", C(1.234, 1123456789012)));
+        expect("(1+1i)" == fmt::format("{:g}", C(1., +1.)));
+        expect("(1-1i)" == fmt::format("{:g}", C(1., -1.)));
+        expect("1" == fmt::format("{:g}", C(1., 0.)));
+        expect("(1.12346e+12+1.234i)" == fmt::format("{:g}", C(1123456789012, 1.234)));
+        expect("1.12346e+12" == fmt::format("{:g}", C(1123456789012, 0)));
+        expect("(1.234+1.12346e+12i)" == fmt::format("{:g}", C(1.234, 1123456789012)));
+        expect("(1.12346E+12+1.234i)" == fmt::format("{:G}", C(1123456789012, 1.234)));
+        expect("1.12346E+12" == fmt::format("{:G}", C(1123456789012, 0)));
+        expect("(1.234+1.12346E+12i)" == fmt::format("{:G}", C(1.234, 1123456789012)));
+
+        expect("(1.000000+1.000000i)" == fmt::format("{:f}", C(1., +1.)));
+        expect("(1.000000-1.000000i)" == fmt::format("{:f}", C(1., -1.)));
+        expect("1.000000" == fmt::format("{:f}", C(1., 0.)));
+        expect("(1.000000+1.000000i)" == fmt::format("{:F}", C(1., +1.)));
+        expect("(1.000000-1.000000i)" == fmt::format("{:F}", C(1., -1.)));
+        expect("1.000000" == fmt::format("{:F}", C(1., 0.)));
+
+        expect("(1.000000e+00+1.000000e+00i)" == fmt::format("{:e}", C(1., +1.)));
+        expect("(1.000000e+00-1.000000e+00i)" == fmt::format("{:e}", C(1., -1.)));
+        expect("1.000000e+00" == fmt::format("{:e}", C(1., 0.)));
+        expect("(1.000000E+00+1.000000E+00i)" == fmt::format("{:E}", C(1., +1.)));
+        expect("(1.000000E+00-1.000000E+00i)" == fmt::format("{:E}", C(1., -1.)));
+        expect("1.000000E+00" == fmt::format("{:E}", C(1., 0.)));
+    };
+};
+
+}
+
+int
+main() { /* tests are statically executed */
+}


### PR DESCRIPTION
## IIR and FIR coefficient generator tool and time-domain filter implementation

This PR introduces implementation for both Infinite Impulse Response (IIR) and Finite Impulse Response (FIR) filters within the `gr::filter` namespace. 

The primary focus lies in:
  * Provide a robust, clean, and lean C++-only implementation (<800 SLOCs!) that is easy(/ier) to maintain and can be used within `Block<T>`s to derive default FIR or IIR filter parameters based on high-level filter parameter requirements w/o strings attached (e.g. needing Python to compute multiplications of complex numbers).
  * consistent evaluation and creation of the required IIR and FIR filter coefficients, e.g.
    ```cpp
    constexpr auto kFilterParams = FilterParameters{ .order = 4UZ, .fLow = 4.0, .fHigh = 6.0, .attenuationDb = 60, .fs = 1000.0 }
    const auto digitalBandPass1 = iir::designFilter<double>(BANDPASS, kFilterParams, /* optional */ BUTTERWORTH);
    const auto digitalBandPass2 = fir::designFilter<double>(BANDPASS, kFilterParams, /* optional */ Kaiser);
    ```
 * application of filter coefficients for digital signal processing, e.g.
   ```cpp
   for (const auto &frequency : { 3.0, 3.5, 5., 6.5, 7.0 }) {
     auto filter = Filter<double>(digitalBandPass);
     std::vector<double> yValue(xValues.size());
     std::transform(xValues.cbegin(), xValues.cend(), yFiltered.begin(), [&filter](double x) { 
       const double 3.0 * std::sin(2. * std::numbers::pi * frequency * t)L
       return filter.processOne(y); });
      chart.draw(xValues, yFiltered, fmt::format("filtered@{}Hz", frequency));
   }
   ```
 * Automatic derivation of 'transition width' in FIR filters to match user expectations based on high-level filter parameter: the API distinction between IIR and FIR are deliberately kept to a minimum to share a common infrastructure and transparent switching between filter design and implementation.
   ```cpp
    struct FilterParameters {
      std::size_t order{ 4UZ };                                      /// default filter order
      double      fLow{ std::numeric_limits<double>::quiet_NaN() };  /// Lower cutoff frequency [Hertz].
      double      fHigh{ std::numeric_limits<double>::quiet_NaN() }; /// Upper cutoff frequency [Hertz].
      double      gain{ 1.0 };                                       /// required total filter gain
      double      rippleDb{ 0.1 };                                   /// Maximum allowed ripple in the pass-band [dB].
      double      attenuationDb{ 40 };                               /// Minimum required attenuation in the stop-band [dB].
      double      beta{ 1.6 };                                       /// default beta for Kaiser-type windowing
      double      fs{ std::numeric_limits<double>::quiet_NaN() };    /// Sampling frequency for digital filters [Hertz].
    };
    ```
   In order to minimise the level of surprise to users that express and have expectations w.r.t. the high-level filter parameter and their performance, the 'transition width' typical in other FIR filter implementations has been changed and been made an implicit parameter and is automatically derived to match the required:
    * filter `.order`, i.e. to achieve 20dB attenuation/decade per order,
    * filter `.fLow` and `.fHigh` parameters to have a correct corner frequency (especially in the vicinity of DC and the Nyquist frequency), and
    * filter stop-band attenuation `.attenuationDb`, which is particularly important for `.fLow` and `.fHigh` being in the vicinity of DC, the Nyquist frequency, or close to each other in case of band-stop filters.
   This should always provide safe defaults, the choice of least surprise, and implementation that requires the least amount of filter design expertise or having to inspect and evaluate each filter for a given parameter combination.
   *N.B The actual number of generated filter taps is still visible via `FilterCoefficients::b::size()`.*

### IIR Filter Implementation
- The IIR section provides an extensive toolkit to design various types of filters such as Butterworth, Bessel, Chebyshev Type I, and Chebyshev Type II.
- It includes methods for analog filter design (`designAnalogFilter(filter::Type, FilterParaneters, filter::Design)`), transformation to digital filters using Tustin's bilinear transform (`analogToDigitalTransform`), or direct digital filter genration (`designFilter<T>(filter::Type, FilterParaneters, filter::Design)`) that yield the desired `FilterCoefficients<T>`:
  ```cpp
  /**
   * @brief Filter coefficients of a digital transfer function H(z) = B(z)/A(z) in the z-domain with:
   *   B(z) = b[0] + b[1]·z^{-1} + b[2]·z^{-2} + …
   *   A(z) = a[0] + a[1]·z^{-1} + a[2]·z^{-2} + …
   *
   * The difference equation representing the filter is:
   * y[n] = b[0]·x[n] + b[1]·x[n-1] + … - (a[1]·y[n-1] + a[2]·y[n-2] + …)
   *
   * @note Typically, a[0] is 1 for causal systems and a{
   */
  template<typename T>
  struct FilterCoefficients {
    using value_type = T;
    std::vector<T> b{};                    /// numerator coefficients
    std::vector<T> a{ static_cast<T>(1) }; /// denominator coefficients
  };
  ```
- The IIR filters are tailored through `FilterParameters`, allowing for specific definitions of filter order, cutoff frequencies, and other critical parameters.
- There are facilities to inspect the analog poles and zeros
![image](https://github.com/fair-acc/graph-prototype/assets/46007894/ec958910-330a-494a-b703-b84a908bf741)![image](https://github.com/fair-acc/graph-prototype/assets/46007894/401fab8e-8418-4e4c-9c57-cc90cbc4354b)
- as well as the filter performance for the low-pass, high-pass, band-pass, and band-stop (here showing the analog and IIR filter being numerically virtually identical): 
 ![image](https://github.com/fair-acc/graph-prototype/assets/46007894/e8fd1153-3875-4ada-9893-41324c1a96a8)
- or example to illustrate the IIR band-pass filter using various input frequencies:
![image](https://github.com/fair-acc/graph-prototype/assets/46007894/07dbda04-0478-42d6-af4d-550f612c3710)

### FIR Filter Implementation
- The FIR component offers a filter coefficient generator ((`designFilter<T>(filter::Type, FilterParaneters, window::Type)`)) based on the window method and that behaves very similar to the IIR filter. The default apodisation is the `Kaiser` window that can be further configured via the `FilterParameters::beta` parameter or replaced by any other of the window functions (e.g. `Rectangular`, `Hamming`, `Hann`, `HannExp`, `Blackman`, `Nuttall`, `BlackmanHarris`, `BlackmanNuttall`, `FlatTop`, `Exponential`, `Kaiser`).
- Example low-, high-, and band-pass filter (`N` indicates the number of required taps):
  ![image](https://github.com/fair-acc/graph-prototype/assets/46007894/0c2292ad-32d6-4fd6-8031-f977bb1c5fc9)
  on can see that the FIR requires significantly more taps to achieve the same performance as the equivalent IIR filter (see IIR example above).
- Example band-stop filter:
 ![image](https://github.com/fair-acc/graph-prototype/assets/46007894/5f6536ed-f309-45de-b3bc-f8da44914cb0)
- or example to illustrating the FIR band-pass filter using various input frequencies:
 ![image](https://github.com/fair-acc/graph-prototype/assets/46007894/4c68f49d-0801-4033-9408-3d0806672d8e)


### IIR vs. FIR Filter Performance

IIR filters are commonly misunderstood, and FIR filters are strongly favoured in GNU Radio applications due to their cognitive simplicity and auspicious linear phase response. However,  
  - IIR filters exhibit no side lobes in their response, leading to a more predictable and stable filter performance.
  - IIR filters are numerically more efficient, which is particularly beneficial for real-time signal processing applications.
  - While FIRs are presumed superior w.r.t. phase linearity, especially when using IIR filters like Bessel, which are optimized for phase linearity.

IIR are more predictable and correspond to their well-behaved analog counterparts and, for example, usually exhibit no side-lobs that are common and unavoidable for most FIR filters and produce artefacts in the presence of strong carrier waves. Benchmarks indicate significant performance advantages for IIR filters over their FIR counterparts, particularly in terms of computational complexity:
```plaintext
LOWPASS complexity: #IIR 9 vs. #FIR 733 multiplications & additions
HIGHPASS complexity: #IIR 9  vs. #FIR 489 multiplications & additions
BANDSTOP complexity: #IIR 18 vs. #FIR 7927 multiplications & additions
```
![image](https://github.com/fair-acc/graph-prototype/assets/46007894/5dcd2c14-1c35-4de9-9caf-590ba5d65a41)

The benchmark indicates that -- for the IIR -- the performance is presently limited by the CPU's instructions bandwidth (i.e. CPU clock frequency), which could be further improved to roughly up to 500 MS/s for filter cascades and/or use of FFT-based filtering techniques (to be implemented/benchmarked).

While often associated with non-linear phase responses, the following plots indicate that IIR filters can achieve near-linear phase characteristics when appropriately designed, such as using a Bessel filter, and the errors kept well below the one-degree error over the pass-band (N.B. here the phase offsets are visualisation purposes only):
![image](https://github.com/fair-acc/graph-prototype/assets/46007894/3a355517-419e-4d6d-aed6-6a3fad8fa90d)


The comparison underlines that the phase linearity advantage, typically attributed to FIR filters, is minimal and can be further minimised with the correct IIR filter design choice. While FIR filters have their exclusive and/or preferred use cases, the above comparison suggests that IIR filters have their merits, especially in high-bandwidth low-, high-, band-pass and band-stop applications, and make them a preferable option for a wide range of filtering tasks. Please experiment, comment and enhance if you find a better, more efficient, cleaner or leaner implementation.


**For further details, please see the corresponding unit tests**

### Some known issues:
 * the present analog vs. digital filter comparison are less than perfect, especially for the `CHEBYSHEV2` implementation.
 * the filter computation using 'float` and `double` works fine using gcc/clang on x86_64 but seems to have some numeric rounding issues for WASM (Emscripten, 32/64 bit) -- the reason is not understood (Emscripten is Clang-based :thinking: )
* IIR-biquads are fine for all orders, but the filter produce stable results w/o using biquads only up to ~ 5th order depending on the lower- or upper-cut-off frequency -- other implementations suggest stable IIR filter up to the 10th order or beyond (-- which I find doubtful... if someone could comment on that).

Your review and feedback on this implementation would be greatly appreciated to refine and optimise the functionality provided. Especially if you can find further improvements or alternative implementations that are more robust in terms of numerics. :pray: :+1: 


