### PR TITLE
Inline header only dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         if: matrix.configurations.compiler != 'emscripten'
         shell: bash
         run: |
-          cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=${{ matrix.configurations.compiler == 'gcc13' &&  matrix.cmake-build-type == 'Debug'}}
+          cmake -S . -B ../build -DDISABLE_EXTERNAL_DEPS_WARNINGS=ON -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=${{ matrix.configurations.compiler == 'gcc13' &&  matrix.cmake-build-type == 'Debug'}}
 
       - name: Configure CMake Emscripten
         if: matrix.configurations.compiler == 'emscripten'
@@ -96,7 +96,7 @@ jobs:
         run: |
           export SYSTEM_NODE=`which node` # use system node instead of old version distributed with emsdk for threading support
           source ~/emsdk/emsdk_env.sh
-          emcmake cmake -S . -B ../build -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=OFF -DCMAKE_CROSSCOMPILING_EMULATOR=${SYSTEM_NODE}
+          emcmake cmake -S . -B ../build -DDISABLE_EXTERNAL_DEPS_WARNINGS=ON -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=OFF -DCMAKE_CROSSCOMPILING_EMULATOR=${SYSTEM_NODE}
 
       - name: Build
         if: matrix.configurations.compiler != 'gcc13' || matrix.cmake-build-type != 'Debug'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ if (NOT DEFINED GR_TOPLEVEL_PROJECT)
     endif ()
 endif ()
 
+set(CMAKE_EXT_DEP_WARNING_GUARD "")
+if(DISABLE_EXTERNAL_DEPS_WARNINGS) # enable warnings for external dependencies
+    set(CMAKE_EXT_DEP_WARNING_GUARD SYSTEM)
+endif()
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "(Clang|GNU|Intel)")
     # -Og is a much more reasonable default for debugging. Also enable gdb extensions.
     set(CMAKE_CXX_FLAGS_DEBUG "-Og -ggdb" CACHE INTERNAL
@@ -82,17 +87,18 @@ if (EMSCRIPTEN)
     )
 endif ()
 
+# include header-only libraries that have been inlined to simplify builds w/o requiring access to the internet
+add_library(refl-cpp INTERFACE)
+target_include_directories(refl-cpp ${CMAKE_EXT_DEP_WARNING_GUARD} INTERFACE ${PROJECT_SOURCE_DIR}/third_party/refl-cpp/)
+
+add_library(magic_enum INTERFACE)
+target_include_directories(magic_enum ${CMAKE_EXT_DEP_WARNING_GUARD} INTERFACE ${PROJECT_SOURCE_DIR}/third_party/magic_enum/)
+
 include(FetchContent)
 FetchContent_Declare(
         fmt
         GIT_REPOSITORY https://github.com/fmtlib/fmt.git
         GIT_TAG 10.1.1
-)
-
-FetchContent_Declare(
-        refl-cpp
-        GIT_REPOSITORY https://github.com/veselink1/refl-cpp.git
-        GIT_TAG 27fbd7d2e6d86bc135b87beef6b5f7ce53afd4fc # v0.12.3+4 11/2022
 )
 
 FetchContent_Declare(
@@ -119,7 +125,7 @@ FetchContent_Declare(
         GIT_TAG v0.2.0
 )
 
-FetchContent_MakeAvailable(fmt refl-cpp pmt ut yaml-cpp vir-simd)
+FetchContent_MakeAvailable(fmt pmt ut yaml-cpp vir-simd)
 
 add_library(pmtv INTERFACE)
 target_include_directories(pmtv INTERFACE ${pmt_SOURCE_DIR}/include/)

--- a/algorithm/CMakeLists.txt
+++ b/algorithm/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(gnuradio-algorithm INTERFACE)
 target_include_directories(gnuradio-algorithm INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/> $<INSTALL_INTERFACE:include/>)
-target_link_libraries(gnuradio-algorithm INTERFACE gnuradio-options gnuradio-meta vir fftw fmt)
+target_link_libraries(gnuradio-algorithm INTERFACE gnuradio-options gnuradio-meta vir fftw fmt magic_enum)
 
 if (ENABLE_TESTING)
     add_subdirectory(test)

--- a/algorithm/include/gnuradio-4.0/algorithm/fourier/window.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/fourier/window.hpp
@@ -11,6 +11,8 @@
 #include <vector>
 
 #include <fmt/format.h>
+#include <magic_enum.hpp>
+#include <magic_enum_utility.hpp>
 
 #include <gnuradio-4.0/meta/utils.hpp>
 
@@ -22,53 +24,16 @@ namespace gr::algorithm::window {
  */
 enum class Type : int { None, Rectangular, Hamming, Hann, HannExp, Blackman, Nuttall, BlackmanHarris, BlackmanNuttall, FlatTop, Exponential, Kaiser };
 using enum Type;
-inline static constexpr std::array<Type, 12>     TypeList{ None, Rectangular, Hamming, Hann, HannExp, Blackman, Nuttall, BlackmanHarris, BlackmanNuttall, FlatTop, Exponential, Kaiser };
 inline static constexpr gr::meta::fixed_string TypeNames = "[None, Rectangular, Hamming, Hann, HannExp, Blackman, Nuttall, BlackmanHarris, BlackmanNuttall, FlatTop, Exponential, Kaiser]";
-
-constexpr std::string_view
-to_string(Type window) noexcept {
-    switch (window) {
-    case None: return "None";
-    case Rectangular: return "Rectangular";
-    case Hamming: return "Hamming";
-    case Hann: return "Hann";
-    case HannExp: return "HannExp";
-    case Blackman: return "Blackman";
-    case Nuttall: return "Nuttall";
-    case BlackmanHarris: return "BlackmanHarris";
-    case BlackmanNuttall: return "BlackmanNuttall";
-    case FlatTop: return "FlatTop";
-    case Exponential: return "Exponential";
-    case Kaiser: return "Kaiser";
-    default: return "Unknown";
-    }
-}
-
-constexpr Type
-parse(std::string_view name) {
-    constexpr auto toLower = [](std::string_view sv) {
-        std::string lowerStr(sv);
-        std::ranges::transform(lowerStr.begin(), lowerStr.end(), lowerStr.begin(), ::tolower);
-        return lowerStr;
-    };
-
-    for (const auto &type : TypeList) {
-        if (toLower(to_string(type)) == toLower(name)) {
-            return type;
-        }
-    }
-
-    throw std::invalid_argument(fmt::format("unknown window type '{}'", name));
-}
 
 namespace detail {
 template<typename T>
     requires std::is_floating_point_v<T>
 constexpr T
 bessel_i0(const T x) noexcept {
-    T       sum    = 1;
-    T       term   = 1;
-    int     k      = 1;
+    T   sum  = 1;
+    T   term = 1;
+    int k    = 1;
 
     const T x_half = x / 2;
 

--- a/blocks/fourier/test/qa_fourier.cpp
+++ b/blocks/fourier/test/qa_fourier.cpp
@@ -74,10 +74,10 @@ equalDataset(const gr::blocks::fft::FFT<T, gr::DataSet<U>> &fftBlock, const gr::
     using namespace boost::ut;
     using namespace boost::ut::reflection;
 
-    const U    tolerance = U(0.0001);
+    const U tolerance = U(0.0001);
 
-    const auto N         = fftBlock._magnitudeSpectrum.size();
-    auto const freq      = static_cast<U>(sample_rate) / static_cast<U>(fftBlock.fftSize);
+    const auto N    = fftBlock._magnitudeSpectrum.size();
+    auto const freq = static_cast<U>(sample_rate) / static_cast<U>(fftBlock.fftSize);
     expect(ge(ds1.signal_values.size(), N)) << fmt::format("<{}> DataSet signal length {} vs. magnitude size {}", type_name<T>(), ds1.signal_values.size(), N);
     if (N == fftBlock.fftSize) { // complex input
         expect(approx(ds1.signal_values[0], -(static_cast<U>(N) / U(2.f)) * freq, tolerance)) << fmt::format("<{}> equal DataSet frequency[0]", type_name<T>());
@@ -190,12 +190,12 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
         FFT<InType, OutType> fftBlock{};
 
         using value_type = OutType::value_type;
-        constexpr value_type    tolerance{ value_type(0.00001) };
+        constexpr value_type tolerance{ value_type(0.00001) };
 
         constexpr std::uint32_t N{ 8 };
-        for (const auto &window : gr::algorithm::window::TypeList) {
+        for (const auto &[window, windowName] : magic_enum::enum_entries<gr::algorithm::window::Type>()) {
             std::ignore = fftBlock.settings().set({ { "fftSize", N } });
-            std::ignore = fftBlock.settings().set({ { "window", std::string(gr::algorithm::window::to_string(window)) } });
+            std::ignore = fftBlock.settings().set({ { "window", std::string(windowName) } });
             std::ignore = fftBlock.settings().applyStagedParameters();
 
             std::vector<InType> signal(N);
@@ -213,7 +213,7 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
 
             expect(eq(fftBlock.fftSize, N)) << fmt::format("<{}> equal fft size", type_name<T>());
             expect(eq(fftBlock._window.size(), N)) << fmt::format("<{}> equal window vector size", type_name<T>());
-            expect(eq(fftBlock.window.value, gr::algorithm::window::to_string(window))) << fmt::format("<{}> equal window function", type_name<T>());
+            expect(eq(fftBlock.window.value, magic_enum::enum_name(window))) << fmt::format("<{}> equal window function", type_name<T>());
 
             std::vector<value_type> windowFunc = gr::algorithm::window::create<value_type>(window, N);
             for (std::size_t i = 0; i < N; i++) {

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(gnuradio-core INTERFACE)
 target_include_directories(gnuradio-core INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src> $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include> $<INSTALL_INTERFACE:include/>)
-target_link_libraries(gnuradio-core INTERFACE gnuradio-options gnuradio-meta refl-cpp::refl-cpp pmtv vir)
+target_link_libraries(gnuradio-core INTERFACE gnuradio-options gnuradio-meta refl-cpp magic_enum pmtv vir)
 
 # configure a header file to pass the CMake settings to the source code
 configure_file("${PROJECT_SOURCE_DIR}/cmake/config.h.in"  "${CMAKE_CURRENT_BINARY_DIR}/include/gnuradio-4.0/config.h" @ONLY)

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -22,5 +22,5 @@ endif ()
 
 if (ENABLE_EXAMPLES)
     add_executable(main main.cpp)
-    target_link_libraries(main PUBLIC gnuradio-options gnuradio-core fmt::fmt refl-cpp::refl-cpp)
+    target_link_libraries(main PUBLIC gnuradio-options gnuradio-core fmt::fmt refl-cpp magic_enum)
 endif ()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,5 +15,5 @@ sonar.cfamily.cpp23.enabled=true
 sonar.coverageReportPaths=/home/runner/work/graph-prototype/build/coverage.xml
 sonar.test=.
 # note: only add benchmarks starting with bm_ to be able to exclude bm-nosonar_ files
-sonar.exclusions=**/test/**/*,**/benchmarks/*
+sonar.exclusions=**/third_party/**/*,**/test/**/*,**/benchmarks/*
 sonar.test.inclusions=**/test/**/*,**/benchmarks/bm_*

--- a/third_party/magic_enum/magic_enum.hpp
+++ b/third_party/magic_enum/magic_enum.hpp
@@ -1,0 +1,1438 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_HPP
+#define NEARGYE_MAGIC_ENUM_HPP
+
+#define MAGIC_ENUM_VERSION_MAJOR 0
+#define MAGIC_ENUM_VERSION_MINOR 9
+#define MAGIC_ENUM_VERSION_PATCH 3
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+#if defined(MAGIC_ENUM_CONFIG_FILE)
+#  include MAGIC_ENUM_CONFIG_FILE
+#endif
+
+#if !defined(MAGIC_ENUM_USING_ALIAS_OPTIONAL)
+#  include <optional>
+#endif
+#if !defined(MAGIC_ENUM_USING_ALIAS_STRING)
+#  include <string>
+#endif
+#if !defined(MAGIC_ENUM_USING_ALIAS_STRING_VIEW)
+#  include <string_view>
+#endif
+
+#if defined(MAGIC_ENUM_NO_ASSERT)
+#  define MAGIC_ENUM_ASSERT(...) static_cast<void>(0)
+#else
+#  include <cassert>
+#  define MAGIC_ENUM_ASSERT(...) assert((__VA_ARGS__))
+#endif
+
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wunknown-warning-option"
+#  pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized" // May be used uninitialized 'return {};'.
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 26495) // Variable 'static_str<N>::chars_' is uninitialized.
+#  pragma warning(disable : 28020) // Arithmetic overflow: Using operator '-' on a 4 byte value and then casting the result to a 8 byte value.
+#  pragma warning(disable : 26451) // The expression '0<=_Param_(1)&&_Param_(1)<=1-1' is not true at this call.
+#  pragma warning(disable : 4514) // Unreferenced inline function has been removed.
+#endif
+
+// Checks magic_enum compiler compatibility.
+#if defined(__clang__) && __clang_major__ >= 5 || defined(__GNUC__) && __GNUC__ >= 9 || defined(_MSC_VER) && _MSC_VER >= 1910 || defined(__RESHARPER__)
+#  undef  MAGIC_ENUM_SUPPORTED
+#  define MAGIC_ENUM_SUPPORTED 1
+#endif
+
+// Checks magic_enum compiler aliases compatibility.
+#if defined(__clang__) && __clang_major__ >= 5 || defined(__GNUC__) && __GNUC__ >= 9 || defined(_MSC_VER) && _MSC_VER >= 1920
+#  undef  MAGIC_ENUM_SUPPORTED_ALIASES
+#  define MAGIC_ENUM_SUPPORTED_ALIASES 1
+#endif
+
+// Enum value must be greater or equals than MAGIC_ENUM_RANGE_MIN. By default MAGIC_ENUM_RANGE_MIN = -128.
+// If need another min range for all enum types by default, redefine the macro MAGIC_ENUM_RANGE_MIN.
+#if !defined(MAGIC_ENUM_RANGE_MIN)
+#  define MAGIC_ENUM_RANGE_MIN -128
+#endif
+
+// Enum value must be less or equals than MAGIC_ENUM_RANGE_MAX. By default MAGIC_ENUM_RANGE_MAX = 128.
+// If need another max range for all enum types by default, redefine the macro MAGIC_ENUM_RANGE_MAX.
+#if !defined(MAGIC_ENUM_RANGE_MAX)
+#  define MAGIC_ENUM_RANGE_MAX 127
+#endif
+
+// Improve ReSharper C++ intellisense performance with builtins, avoiding unnecessary template instantiations.
+#if defined(__RESHARPER__)
+#  undef MAGIC_ENUM_GET_ENUM_NAME_BUILTIN
+#  undef MAGIC_ENUM_GET_TYPE_NAME_BUILTIN
+#  if __RESHARPER__ >= 20230100
+#    define MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V) __rscpp_enumerator_name(V)
+#    define MAGIC_ENUM_GET_TYPE_NAME_BUILTIN(T) __rscpp_type_name<T>()
+#  else
+#    define MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V) nullptr
+#    define MAGIC_ENUM_GET_TYPE_NAME_BUILTIN(T) nullptr
+#  endif
+#endif
+
+namespace magic_enum {
+
+// If need another optional type, define the macro MAGIC_ENUM_USING_ALIAS_OPTIONAL.
+#if defined(MAGIC_ENUM_USING_ALIAS_OPTIONAL)
+MAGIC_ENUM_USING_ALIAS_OPTIONAL
+#else
+using std::optional;
+#endif
+
+// If need another string_view type, define the macro MAGIC_ENUM_USING_ALIAS_STRING_VIEW.
+#if defined(MAGIC_ENUM_USING_ALIAS_STRING_VIEW)
+MAGIC_ENUM_USING_ALIAS_STRING_VIEW
+#else
+using std::string_view;
+#endif
+
+// If need another string type, define the macro MAGIC_ENUM_USING_ALIAS_STRING.
+#if defined(MAGIC_ENUM_USING_ALIAS_STRING)
+MAGIC_ENUM_USING_ALIAS_STRING
+#else
+using std::string;
+#endif
+
+using char_type = string_view::value_type;
+static_assert(std::is_same_v<string_view::value_type, string::value_type>, "magic_enum::customize requires same string_view::value_type and string::value_type");
+static_assert([] {
+  if constexpr (std::is_same_v<char_type, wchar_t>) {
+    constexpr const char     c[] =  "abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789|";
+    constexpr const wchar_t wc[] = L"abcdefghijklmnopqrstuvwxyz_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789|";
+    static_assert(std::size(c) == std::size(wc), "magic_enum::customize identifier characters are multichars in wchar_t.");
+
+    for (std::size_t i = 0; i < std::size(c); ++i) {
+      if (c[i] != wc[i]) {
+        return false;
+      }
+    }
+  }
+  return true;
+} (), "magic_enum::customize wchar_t is not compatible with ASCII.");
+
+namespace customize {
+
+// Enum value must be in range [MAGIC_ENUM_RANGE_MIN, MAGIC_ENUM_RANGE_MAX]. By default MAGIC_ENUM_RANGE_MIN = -128, MAGIC_ENUM_RANGE_MAX = 128.
+// If need another range for all enum types by default, redefine the macro MAGIC_ENUM_RANGE_MIN and MAGIC_ENUM_RANGE_MAX.
+// If need another range for specific enum type, add specialization enum_range for necessary enum type.
+template <typename E>
+struct enum_range {
+  static_assert(std::is_enum_v<E>, "magic_enum::customize::enum_range requires enum type.");
+  static constexpr int min = MAGIC_ENUM_RANGE_MIN;
+  static constexpr int max = MAGIC_ENUM_RANGE_MAX;
+  static_assert(max > min, "magic_enum::customize::enum_range requires max > min.");
+};
+
+static_assert(MAGIC_ENUM_RANGE_MAX > MAGIC_ENUM_RANGE_MIN, "MAGIC_ENUM_RANGE_MAX must be greater than MAGIC_ENUM_RANGE_MIN.");
+static_assert((MAGIC_ENUM_RANGE_MAX - MAGIC_ENUM_RANGE_MIN) < (std::numeric_limits<std::uint16_t>::max)(), "MAGIC_ENUM_RANGE must be less than UINT16_MAX.");
+
+namespace detail {
+
+enum class customize_tag {
+  default_tag,
+  invalid_tag,
+  custom_tag
+};
+
+} // namespace magic_enum::customize::detail
+
+class customize_t : public std::pair<detail::customize_tag, string_view> {
+ public:
+  constexpr customize_t(string_view srt) : std::pair<detail::customize_tag, string_view>{detail::customize_tag::custom_tag, srt} {}
+  constexpr customize_t(const char_type* srt) : customize_t{string_view{srt}} {}
+  constexpr customize_t(detail::customize_tag tag) : std::pair<detail::customize_tag, string_view>{tag, string_view{}} {
+    MAGIC_ENUM_ASSERT(tag != detail::customize_tag::custom_tag);
+  }
+};
+
+// Default customize.
+inline constexpr auto default_tag = customize_t{detail::customize_tag::default_tag};
+// Invalid customize.
+inline constexpr auto invalid_tag = customize_t{detail::customize_tag::invalid_tag};
+
+// If need custom names for enum, add specialization enum_name for necessary enum type.
+template <typename E>
+constexpr customize_t enum_name(E) noexcept {
+  return default_tag;
+}
+
+// If need custom type name for enum, add specialization enum_type_name for necessary enum type.
+template <typename E>
+constexpr customize_t enum_type_name() noexcept {
+  return default_tag;
+}
+
+} // namespace magic_enum::customize
+
+namespace detail {
+
+template <typename T>
+struct supported
+#if defined(MAGIC_ENUM_SUPPORTED) && MAGIC_ENUM_SUPPORTED || defined(MAGIC_ENUM_NO_CHECK_SUPPORT)
+    : std::true_type {};
+#else
+    : std::false_type {};
+#endif
+
+template <auto V, typename E = std::decay_t<decltype(V)>, std::enable_if_t<std::is_enum_v<E>, int> = 0>
+using enum_constant = std::integral_constant<E, V>;
+
+template <typename... T>
+inline constexpr bool always_false_v = false;
+
+template <typename T, typename = void>
+struct has_is_flags : std::false_type {};
+
+template <typename T>
+struct has_is_flags<T, std::void_t<decltype(customize::enum_range<T>::is_flags)>> : std::bool_constant<std::is_same_v<bool, std::decay_t<decltype(customize::enum_range<T>::is_flags)>>> {};
+
+template <typename T, typename = void>
+struct range_min : std::integral_constant<int, MAGIC_ENUM_RANGE_MIN> {};
+
+template <typename T>
+struct range_min<T, std::void_t<decltype(customize::enum_range<T>::min)>> : std::integral_constant<decltype(customize::enum_range<T>::min), customize::enum_range<T>::min> {};
+
+template <typename T, typename = void>
+struct range_max : std::integral_constant<int, MAGIC_ENUM_RANGE_MAX> {};
+
+template <typename T>
+struct range_max<T, std::void_t<decltype(customize::enum_range<T>::max)>> : std::integral_constant<decltype(customize::enum_range<T>::max), customize::enum_range<T>::max> {};
+
+struct str_view {
+  const char* str_ = nullptr;
+  std::size_t size_ = 0;
+};
+
+template <std::uint16_t N>
+class static_str {
+ public:
+  constexpr explicit static_str(str_view str) noexcept : static_str{str.str_, std::make_integer_sequence<std::uint16_t, N>{}} {
+    MAGIC_ENUM_ASSERT(str.size_ == N);
+  }
+
+  constexpr explicit static_str(string_view str) noexcept : static_str{str.data(), std::make_integer_sequence<std::uint16_t, N>{}} {
+    MAGIC_ENUM_ASSERT(str.size() == N);
+  }
+
+  constexpr const char_type* data() const noexcept { return chars_; }
+
+  constexpr std::uint16_t size() const noexcept { return N; }
+
+  constexpr operator string_view() const noexcept { return {data(), size()}; }
+
+ private:
+  template <std::uint16_t... I>
+  constexpr static_str(const char* str, std::integer_sequence<std::uint16_t, I...>) noexcept : chars_{static_cast<char_type>(str[I])..., static_cast<char_type>('\0')} {}
+
+  template <std::uint16_t... I>
+  constexpr static_str(string_view str, std::integer_sequence<std::uint16_t, I...>) noexcept : chars_{str[I]..., static_cast<char_type>('\0')} {}
+
+  char_type chars_[static_cast<std::size_t>(N) + 1];
+};
+
+template <>
+class static_str<0> {
+ public:
+  constexpr explicit static_str() = default;
+
+  constexpr explicit static_str(str_view) noexcept {}
+
+  constexpr explicit static_str(string_view) noexcept {}
+
+  constexpr const char_type* data() const noexcept { return nullptr; }
+
+  constexpr std::uint16_t size() const noexcept { return 0; }
+
+  constexpr operator string_view() const noexcept { return {}; }
+};
+
+template <typename Op = std::equal_to<>>
+class case_insensitive {
+  static constexpr char_type to_lower(char_type c) noexcept {
+    return (c >= static_cast<char_type>('A') && c <= static_cast<char_type>('Z')) ? static_cast<char_type>(c + (static_cast<char_type>('a') - static_cast<char_type>('A'))) : c;
+  }
+
+ public:
+  template <typename L, typename R>
+  constexpr auto operator()(L lhs,R rhs) const noexcept -> std::enable_if_t<std::is_same_v<std::decay_t<L>, char_type> && std::is_same_v<std::decay_t<R>, char_type>, bool> {
+    return Op{}(to_lower(lhs), to_lower(rhs));
+  }
+};
+
+constexpr std::size_t find(string_view str, char_type c) noexcept {
+#if defined(__clang__) && __clang_major__ < 9 && defined(__GLIBCXX__) || defined(_MSC_VER) && _MSC_VER < 1920 && !defined(__clang__)
+// https://stackoverflow.com/questions/56484834/constexpr-stdstring-viewfind-last-of-doesnt-work-on-clang-8-with-libstdc
+// https://developercommunity.visualstudio.com/content/problem/360432/vs20178-regression-c-failed-in-test.html
+  constexpr bool workaround = true;
+#else
+  constexpr bool workaround = false;
+#endif
+
+  if constexpr (workaround) {
+    for (std::size_t i = 0; i < str.size(); ++i) {
+      if (str[i] == c) {
+        return i;
+      }
+    }
+
+    return string_view::npos;
+  } else {
+    return str.find(c);
+  }
+}
+
+template <typename BinaryPredicate>
+constexpr bool is_default_predicate() noexcept {
+  return std::is_same_v<std::decay_t<BinaryPredicate>, std::equal_to<string_view::value_type>> ||
+         std::is_same_v<std::decay_t<BinaryPredicate>, std::equal_to<>>;
+}
+
+template <typename BinaryPredicate>
+constexpr bool is_nothrow_invocable() {
+  return is_default_predicate<BinaryPredicate>() ||
+         std::is_nothrow_invocable_r_v<bool, BinaryPredicate, char_type, char_type>;
+}
+
+template <typename BinaryPredicate>
+constexpr bool cmp_equal(string_view lhs, string_view rhs, [[maybe_unused]] BinaryPredicate&& p) noexcept(is_nothrow_invocable<BinaryPredicate>()) {
+#if defined(_MSC_VER) && _MSC_VER < 1920 && !defined(__clang__)
+  // https://developercommunity.visualstudio.com/content/problem/360432/vs20178-regression-c-failed-in-test.html
+  // https://developercommunity.visualstudio.com/content/problem/232218/c-constexpr-string-view.html
+  constexpr bool workaround = true;
+#else
+  constexpr bool workaround = false;
+#endif
+
+  if constexpr (!is_default_predicate<BinaryPredicate>() || workaround) {
+    if (lhs.size() != rhs.size()) {
+      return false;
+    }
+
+    const auto size = lhs.size();
+    for (std::size_t i = 0; i < size; ++i) {
+      if (!p(lhs[i], rhs[i])) {
+        return false;
+      }
+    }
+
+    return true;
+  } else {
+    return lhs == rhs;
+  }
+}
+
+template <typename L, typename R>
+constexpr bool cmp_less(L lhs, R rhs) noexcept {
+  static_assert(std::is_integral_v<L> && std::is_integral_v<R>, "magic_enum::detail::cmp_less requires integral type.");
+
+  if constexpr (std::is_signed_v<L> == std::is_signed_v<R>) {
+    // If same signedness (both signed or both unsigned).
+    return lhs < rhs;
+  } else if constexpr (std::is_same_v<L, bool>) { // bool special case
+      return static_cast<R>(lhs) < rhs;
+  } else if constexpr (std::is_same_v<R, bool>) { // bool special case
+      return lhs < static_cast<L>(rhs);
+  } else if constexpr (std::is_signed_v<R>) {
+    // If 'right' is negative, then result is 'false', otherwise cast & compare.
+    return rhs > 0 && lhs < static_cast<std::make_unsigned_t<R>>(rhs);
+  } else {
+    // If 'left' is negative, then result is 'true', otherwise cast & compare.
+    return lhs < 0 || static_cast<std::make_unsigned_t<L>>(lhs) < rhs;
+  }
+}
+
+template <typename I>
+constexpr I log2(I value) noexcept {
+  static_assert(std::is_integral_v<I>, "magic_enum::detail::log2 requires integral type.");
+
+  if constexpr (std::is_same_v<I, bool>) { // bool special case
+    return MAGIC_ENUM_ASSERT(false), value;
+  } else {
+    auto ret = I{0};
+    for (; value > I{1}; value >>= I{1}, ++ret) {}
+
+    return ret;
+  }
+}
+
+#if defined(__cpp_lib_array_constexpr) && __cpp_lib_array_constexpr >= 201603L
+#  define MAGIC_ENUM_ARRAY_CONSTEXPR 1
+#else
+template <typename T, std::size_t N, std::size_t... I>
+constexpr std::array<std::remove_cv_t<T>, N> to_array(T (&a)[N], std::index_sequence<I...>) noexcept {
+  return {{a[I]...}};
+}
+#endif
+
+template <typename T>
+inline constexpr bool is_enum_v = std::is_enum_v<T> && std::is_same_v<T, std::decay_t<T>>;
+
+template <typename E>
+constexpr auto n() noexcept {
+  static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
+
+  if constexpr (supported<E>::value) {
+#if defined(MAGIC_ENUM_GET_TYPE_NAME_BUILTIN)
+    constexpr auto name_ptr = MAGIC_ENUM_GET_TYPE_NAME_BUILTIN(E);
+    constexpr auto name = name_ptr ? str_view{name_ptr, std::char_traits<char>::length(name_ptr)} : str_view{};
+#elif defined(__clang__)
+    auto name = str_view{__PRETTY_FUNCTION__ + 34, sizeof(__PRETTY_FUNCTION__) - 36};
+#elif defined(__GNUC__)
+    auto name = str_view{__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1};
+    if (name.str_[name.size_ - 1] == ']') {
+      name.size_ -= 50;
+      name.str_ += 49;
+    } else {
+      name.size_ -= 40;
+      name.str_ += 37;
+    }
+#elif defined(_MSC_VER)
+    auto name = str_view{__FUNCSIG__ + 40, sizeof(__FUNCSIG__) - 57};
+#else
+    auto name = str_view{};
+#endif
+    std::size_t p = 0;
+    for (std::size_t i = name.size_; i > 0; --i) {
+      if (name.str_[i] == ':') {
+        p = i + 1;
+        break;
+      }
+    }
+    if (p > 0) {
+      name.size_ -= p;
+      name.str_ += p;
+    }
+    return name;
+  } else {
+    return str_view{}; // Unsupported compiler or Invalid customize.
+  }
+}
+
+template <typename E>
+constexpr auto type_name() noexcept {
+  [[maybe_unused]] constexpr auto custom = customize::enum_type_name<E>();
+  static_assert(std::is_same_v<std::decay_t<decltype(custom)>, customize::customize_t>, "magic_enum::customize requires customize_t type.");
+  if constexpr (custom.first == customize::detail::customize_tag::custom_tag) {
+    constexpr auto name = custom.second;
+    static_assert(!name.empty(), "magic_enum::customize requires not empty string.");
+    return static_str<name.size()>{name};
+  } else if constexpr (custom.first == customize::detail::customize_tag::invalid_tag) {
+    return static_str<0>{};
+  } else if constexpr (custom.first == customize::detail::customize_tag::default_tag) {
+    constexpr auto name = n<E>();
+    return static_str<name.size_>{name};
+  } else {
+    static_assert(always_false_v<E>, "magic_enum::customize invalid.");
+  }
+}
+
+template <typename E>
+inline constexpr auto type_name_v = type_name<E>();
+
+template <auto V>
+constexpr auto n() noexcept {
+  static_assert(is_enum_v<decltype(V)>, "magic_enum::detail::n requires enum type.");
+
+  if constexpr (supported<decltype(V)>::value) {
+#if defined(MAGIC_ENUM_GET_ENUM_NAME_BUILTIN)
+    constexpr auto name_ptr = MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V);
+    auto name = name_ptr ? str_view{name_ptr, std::char_traits<char>::length(name_ptr)} : str_view{};
+#elif defined(__clang__)
+    auto name = str_view{__PRETTY_FUNCTION__ + 34, sizeof(__PRETTY_FUNCTION__) - 36};
+    if (name.size_ > 22 && name.str_[0] == '(' && name.str_[1] == 'a' && name.str_[10] == ' ' && name.str_[22] == ':') {
+      name.size_ -= 23;
+      name.str_ += 23;
+    }
+    if (name.str_[0] == '(' || name.str_[0] == '-' || (name.str_[0] >= '0' && name.str_[0] <= '9')) {
+      name = str_view{};
+    }
+#elif defined(__GNUC__)
+    auto name = str_view{__PRETTY_FUNCTION__, sizeof(__PRETTY_FUNCTION__) - 1};
+    if (name.str_[name.size_ - 1] == ']') {
+      name.size_ -= 55;
+      name.str_ += 54;
+    } else {
+      name.size_ -= 40;
+      name.str_ += 37;
+    }
+    if (name.str_[0] == '(') {
+      name = str_view{};
+    }
+#elif defined(_MSC_VER)
+    str_view name;
+    if ((__FUNCSIG__[5] == '_' && __FUNCSIG__[35] != '(') || (__FUNCSIG__[5] == 'c' && __FUNCSIG__[41] != '(')) {
+      name = str_view{__FUNCSIG__ + 35, sizeof(__FUNCSIG__) - 52};
+    }
+#else
+    auto name = str_view{};
+#endif
+    std::size_t p = 0;
+    for (std::size_t i = name.size_; i > 0; --i) {
+      if (name.str_[i] == ':') {
+        p = i + 1;
+        break;
+      }
+    }
+    if (p > 0) {
+      name.size_ -= p;
+      name.str_ += p;
+    }
+    return name;
+  } else {
+    return str_view{}; // Unsupported compiler or Invalid customize.
+  }
+}
+
+#if defined(_MSC_VER) && !defined(__clang__) && _MSC_VER < 1920
+#  define MAGIC_ENUM_VS_2017_WORKAROUND 1
+#endif
+
+#if defined(MAGIC_ENUM_VS_2017_WORKAROUND)
+template <typename E, E V>
+constexpr auto n() noexcept {
+  static_assert(is_enum_v<E>, "magic_enum::detail::n requires enum type.");
+
+#  if defined(MAGIC_ENUM_GET_ENUM_NAME_BUILTIN)
+  constexpr auto name_ptr = MAGIC_ENUM_GET_ENUM_NAME_BUILTIN(V);
+  auto name = name_ptr ? str_view{name_ptr, std::char_traits<char>::length(name_ptr)} : str_view{};
+#  else
+  str_view name = str_view{__FUNCSIG__, sizeof(__FUNCSIG__) - 17};
+  std::size_t p = 0;
+  for (std::size_t i = name.size_; i > 0; --i) {
+    if (name.str_[i] == ',' || name.str_[i] == ':') {
+      p = i + 1;
+      break;
+    }
+  }
+  if (p > 0) {
+    name.size_ -= p;
+    name.str_ += p;
+  }
+  if (name.str_[0] == '(' || name.str_[0] == '-' || (name.str_[0] >= '0' && name.str_[0] <= '9')) {
+    name = str_view{};
+  }
+  return name;
+#  endif
+}
+#endif
+
+template <typename E, E V>
+constexpr auto enum_name() noexcept {
+  [[maybe_unused]] constexpr auto custom = customize::enum_name<E>(V);
+  static_assert(std::is_same_v<std::decay_t<decltype(custom)>, customize::customize_t>, "magic_enum::customize requires customize_t type.");
+  if constexpr (custom.first == customize::detail::customize_tag::custom_tag) {
+    constexpr auto name = custom.second;
+    static_assert(!name.empty(), "magic_enum::customize requires not empty string.");
+    return static_str<name.size()>{name};
+  } else if constexpr (custom.first == customize::detail::customize_tag::invalid_tag) {
+    return static_str<0>{};
+  } else if constexpr (custom.first == customize::detail::customize_tag::default_tag) {
+#if defined(MAGIC_ENUM_VS_2017_WORKAROUND)
+    constexpr auto name = n<E, V>();
+#else
+    constexpr auto name = n<V>();
+#endif
+    return static_str<name.size_>{name};
+  } else {
+    static_assert(always_false_v<E>, "magic_enum::customize invalid.");
+  }
+}
+
+template <typename E, E V>
+inline constexpr auto enum_name_v = enum_name<E, V>();
+
+template <typename E, auto V>
+constexpr bool is_valid() noexcept {
+#if defined(__clang__) && __clang_major__ >= 16
+  // https://reviews.llvm.org/D130058, https://reviews.llvm.org/D131307
+  constexpr E v = __builtin_bit_cast(E, V);
+#else
+  constexpr E v = static_cast<E>(V);
+#endif
+  [[maybe_unused]] constexpr auto custom = customize::enum_name<E>(v);
+  static_assert(std::is_same_v<std::decay_t<decltype(custom)>, customize::customize_t>, "magic_enum::customize requires customize_t type.");
+  if constexpr (custom.first == customize::detail::customize_tag::custom_tag) {
+    constexpr auto name = custom.second;
+    static_assert(!name.empty(), "magic_enum::customize requires not empty string.");
+    return name.size() != 0;
+  } else if constexpr (custom.first == customize::detail::customize_tag::default_tag) {
+#if defined(MAGIC_ENUM_VS_2017_WORKAROUND)
+    return n<E, v>().size_ != 0;
+#else
+    return n<v>().size_ != 0;
+#endif
+  } else {
+    return false;
+  }
+}
+
+enum class enum_subtype {
+  common,
+  flags
+};
+
+template <typename E, int O, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr U ualue(std::size_t i) noexcept {
+  if constexpr (std::is_same_v<U, bool>) { // bool special case
+    static_assert(O == 0, "magic_enum::detail::ualue requires valid offset.");
+
+    return static_cast<U>(i);
+  } else if constexpr (S == enum_subtype::flags) {
+    return static_cast<U>(U{1} << static_cast<U>(static_cast<int>(i) + O));
+  } else {
+    return static_cast<U>(static_cast<int>(i) + O);
+  }
+}
+
+template <typename E, int O, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr E value(std::size_t i) noexcept {
+  return static_cast<E>(ualue<E, O, S>(i));
+}
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr int reflected_min() noexcept {
+  if constexpr (S == enum_subtype::flags) {
+    return 0;
+  } else {
+    constexpr auto lhs = range_min<E>::value;
+    constexpr auto rhs = (std::numeric_limits<U>::min)();
+
+    if constexpr (cmp_less(rhs, lhs)) {
+      return lhs;
+    } else {
+      return rhs;
+    }
+  }
+}
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr int reflected_max() noexcept {
+  if constexpr (S == enum_subtype::flags) {
+    return std::numeric_limits<U>::digits - 1;
+  } else {
+    constexpr auto lhs = range_max<E>::value;
+    constexpr auto rhs = (std::numeric_limits<U>::max)();
+
+    if constexpr (cmp_less(lhs, rhs)) {
+      return lhs;
+    } else {
+      return rhs;
+    }
+  }
+}
+
+#define MAGIC_ENUM_FOR_EACH_256(T)                                                                                                                                                                 \
+  T(  0)T(  1)T(  2)T(  3)T(  4)T(  5)T(  6)T(  7)T(  8)T(  9)T( 10)T( 11)T( 12)T( 13)T( 14)T( 15)T( 16)T( 17)T( 18)T( 19)T( 20)T( 21)T( 22)T( 23)T( 24)T( 25)T( 26)T( 27)T( 28)T( 29)T( 30)T( 31) \
+  T( 32)T( 33)T( 34)T( 35)T( 36)T( 37)T( 38)T( 39)T( 40)T( 41)T( 42)T( 43)T( 44)T( 45)T( 46)T( 47)T( 48)T( 49)T( 50)T( 51)T( 52)T( 53)T( 54)T( 55)T( 56)T( 57)T( 58)T( 59)T( 60)T( 61)T( 62)T( 63) \
+  T( 64)T( 65)T( 66)T( 67)T( 68)T( 69)T( 70)T( 71)T( 72)T( 73)T( 74)T( 75)T( 76)T( 77)T( 78)T( 79)T( 80)T( 81)T( 82)T( 83)T( 84)T( 85)T( 86)T( 87)T( 88)T( 89)T( 90)T( 91)T( 92)T( 93)T( 94)T( 95) \
+  T( 96)T( 97)T( 98)T( 99)T(100)T(101)T(102)T(103)T(104)T(105)T(106)T(107)T(108)T(109)T(110)T(111)T(112)T(113)T(114)T(115)T(116)T(117)T(118)T(119)T(120)T(121)T(122)T(123)T(124)T(125)T(126)T(127) \
+  T(128)T(129)T(130)T(131)T(132)T(133)T(134)T(135)T(136)T(137)T(138)T(139)T(140)T(141)T(142)T(143)T(144)T(145)T(146)T(147)T(148)T(149)T(150)T(151)T(152)T(153)T(154)T(155)T(156)T(157)T(158)T(159) \
+  T(160)T(161)T(162)T(163)T(164)T(165)T(166)T(167)T(168)T(169)T(170)T(171)T(172)T(173)T(174)T(175)T(176)T(177)T(178)T(179)T(180)T(181)T(182)T(183)T(184)T(185)T(186)T(187)T(188)T(189)T(190)T(191) \
+  T(192)T(193)T(194)T(195)T(196)T(197)T(198)T(199)T(200)T(201)T(202)T(203)T(204)T(205)T(206)T(207)T(208)T(209)T(210)T(211)T(212)T(213)T(214)T(215)T(216)T(217)T(218)T(219)T(220)T(221)T(222)T(223) \
+  T(224)T(225)T(226)T(227)T(228)T(229)T(230)T(231)T(232)T(233)T(234)T(235)T(236)T(237)T(238)T(239)T(240)T(241)T(242)T(243)T(244)T(245)T(246)T(247)T(248)T(249)T(250)T(251)T(252)T(253)T(254)T(255)
+
+template <typename E, enum_subtype S, std::size_t Size, int Min, std::size_t I>
+constexpr void valid_count(bool* valid, std::size_t& count) noexcept {
+#define MAGIC_ENUM_V(O)                                     \
+  if constexpr ((I + O) < Size) {                           \
+    if constexpr (is_valid<E, ualue<E, Min, S>(I + O)>()) { \
+      valid[I + O] = true;                                  \
+      ++count;                                              \
+    }                                                       \
+  }
+
+  MAGIC_ENUM_FOR_EACH_256(MAGIC_ENUM_V);
+
+  if constexpr ((I + 256) < Size) {
+    valid_count<E, S, Size, Min, I + 256>(valid, count);
+  }
+#undef MAGIC_ENUM_V
+}
+
+template <std::size_t N>
+struct valid_count_t {
+  std::size_t count = 0;
+  bool valid[N] = {};
+};
+
+template <typename E, enum_subtype S, std::size_t Size, int Min>
+constexpr auto valid_count() noexcept {
+  valid_count_t<Size> vc;
+  valid_count<E, S, Size, Min, 0>(vc.valid, vc.count);
+  return vc;
+}
+
+template <typename E, enum_subtype S, std::size_t Size, int Min>
+constexpr auto values() noexcept {
+  constexpr auto vc = valid_count<E, S, Size, Min>();
+
+  if constexpr (vc.count > 0) {
+#if defined(MAGIC_ENUM_ARRAY_CONSTEXPR)
+    std::array<E, vc.count> values = {};
+#else
+    E values[vc.count] = {};
+#endif
+    for (std::size_t i = 0, v = 0; v < vc.count; ++i) {
+      if (vc.valid[i]) {
+        values[v++] = value<E, Min, S>(i);
+      }
+    }
+#if defined(MAGIC_ENUM_ARRAY_CONSTEXPR)
+    return values;
+#else
+    return to_array(values, std::make_index_sequence<vc.count>{});
+#endif
+  } else {
+    return std::array<E, 0>{};
+  }
+}
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr auto values() noexcept {
+  constexpr auto min = reflected_min<E, S>();
+  constexpr auto max = reflected_max<E, S>();
+  constexpr auto range_size = max - min + 1;
+  static_assert(range_size > 0, "magic_enum::enum_range requires valid size.");
+  static_assert(range_size < (std::numeric_limits<std::uint16_t>::max)(), "magic_enum::enum_range requires valid size.");
+
+  return values<E, S, range_size, min>();
+}
+
+template <typename E, typename U = std::underlying_type_t<E>>
+constexpr enum_subtype subtype(std::true_type) noexcept {
+  if constexpr (std::is_same_v<U, bool>) { // bool special case
+    return enum_subtype::common;
+  } else if constexpr (has_is_flags<E>::value) {
+    return customize::enum_range<E>::is_flags ? enum_subtype::flags : enum_subtype::common;
+  } else {
+#if defined(MAGIC_ENUM_AUTO_IS_FLAGS)
+    constexpr auto flags_values = values<E, enum_subtype::flags>();
+    constexpr auto default_values = values<E, enum_subtype::common>();
+    if (flags_values.size() == 0 || default_values.size() > flags_values.size()) {
+      return enum_subtype::common;
+    }
+    for (std::size_t i = 0; i < default_values.size(); ++i) {
+      const auto v = static_cast<U>(default_values[i]);
+      if (v != 0 && (v & (v - 1)) != 0) {
+        return enum_subtype::common;
+      }
+    }
+    return enum_subtype::flags;
+#else
+    return enum_subtype::common;
+#endif
+  }
+}
+
+template <typename T>
+constexpr enum_subtype subtype(std::false_type) noexcept {
+  // For non-enum type return default common subtype.
+  return enum_subtype::common;
+}
+
+template <typename E, typename D = std::decay_t<E>>
+inline constexpr auto subtype_v = subtype<D>(std::is_enum<D>{});
+
+template <typename E, enum_subtype S>
+inline constexpr auto values_v = values<E, S>();
+
+template <typename E, enum_subtype S, typename D = std::decay_t<E>>
+using values_t = decltype((values_v<D, S>));
+
+template <typename E, enum_subtype S>
+inline constexpr auto count_v = values_v<E, S>.size();
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+inline constexpr auto min_v = (count_v<E, S> > 0) ? static_cast<U>(values_v<E, S>.front()) : U{0};
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+inline constexpr auto max_v = (count_v<E, S> > 0) ? static_cast<U>(values_v<E, S>.back()) : U{0};
+
+template <typename E, enum_subtype S, std::size_t... I>
+constexpr auto names(std::index_sequence<I...>) noexcept {
+  return std::array<string_view, sizeof...(I)>{{enum_name_v<E, values_v<E, S>[I]>...}};
+}
+
+template <typename E, enum_subtype S>
+inline constexpr auto names_v = names<E, S>(std::make_index_sequence<count_v<E, S>>{});
+
+template <typename E, enum_subtype S, typename D = std::decay_t<E>>
+using names_t = decltype((names_v<D, S>));
+
+template <typename E, enum_subtype S, std::size_t... I>
+constexpr auto entries(std::index_sequence<I...>) noexcept {
+  return std::array<std::pair<E, string_view>, sizeof...(I)>{{{values_v<E, S>[I], enum_name_v<E, values_v<E, S>[I]>}...}};
+}
+
+template <typename E, enum_subtype S>
+inline constexpr auto entries_v = entries<E, S>(std::make_index_sequence<count_v<E, S>>{});
+
+template <typename E, enum_subtype S, typename D = std::decay_t<E>>
+using entries_t = decltype((entries_v<D, S>));
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr bool is_sparse() noexcept {
+  if constexpr (count_v<E, S> == 0) {
+    return false;
+  } else if constexpr (std::is_same_v<U, bool>) { // bool special case
+    return false;
+  } else {
+    constexpr auto max = (S == enum_subtype::flags) ? log2(max_v<E, S>) : max_v<E, S>;
+    constexpr auto min = (S == enum_subtype::flags) ? log2(min_v<E, S>) : min_v<E, S>;
+    constexpr auto range_size = max - min + 1;
+
+    return range_size != count_v<E, S>;
+  }
+}
+
+template <typename E, enum_subtype S = subtype_v<E>>
+inline constexpr bool is_sparse_v = is_sparse<E, S>();
+
+template <typename E, enum_subtype S, typename U = std::underlying_type_t<E>>
+constexpr U values_ors() noexcept {
+  static_assert(S == enum_subtype::flags, "magic_enum::detail::values_ors requires valid subtype.");
+
+  auto ors = U{0};
+  for (std::size_t i = 0; i < count_v<E, S>; ++i) {
+    ors |= static_cast<U>(values_v<E, S>[i]);
+  }
+
+  return ors;
+}
+
+template <bool, typename R>
+struct enable_if_enum {};
+
+template <typename R>
+struct enable_if_enum<true, R> {
+  using type = R;
+  static_assert(supported<R>::value, "magic_enum unsupported compiler (https://github.com/Neargye/magic_enum#compiler-compatibility).");
+};
+
+template <typename T, typename R, typename BinaryPredicate = std::equal_to<>, typename D = std::decay_t<T>>
+using enable_if_t = typename enable_if_enum<std::is_enum_v<D> && std::is_invocable_r_v<bool, BinaryPredicate, char_type, char_type>, R>::type;
+
+template <typename T, std::enable_if_t<std::is_enum_v<std::decay_t<T>>, int> = 0>
+using enum_concept = T;
+
+template <typename T, bool = std::is_enum_v<T>>
+struct is_scoped_enum : std::false_type {};
+
+template <typename T>
+struct is_scoped_enum<T, true> : std::bool_constant<!std::is_convertible_v<T, std::underlying_type_t<T>>> {};
+
+template <typename T, bool = std::is_enum_v<T>>
+struct is_unscoped_enum : std::false_type {};
+
+template <typename T>
+struct is_unscoped_enum<T, true> : std::bool_constant<std::is_convertible_v<T, std::underlying_type_t<T>>> {};
+
+template <typename T, bool = std::is_enum_v<std::decay_t<T>>>
+struct underlying_type {};
+
+template <typename T>
+struct underlying_type<T, true> : std::underlying_type<std::decay_t<T>> {};
+
+#if defined(MAGIC_ENUM_ENABLE_HASH) || defined(MAGIC_ENUM_ENABLE_HASH_SWITCH)
+
+template <typename Value, typename = void>
+struct constexpr_hash_t;
+
+template <typename Value>
+struct constexpr_hash_t<Value, std::enable_if_t<is_enum_v<Value>>> {
+  constexpr auto operator()(Value value) const noexcept {
+    using U = typename underlying_type<Value>::type;
+    if constexpr (std::is_same_v<U, bool>) { // bool special case
+      return static_cast<std::size_t>(value);
+    } else {
+      return static_cast<U>(value);
+    }
+  }
+  using secondary_hash = constexpr_hash_t;
+};
+
+template <typename Value>
+struct constexpr_hash_t<Value, std::enable_if_t<std::is_same_v<Value, string_view>>> {
+  static constexpr std::uint32_t crc_table[256] {
+    0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L, 0x706af48fL, 0xe963a535L, 0x9e6495a3L,
+    0x0edb8832L, 0x79dcb8a4L, 0xe0d5e91eL, 0x97d2d988L, 0x09b64c2bL, 0x7eb17cbdL, 0xe7b82d07L, 0x90bf1d91L,
+    0x1db71064L, 0x6ab020f2L, 0xf3b97148L, 0x84be41deL, 0x1adad47dL, 0x6ddde4ebL, 0xf4d4b551L, 0x83d385c7L,
+    0x136c9856L, 0x646ba8c0L, 0xfd62f97aL, 0x8a65c9ecL, 0x14015c4fL, 0x63066cd9L, 0xfa0f3d63L, 0x8d080df5L,
+    0x3b6e20c8L, 0x4c69105eL, 0xd56041e4L, 0xa2677172L, 0x3c03e4d1L, 0x4b04d447L, 0xd20d85fdL, 0xa50ab56bL,
+    0x35b5a8faL, 0x42b2986cL, 0xdbbbc9d6L, 0xacbcf940L, 0x32d86ce3L, 0x45df5c75L, 0xdcd60dcfL, 0xabd13d59L,
+    0x26d930acL, 0x51de003aL, 0xc8d75180L, 0xbfd06116L, 0x21b4f4b5L, 0x56b3c423L, 0xcfba9599L, 0xb8bda50fL,
+    0x2802b89eL, 0x5f058808L, 0xc60cd9b2L, 0xb10be924L, 0x2f6f7c87L, 0x58684c11L, 0xc1611dabL, 0xb6662d3dL,
+    0x76dc4190L, 0x01db7106L, 0x98d220bcL, 0xefd5102aL, 0x71b18589L, 0x06b6b51fL, 0x9fbfe4a5L, 0xe8b8d433L,
+    0x7807c9a2L, 0x0f00f934L, 0x9609a88eL, 0xe10e9818L, 0x7f6a0dbbL, 0x086d3d2dL, 0x91646c97L, 0xe6635c01L,
+    0x6b6b51f4L, 0x1c6c6162L, 0x856530d8L, 0xf262004eL, 0x6c0695edL, 0x1b01a57bL, 0x8208f4c1L, 0xf50fc457L,
+    0x65b0d9c6L, 0x12b7e950L, 0x8bbeb8eaL, 0xfcb9887cL, 0x62dd1ddfL, 0x15da2d49L, 0x8cd37cf3L, 0xfbd44c65L,
+    0x4db26158L, 0x3ab551ceL, 0xa3bc0074L, 0xd4bb30e2L, 0x4adfa541L, 0x3dd895d7L, 0xa4d1c46dL, 0xd3d6f4fbL,
+    0x4369e96aL, 0x346ed9fcL, 0xad678846L, 0xda60b8d0L, 0x44042d73L, 0x33031de5L, 0xaa0a4c5fL, 0xdd0d7cc9L,
+    0x5005713cL, 0x270241aaL, 0xbe0b1010L, 0xc90c2086L, 0x5768b525L, 0x206f85b3L, 0xb966d409L, 0xce61e49fL,
+    0x5edef90eL, 0x29d9c998L, 0xb0d09822L, 0xc7d7a8b4L, 0x59b33d17L, 0x2eb40d81L, 0xb7bd5c3bL, 0xc0ba6cadL,
+    0xedb88320L, 0x9abfb3b6L, 0x03b6e20cL, 0x74b1d29aL, 0xead54739L, 0x9dd277afL, 0x04db2615L, 0x73dc1683L,
+    0xe3630b12L, 0x94643b84L, 0x0d6d6a3eL, 0x7a6a5aa8L, 0xe40ecf0bL, 0x9309ff9dL, 0x0a00ae27L, 0x7d079eb1L,
+    0xf00f9344L, 0x8708a3d2L, 0x1e01f268L, 0x6906c2feL, 0xf762575dL, 0x806567cbL, 0x196c3671L, 0x6e6b06e7L,
+    0xfed41b76L, 0x89d32be0L, 0x10da7a5aL, 0x67dd4accL, 0xf9b9df6fL, 0x8ebeeff9L, 0x17b7be43L, 0x60b08ed5L,
+    0xd6d6a3e8L, 0xa1d1937eL, 0x38d8c2c4L, 0x4fdff252L, 0xd1bb67f1L, 0xa6bc5767L, 0x3fb506ddL, 0x48b2364bL,
+    0xd80d2bdaL, 0xaf0a1b4cL, 0x36034af6L, 0x41047a60L, 0xdf60efc3L, 0xa867df55L, 0x316e8eefL, 0x4669be79L,
+    0xcb61b38cL, 0xbc66831aL, 0x256fd2a0L, 0x5268e236L, 0xcc0c7795L, 0xbb0b4703L, 0x220216b9L, 0x5505262fL,
+    0xc5ba3bbeL, 0xb2bd0b28L, 0x2bb45a92L, 0x5cb36a04L, 0xc2d7ffa7L, 0xb5d0cf31L, 0x2cd99e8bL, 0x5bdeae1dL,
+    0x9b64c2b0L, 0xec63f226L, 0x756aa39cL, 0x026d930aL, 0x9c0906a9L, 0xeb0e363fL, 0x72076785L, 0x05005713L,
+    0x95bf4a82L, 0xe2b87a14L, 0x7bb12baeL, 0x0cb61b38L, 0x92d28e9bL, 0xe5d5be0dL, 0x7cdcefb7L, 0x0bdbdf21L,
+    0x86d3d2d4L, 0xf1d4e242L, 0x68ddb3f8L, 0x1fda836eL, 0x81be16cdL, 0xf6b9265bL, 0x6fb077e1L, 0x18b74777L,
+    0x88085ae6L, 0xff0f6a70L, 0x66063bcaL, 0x11010b5cL, 0x8f659effL, 0xf862ae69L, 0x616bffd3L, 0x166ccf45L,
+    0xa00ae278L, 0xd70dd2eeL, 0x4e048354L, 0x3903b3c2L, 0xa7672661L, 0xd06016f7L, 0x4969474dL, 0x3e6e77dbL,
+    0xaed16a4aL, 0xd9d65adcL, 0x40df0b66L, 0x37d83bf0L, 0xa9bcae53L, 0xdebb9ec5L, 0x47b2cf7fL, 0x30b5ffe9L,
+    0xbdbdf21cL, 0xcabac28aL, 0x53b39330L, 0x24b4a3a6L, 0xbad03605L, 0xcdd70693L, 0x54de5729L, 0x23d967bfL,
+    0xb3667a2eL, 0xc4614ab8L, 0x5d681b02L, 0x2a6f2b94L, 0xb40bbe37L, 0xc30c8ea1L, 0x5a05df1bL, 0x2d02ef8dL
+  };
+  constexpr std::uint32_t operator()(string_view value) const noexcept {
+    auto crc = static_cast<std::uint32_t>(0xffffffffL);
+    for (const auto c : value) {
+      crc = (crc >> 8) ^ crc_table[(crc ^ static_cast<std::uint32_t>(c)) & 0xff];
+    }
+    return crc ^ 0xffffffffL;
+  }
+
+  struct secondary_hash {
+    constexpr std::uint32_t operator()(string_view value) const noexcept {
+      auto acc = static_cast<std::uint64_t>(2166136261ULL);
+      for (const auto c : value) {
+        acc = ((acc ^ static_cast<std::uint64_t>(c)) * static_cast<std::uint64_t>(16777619ULL)) & (std::numeric_limits<std::uint32_t>::max)();
+      }
+      return static_cast<std::uint32_t>(acc);
+    }
+  };
+};
+
+template <typename Hash>
+inline constexpr Hash hash_v{};
+
+template <auto* GlobValues, typename Hash>
+constexpr auto calculate_cases(std::size_t Page) noexcept {
+  constexpr std::array values = *GlobValues;
+  constexpr std::size_t size = values.size();
+
+  using switch_t = std::invoke_result_t<Hash, typename decltype(values)::value_type>;
+  static_assert(std::is_integral_v<switch_t> && !std::is_same_v<switch_t, bool>);
+  const std::size_t values_to = (std::min)(static_cast<std::size_t>(256), size - Page);
+
+  std::array<switch_t, 256> result{};
+  auto fill = result.begin();
+  {
+    auto first = values.begin() + static_cast<std::ptrdiff_t>(Page);
+    auto last = values.begin() + static_cast<std::ptrdiff_t>(Page + values_to);
+    while (first != last) {
+      *fill++ = hash_v<Hash>(*first++);
+    }
+  }
+
+  // dead cases, try to avoid case collisions
+  for (switch_t last_value = result[values_to - 1]; fill != result.end() && last_value != (std::numeric_limits<switch_t>::max)(); *fill++ = ++last_value) {
+  }
+
+  {
+    auto it = result.begin();
+    auto last_value = (std::numeric_limits<switch_t>::min)();
+    for (; fill != result.end(); *fill++ = last_value++) {
+      while (last_value == *it) {
+        ++last_value, ++it;
+      }
+    }
+  }
+
+  return result;
+}
+
+template <typename R, typename F, typename... Args>
+constexpr R invoke_r(F&& f, Args&&... args) noexcept(std::is_nothrow_invocable_r_v<R, F, Args...>) {
+  if constexpr (std::is_void_v<R>) {
+    std::forward<F>(f)(std::forward<Args>(args)...);
+  } else {
+    return static_cast<R>(std::forward<F>(f)(std::forward<Args>(args)...));
+  }
+}
+
+enum class case_call_t {
+  index,
+  value
+};
+
+template <typename T = void>
+inline constexpr auto default_result_type_lambda = []() noexcept(std::is_nothrow_default_constructible_v<T>) { return T{}; };
+
+template <>
+inline constexpr auto default_result_type_lambda<void> = []() noexcept {};
+
+template <auto* Arr, typename Hash>
+constexpr bool has_duplicate() noexcept {
+  using value_t = std::decay_t<decltype((*Arr)[0])>;
+  using hash_value_t = std::invoke_result_t<Hash, value_t>;
+  std::array<hash_value_t, Arr->size()> hashes{};
+  std::size_t size = 0;
+  for (auto elem : *Arr) {
+    hashes[size] = hash_v<Hash>(elem);
+    for (auto i = size++; i > 0; --i) {
+      if (hashes[i] < hashes[i - 1]) {
+        auto tmp = hashes[i];
+        hashes[i] = hashes[i - 1];
+        hashes[i - 1] = tmp;
+      } else if (hashes[i] == hashes[i - 1]) {
+        return false;
+      } else {
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+#define MAGIC_ENUM_CASE(val)                                                                                                  \
+  case cases[val]:                                                                                                            \
+    if constexpr ((val) + Page < size) {                                                                                      \
+      if (!pred(values[val + Page], searched)) {                                                                              \
+        break;                                                                                                                \
+      }                                                                                                                       \
+      if constexpr (CallValue == case_call_t::index) {                                                                        \
+        if constexpr (std::is_invocable_r_v<result_t, Lambda, std::integral_constant<std::size_t, val + Page>>) {             \
+          return detail::invoke_r<result_t>(std::forward<Lambda>(lambda), std::integral_constant<std::size_t, val + Page>{}); \
+        } else if constexpr (std::is_invocable_v<Lambda, std::integral_constant<std::size_t, val + Page>>) {                  \
+          MAGIC_ENUM_ASSERT(false && "magic_enum::detail::constexpr_switch wrong result type.");                                         \
+        }                                                                                                                     \
+      } else if constexpr (CallValue == case_call_t::value) {                                                                 \
+        if constexpr (std::is_invocable_r_v<result_t, Lambda, enum_constant<values[val + Page]>>) {                           \
+          return detail::invoke_r<result_t>(std::forward<Lambda>(lambda), enum_constant<values[val + Page]>{});               \
+        } else if constexpr (std::is_invocable_r_v<result_t, Lambda, enum_constant<values[val + Page]>>) {                    \
+          MAGIC_ENUM_ASSERT(false && "magic_enum::detail::constexpr_switch wrong result type.");                                         \
+        }                                                                                                                     \
+      }                                                                                                                       \
+      break;                                                                                                                  \
+    } else [[fallthrough]];
+
+template <auto* GlobValues,
+          case_call_t CallValue,
+          std::size_t Page = 0,
+          typename Hash = constexpr_hash_t<typename std::decay_t<decltype(*GlobValues)>::value_type>,
+          typename BinaryPredicate = std::equal_to<>,
+          typename Lambda,
+          typename ResultGetterType>
+constexpr decltype(auto) constexpr_switch(
+    Lambda&& lambda,
+    typename std::decay_t<decltype(*GlobValues)>::value_type searched,
+    ResultGetterType&& def,
+    BinaryPredicate&& pred = {}) {
+  using result_t = std::invoke_result_t<ResultGetterType>;
+  using hash_t = std::conditional_t<has_duplicate<GlobValues, Hash>(), Hash, typename Hash::secondary_hash>;
+  static_assert(has_duplicate<GlobValues, hash_t>(), "magic_enum::detail::constexpr_switch duplicated hash found, please report it: https://github.com/Neargye/magic_enum/issues.");
+  constexpr std::array values = *GlobValues;
+  constexpr std::size_t size = values.size();
+  constexpr std::array cases = calculate_cases<GlobValues, hash_t>(Page);
+
+  switch (hash_v<hash_t>(searched)) {
+    MAGIC_ENUM_FOR_EACH_256(MAGIC_ENUM_CASE)
+    default:
+      if constexpr (size > 256 + Page) {
+        return constexpr_switch<GlobValues, CallValue, Page + 256, Hash>(std::forward<Lambda>(lambda), searched, std::forward<ResultGetterType>(def));
+      }
+      break;
+  }
+  return def();
+}
+
+#undef MAGIC_ENUM_CASE
+
+#endif
+
+} // namespace magic_enum::detail
+
+// Checks is magic_enum supported compiler.
+inline constexpr bool is_magic_enum_supported = detail::supported<void>::value;
+
+template <typename T>
+using Enum = detail::enum_concept<T>;
+
+// Checks whether T is an Unscoped enumeration type.
+// Provides the member constant value which is equal to true, if T is an [Unscoped enumeration](https://en.cppreference.com/w/cpp/language/enum#Unscoped_enumeration) type. Otherwise, value is equal to false.
+template <typename T>
+struct is_unscoped_enum : detail::is_unscoped_enum<T> {};
+
+template <typename T>
+inline constexpr bool is_unscoped_enum_v = is_unscoped_enum<T>::value;
+
+// Checks whether T is an Scoped enumeration type.
+// Provides the member constant value which is equal to true, if T is an [Scoped enumeration](https://en.cppreference.com/w/cpp/language/enum#Scoped_enumerations) type. Otherwise, value is equal to false.
+template <typename T>
+struct is_scoped_enum : detail::is_scoped_enum<T> {};
+
+template <typename T>
+inline constexpr bool is_scoped_enum_v = is_scoped_enum<T>::value;
+
+// If T is a complete enumeration type, provides a member typedef type that names the underlying type of T.
+// Otherwise, if T is not an enumeration type, there is no member type. Otherwise (T is an incomplete enumeration type), the program is ill-formed.
+template <typename T>
+struct underlying_type : detail::underlying_type<T> {};
+
+template <typename T>
+using underlying_type_t = typename underlying_type<T>::type;
+
+template <auto V>
+using enum_constant = detail::enum_constant<V>;
+
+// Returns type name of enum.
+template <typename E>
+[[nodiscard]] constexpr auto enum_type_name() noexcept -> detail::enable_if_t<E, string_view> {
+  constexpr string_view name = detail::type_name_v<std::decay_t<E>>;
+  static_assert(!name.empty(), "magic_enum::enum_type_name enum type does not have a name.");
+
+  return name;
+}
+
+// Returns number of enum values.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_count() noexcept -> detail::enable_if_t<E, std::size_t> {
+  return detail::count_v<std::decay_t<E>, S>;
+}
+
+// Returns enum value at specified index.
+// No bounds checking is performed: the behavior is undefined if index >= number of enum values.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_value(std::size_t index) noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+
+  if constexpr (detail::is_sparse_v<D, S>) {
+    return MAGIC_ENUM_ASSERT(index < detail::count_v<D, S>), detail::values_v<D, S>[index];
+  } else {
+    constexpr auto min = (S == detail::enum_subtype::flags) ? detail::log2(detail::min_v<D, S>) : detail::min_v<D, S>;
+
+    return MAGIC_ENUM_ASSERT(index < detail::count_v<D, S>), detail::value<D, min, S>(index);
+  }
+}
+
+// Returns enum value at specified index.
+template <typename E, std::size_t I, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_value() noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  static_assert(I < detail::count_v<D, S>, "magic_enum::enum_value out of range.");
+
+  return enum_value<D, S>(I);
+}
+
+// Returns std::array with enum values, sorted by enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_values() noexcept -> detail::enable_if_t<E, detail::values_t<E, S>> {
+  return detail::values_v<std::decay_t<E>, S>;
+}
+
+// Returns integer value from enum value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_integer(E value) noexcept -> detail::enable_if_t<E, underlying_type_t<E>> {
+  return static_cast<underlying_type_t<E>>(value);
+}
+
+// Returns underlying value from enum value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_underlying(E value) noexcept -> detail::enable_if_t<E, underlying_type_t<E>> {
+  return static_cast<underlying_type_t<E>>(value);
+}
+
+// Obtains index in enum values from enum value.
+// Returns optional with index.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_index(E value) noexcept -> detail::enable_if_t<E, optional<std::size_t>> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  if constexpr (detail::count_v<D, S> == 0) {
+    static_cast<void>(value);
+    return {}; // Empty enum.
+  } else if constexpr (detail::is_sparse_v<D, S> || (S == detail::enum_subtype::flags)) {
+#if defined(MAGIC_ENUM_ENABLE_HASH)
+    return detail::constexpr_switch<&detail::values_v<D, S>, detail::case_call_t::index>(
+        [](std::size_t i) { return optional<std::size_t>{i}; },
+        value,
+        detail::default_result_type_lambda<optional<std::size_t>>);
+#else
+    for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+      if (enum_value<D, S>(i) == value) {
+        return i;
+      }
+    }
+    return {}; // Invalid value or out of range.
+#endif
+  } else {
+    const auto v = static_cast<U>(value);
+    if (v >= detail::min_v<D, S> && v <= detail::max_v<D, S>) {
+      return static_cast<std::size_t>(v - detail::min_v<D, S>);
+    }
+    return {}; // Invalid value or out of range.
+  }
+}
+
+// Obtains index in enum values from enum value.
+// Returns optional with index.
+template <detail::enum_subtype S, typename E>
+[[nodiscard]] constexpr auto enum_index(E value) noexcept -> detail::enable_if_t<E, optional<std::size_t>> {
+  using D = std::decay_t<E>;
+
+  return enum_index<D, S>(value);
+}
+
+// Obtains index in enum values from static storage enum variable.
+template <auto V, detail::enum_subtype S = detail::subtype_v<std::decay_t<decltype(V)>>>
+[[nodiscard]] constexpr auto enum_index() noexcept -> detail::enable_if_t<decltype(V), std::size_t> {
+  constexpr auto index = enum_index<std::decay_t<decltype(V)>, S>(V);
+  static_assert(index, "magic_enum::enum_index enum value does not have a index.");
+
+  return *index;
+}
+
+// Returns name from static storage enum variable.
+// This version is much lighter on the compile times and is not restricted to the enum_range limitation.
+template <auto V>
+[[nodiscard]] constexpr auto enum_name() noexcept -> detail::enable_if_t<decltype(V), string_view> {
+  constexpr string_view name = detail::enum_name_v<std::decay_t<decltype(V)>, V>;
+  static_assert(!name.empty(), "magic_enum::enum_name enum value does not have a name.");
+
+  return name;
+}
+
+// Returns name from enum value.
+// If enum value does not have name or value out of range, returns empty string.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_name(E value) noexcept -> detail::enable_if_t<E, string_view> {
+  using D = std::decay_t<E>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    return detail::names_v<D, S>[*i];
+  }
+  return {};
+}
+
+// Returns name from enum value.
+// If enum value does not have name or value out of range, returns empty string.
+template <detail::enum_subtype S, typename E>
+[[nodiscard]] constexpr auto enum_name(E value) -> detail::enable_if_t<E, string_view> {
+  using D = std::decay_t<E>;
+
+  return enum_name<D, S>(value);
+}
+
+// Returns std::array with names, sorted by enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_names() noexcept -> detail::enable_if_t<E, detail::names_t<E, S>> {
+  return detail::names_v<std::decay_t<E>, S>;
+}
+
+// Returns std::array with pairs (value, name), sorted by enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_entries() noexcept -> detail::enable_if_t<E, detail::entries_t<E, S>> {
+  return detail::entries_v<std::decay_t<E>, S>;
+}
+
+// Allows you to write magic_enum::enum_cast<foo>("bar", magic_enum::case_insensitive);
+inline constexpr auto case_insensitive = detail::case_insensitive<>{};
+
+// Obtains enum value from integer value.
+// Returns optional with enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_cast(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, optional<std::decay_t<E>>> {
+  using D = std::decay_t<E>;
+
+  if constexpr (detail::count_v<D, S> == 0) {
+    static_cast<void>(value);
+    return {}; // Empty enum.
+  } else {
+    if constexpr (detail::is_sparse_v<D, S> || (S == detail::enum_subtype::flags)) {
+#if defined(MAGIC_ENUM_ENABLE_HASH)
+      return detail::constexpr_switch<&detail::values_v<D, S>, detail::case_call_t::value>(
+          [](D v) { return optional<D>{v}; },
+          static_cast<D>(value),
+          detail::default_result_type_lambda<optional<D>>);
+#else
+      for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+        if (value == static_cast<underlying_type_t<D>>(enum_value<D, S>(i))) {
+          return static_cast<D>(value);
+        }
+      }
+      return {}; // Invalid value or out of range.
+#endif
+    } else {
+      if (value >= detail::min_v<D, S> && value <= detail::max_v<D, S>) {
+        return static_cast<D>(value);
+      }
+      return {}; // Invalid value or out of range.
+    }
+  }
+}
+
+// Obtains enum value from name.
+// Returns optional with enum value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>, typename BinaryPredicate = std::equal_to<>>
+[[nodiscard]] constexpr auto enum_cast(string_view value, [[maybe_unused]] BinaryPredicate p = {}) noexcept(detail::is_nothrow_invocable<BinaryPredicate>()) -> detail::enable_if_t<E, optional<std::decay_t<E>>, BinaryPredicate> {
+  using D = std::decay_t<E>;
+
+  if constexpr (detail::count_v<D, S> == 0) {
+    static_cast<void>(value);
+    return {}; // Empty enum.
+#if defined(MAGIC_ENUM_ENABLE_HASH)
+    } else if constexpr (detail::is_default_predicate<BinaryPredicate>()) {
+      return detail::constexpr_switch<&detail::names_v<D, S>, detail::case_call_t::index>(
+          [](std::size_t i) { return optional<D>{detail::values_v<D, S>[i]}; },
+          value,
+          detail::default_result_type_lambda<optional<D>>,
+          [&p](string_view lhs, string_view rhs) { return detail::cmp_equal(lhs, rhs, p); });
+#endif
+    } else {
+    for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+      if (detail::cmp_equal(value, detail::names_v<D, S>[i], p)) {
+        return enum_value<D, S>(i);
+      }
+    }
+    return {}; // Invalid value or out of range.
+  }
+}
+
+// Checks whether enum contains value with such value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_contains(E value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  return static_cast<bool>(enum_cast<D, S>(static_cast<U>(value)));
+}
+
+// Checks whether enum contains value with such value.
+template <detail::enum_subtype S, typename E>
+[[nodiscard]] constexpr auto enum_contains(E value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  return static_cast<bool>(enum_cast<D, S>(static_cast<U>(value)));
+}
+
+// Checks whether enum contains value with such integer value.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_contains(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+
+  return static_cast<bool>(enum_cast<D, S>(value));
+}
+
+// Checks whether enum contains enumerator with such name.
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>, typename BinaryPredicate = std::equal_to<>>
+[[nodiscard]] constexpr auto enum_contains(string_view value, BinaryPredicate p = {}) noexcept(detail::is_nothrow_invocable<BinaryPredicate>()) -> detail::enable_if_t<E, bool, BinaryPredicate> {
+  using D = std::decay_t<E>;
+
+  return static_cast<bool>(enum_cast<D, S>(value, std::move(p)));
+}
+
+template <bool AsFlags = true>
+inline constexpr auto as_flags = AsFlags ? detail::enum_subtype::flags : detail::enum_subtype::common;
+
+template <bool AsFlags = true>
+inline constexpr auto as_common = AsFlags ? detail::enum_subtype::common : detail::enum_subtype::flags;
+
+namespace bitwise_operators {
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E operator~(E rhs) noexcept {
+  return static_cast<E>(~static_cast<underlying_type_t<E>>(rhs));
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E operator|(E lhs, E rhs) noexcept {
+  return static_cast<E>(static_cast<underlying_type_t<E>>(lhs) | static_cast<underlying_type_t<E>>(rhs));
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E operator&(E lhs, E rhs) noexcept {
+  return static_cast<E>(static_cast<underlying_type_t<E>>(lhs) & static_cast<underlying_type_t<E>>(rhs));
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E operator^(E lhs, E rhs) noexcept {
+  return static_cast<E>(static_cast<underlying_type_t<E>>(lhs) ^ static_cast<underlying_type_t<E>>(rhs));
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E& operator|=(E& lhs, E rhs) noexcept {
+  return lhs = (lhs | rhs);
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E& operator&=(E& lhs, E rhs) noexcept {
+  return lhs = (lhs & rhs);
+}
+
+template <typename E, detail::enable_if_t<E, int> = 0>
+constexpr E& operator^=(E& lhs, E rhs) noexcept {
+  return lhs = (lhs ^ rhs);
+}
+
+} // namespace magic_enum::bitwise_operators
+
+} // namespace magic_enum
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
+
+#undef MAGIC_ENUM_GET_ENUM_NAME_BUILTIN
+#undef MAGIC_ENUM_GET_TYPE_NAME_BUILTIN
+#undef MAGIC_ENUM_VS_2017_WORKAROUND
+#undef MAGIC_ENUM_ARRAY_CONSTEXPR
+#undef MAGIC_ENUM_FOR_EACH_256
+
+#endif // NEARGYE_MAGIC_ENUM_HPP

--- a/third_party/magic_enum/magic_enum_all.hpp
+++ b/third_party/magic_enum/magic_enum_all.hpp
@@ -1,0 +1,44 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_ALL_HPP
+#define NEARGYE_MAGIC_ENUM_ALL_HPP
+
+#include "magic_enum.hpp"
+#include "magic_enum_containers.hpp"
+#include "magic_enum_flags.hpp"
+#include "magic_enum_format.hpp"
+#include "magic_enum_fuse.hpp"
+#include "magic_enum_iostream.hpp"
+#include "magic_enum_switch.hpp"
+#include "magic_enum_utility.hpp"
+
+#endif // NEARGYE_MAGIC_ENUM_ALL_HPP

--- a/third_party/magic_enum/magic_enum_containers.hpp
+++ b/third_party/magic_enum/magic_enum_containers.hpp
@@ -1,0 +1,1174 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+// Copyright (c) 2022 - 2023 Bela Schaum <schaumb@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_CONTAINERS_HPP
+#define NEARGYE_MAGIC_ENUM_CONTAINERS_HPP
+
+#include "magic_enum.hpp"
+
+#if !defined(MAGIC_ENUM_NO_EXCEPTION) && (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || defined(_CPPUNWIND))
+#  include <stdexcept>
+#  define MAGIC_ENUM_THROW(...) throw (__VA_ARGS__)
+#else
+#  include <cstdlib>
+#  define MAGIC_ENUM_THROW(...) std::abort()
+#endif
+
+namespace magic_enum::containers {
+
+namespace detail {
+
+template <typename T, typename = void>
+static constexpr bool is_transparent_v{};
+
+template <typename T>
+static constexpr bool is_transparent_v<T, std::void_t<typename T::is_transparent>>{true};
+
+template <typename Eq = std::equal_to<>, typename T1, typename T2>
+constexpr bool equal(T1&& t1, T2&& t2, Eq&& eq = {}) {
+  auto first1 = t1.begin();
+  auto last1 = t1.end();
+  auto first2 = t2.begin();
+  auto last2 = t2.end();
+
+  for (; first1 != last1; ++first1, ++first2) {
+    if (first2 == last2 || !eq(*first1, *first2)) {
+      return false;
+    }
+  }
+  return first2 == last2;
+}
+
+template <typename Cmp = std::less<>, typename T1, typename T2>
+constexpr bool lexicographical_compare(T1&& t1, T2&& t2, Cmp&& cmp = {}) noexcept {
+  auto first1 = t1.begin();
+  auto last1 = t1.end();
+  auto first2 = t2.begin();
+  auto last2 = t2.end();
+
+  // copied from std::lexicographical_compare
+  for (; (first1 != last1) && (first2 != last2); ++first1, (void)++first2) {
+    if (cmp(*first1, *first2)) {
+      return true;
+    }
+    if (cmp(*first2, *first1)) {
+      return false;
+    }
+  }
+  return (first1 == last1) && (first2 != last2);
+}
+
+template <typename T>
+constexpr std::size_t popcount(T x) noexcept {
+  std::size_t c = 0;
+  while (x > 0) {
+    c += x & 1;
+    x >>= 1;
+  }
+  return c;
+}
+
+template <typename Cmp = std::less<>, typename ForwardIt, typename E>
+constexpr ForwardIt lower_bound(ForwardIt first, ForwardIt last, E&& e, Cmp&& comp = {}) {
+  auto count = std::distance(first, last);
+  for (auto it = first; count > 0;) {
+    auto step = count / 2;
+    std::advance(it, step);
+    if (comp(*it, e)) {
+      first = ++it;
+      count -= step + 1;
+    } else {
+      count = step;
+    }
+  }
+  return first;
+}
+
+template <typename Cmp = std::less<>, typename BidirIt, typename E>
+constexpr auto equal_range(BidirIt begin, BidirIt end, E&& e, Cmp&& comp = {}) {
+  const auto first = lower_bound(begin, end, e, comp);
+  return std::pair{first, lower_bound(std::make_reverse_iterator(end), std::make_reverse_iterator(first), e, [&comp](auto&& lhs, auto&& rhs) { return comp(rhs, lhs); }).base()};
+}
+
+template <typename E = void, typename Cmp = std::less<E>, typename = void>
+class indexing {
+  [[nodiscard]] static constexpr auto get_indices() noexcept {
+    // reverse result index mapping
+    std::array<std::size_t, enum_count<E>()> rev_res{};
+
+    // std::iota
+    for (std::size_t i = 0; i < enum_count<E>(); ++i) {
+      rev_res[i] = i;
+    }
+
+    constexpr auto orig_values = enum_values<E>();
+    constexpr Cmp cmp{};
+
+    // ~std::sort
+    for (std::size_t i = 0; i < enum_count<E>(); ++i) {
+      for (std::size_t j = i + 1; j < enum_count<E>(); ++j) {
+        if (cmp(orig_values[rev_res[j]], orig_values[rev_res[i]])) {
+          auto tmp = rev_res[i];
+          rev_res[i] = rev_res[j];
+          rev_res[j] = tmp;
+        }
+      }
+    }
+
+    std::array<E, enum_count<E>()> sorted_values{};
+    // reverse the sorted indices
+    std::array<std::size_t, enum_count<E>()> res{};
+    for (std::size_t i = 0; i < enum_count<E>(); ++i) {
+      res[rev_res[i]] = i;
+      sorted_values[i] = orig_values[rev_res[i]];
+    }
+
+    return std::pair{sorted_values, res};
+  }
+
+  static constexpr auto indices = get_indices();
+
+ public:
+  [[nodiscard]] static constexpr const E* begin() noexcept { return indices.first.data(); }
+
+  [[nodiscard]] static constexpr const E* end() noexcept { return indices.first.data() + indices.first.size(); }
+
+  [[nodiscard]] static constexpr const E* it(std::size_t i) noexcept { return indices.first.data() + i; }
+
+  [[nodiscard]] static constexpr optional<std::size_t> at(E val) noexcept {
+    if (auto i = enum_index(val)) {
+      return indices.second[*i];
+    }
+    return {};
+  }
+};
+
+template <typename E, typename Cmp>
+class indexing<E, Cmp, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && (std::is_same_v<Cmp, std::less<E>> || std::is_same_v<Cmp, std::less<>>)>> {
+   static constexpr auto& values = enum_values<E>();
+
+ public:
+   [[nodiscard]] static constexpr const E* begin() noexcept { return values.data(); }
+
+   [[nodiscard]] static constexpr const E* end() noexcept { return values.data() + values.size(); }
+
+  [[nodiscard]] static constexpr const E* it(std::size_t i) noexcept { return values.data() + i; }
+
+  [[nodiscard]] static constexpr optional<std::size_t> at(E val) noexcept { return enum_index(val); }
+};
+
+template <typename Cmp>
+struct indexing<void, Cmp, void> {
+  using is_transparent = std::true_type;
+
+  template <typename E>
+  [[nodiscard]] static constexpr optional<std::size_t> at(E val) noexcept {
+    return indexing<E, Cmp>::at(val);
+  }
+};
+
+template <typename E = void, typename Cmp = std::less<>, typename = void>
+struct name_sort_impl {
+  [[nodiscard]] constexpr bool operator()(E e1, E e2) const noexcept { return Cmp{}(enum_name(e1), enum_name(e2)); }
+};
+
+template <typename Cmp>
+struct name_sort_impl<void, Cmp> {
+  using is_transparent = std::true_type;
+
+  template <typename C = Cmp, typename = void>
+  struct FullCmp : C {};
+
+  template <typename C>
+  struct FullCmp<C, std::enable_if_t<!std::is_invocable_v<C, string_view, string_view> && std::is_invocable_v<C, char_type, char_type>>> {
+    [[nodiscard]] constexpr bool operator()(string_view s1, string_view s2) const noexcept { return lexicographical_compare<C>(s1, s2); }
+  };
+
+  template <typename E1, typename E2>
+  [[nodiscard]] constexpr std::enable_if_t<
+      // at least one of need to be an enum type
+      (std::is_enum_v<std::decay_t<E1>> || std::is_enum_v<std::decay_t<E2>>) &&
+      // if both is enum, only accept if the same enum
+      (!std::is_enum_v<std::decay_t<E1>> || !std::is_enum_v<std::decay_t<E2>> || std::is_same_v<E1, E2>) &&
+      // is invocable with comparator
+      (std::is_invocable_r_v<bool, FullCmp<>, std::conditional_t<std::is_enum_v<std::decay_t<E1>>, string_view, E1>, std::conditional_t<std::is_enum_v<std::decay_t<E2>>, string_view, E2>>),
+      bool>
+  operator()(E1 e1, E2 e2) const noexcept {
+    using D1 = std::decay_t<E1>;
+    using D2 = std::decay_t<E2>;
+    constexpr FullCmp<> cmp{};
+
+    if constexpr (std::is_enum_v<D1> && std::is_enum_v<D2>) {
+      return cmp(enum_name(e1), enum_name(e2));
+    } else if constexpr (std::is_enum_v<D1>) {
+      return cmp(enum_name(e1), e2);
+    } else /* if constexpr (std::is_enum_v<D2>) */ {
+      return cmp(e1, enum_name(e2));
+    }
+  }
+};
+
+struct raw_access_t {};
+
+template <typename Parent, typename Iterator, typename Getter, typename Predicate>
+struct FilteredIterator {
+  Parent parent;
+  Iterator first;
+  Iterator last;
+  Iterator current;
+  Getter getter;
+  Predicate predicate;
+
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = std::remove_reference_t<std::invoke_result_t<Getter, Parent, Iterator>>;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  constexpr FilteredIterator() noexcept = default;
+  constexpr FilteredIterator(const FilteredIterator&) = default;
+  constexpr FilteredIterator& operator=(const FilteredIterator&) = default;
+  constexpr FilteredIterator(FilteredIterator&&) noexcept = default;
+  constexpr FilteredIterator& operator=(FilteredIterator&&) noexcept = default;
+
+  template <typename OtherParent, typename OtherIterator, typename = std::enable_if_t<std::is_convertible_v<OtherParent, Parent> && std::is_convertible_v<OtherIterator, Iterator>>*>
+  constexpr explicit FilteredIterator(const FilteredIterator<OtherParent, OtherIterator, Getter, Predicate>& other)
+      : parent(other.parent), first(other.first), last(other.last), current(other.current), getter(other.getter), predicate(other.predicate) {}
+
+  constexpr FilteredIterator(Parent p, Iterator begin, Iterator end, Iterator curr, Getter getter = {}, Predicate pred = {})
+      : parent(p), first(std::move(begin)), last(std::move(end)), current(std::move(curr)), getter{std::move(getter)}, predicate{std::move(pred)} {
+    if (current == first && !predicate(parent, current)) {
+      ++*this;
+    }
+  }
+
+  [[nodiscard]] constexpr reference operator*() const { return getter(parent, current); }
+
+  [[nodiscard]] constexpr pointer operator->() const { return std::addressof(**this); }
+
+  constexpr FilteredIterator& operator++() {
+    do {
+      ++current;
+    } while (current != last && !predicate(parent, current));
+    return *this;
+  }
+
+  [[nodiscard]] constexpr FilteredIterator operator++(int) {
+    FilteredIterator cp = *this;
+    ++*this;
+    return cp;
+  }
+
+  constexpr FilteredIterator& operator--() {
+    do {
+      --current;
+    } while (current != first && !predicate(parent, current));
+    return *this;
+  }
+
+  [[nodiscard]] constexpr FilteredIterator operator--(int) {
+    FilteredIterator cp = *this;
+    --*this;
+    return cp;
+  }
+
+  [[nodiscard]] friend constexpr bool operator==(const FilteredIterator& lhs, const FilteredIterator& rhs) { return lhs.current == rhs.current; }
+
+  [[nodiscard]] friend constexpr bool operator!=(const FilteredIterator& lhs, const FilteredIterator& rhs) { return lhs.current != rhs.current; }
+};
+
+} // namespace detail
+
+template <typename E = void>
+using name_less = detail::name_sort_impl<E>;
+
+template <typename E = void>
+using name_greater = detail::name_sort_impl<E, std::greater<>>;
+
+using name_less_case_insensitive = detail::name_sort_impl<void, magic_enum::detail::case_insensitive<std::less<>>>;
+
+using name_greater_case_insensitive = detail::name_sort_impl<void, magic_enum::detail::case_insensitive<std::greater<>>>;
+
+template <typename E = void>
+using default_indexing = detail::indexing<E>;
+
+template <typename Cmp = std::less<>>
+using comparator_indexing = detail::indexing<void, Cmp>;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                          ARRAY                                                            //
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename E, typename V, typename Index = default_indexing<E>>
+struct array {
+  static_assert(std::is_enum_v<E>);
+  static_assert(std::is_trivially_constructible_v<Index>);
+  static_assert(enum_count<E>() == 0 || Index::at(enum_values<E>().front())); // check Index is constexpr
+
+  using index_type = Index;
+  using container_type = std::array<V, enum_count<E>()>;
+
+  using value_type = typename container_type::value_type;
+  using size_type = typename container_type::size_type;
+  using difference_type = typename container_type::difference_type;
+  using reference = typename container_type::reference;
+  using const_reference = typename container_type::const_reference;
+  using pointer = typename container_type::pointer;
+  using const_pointer = typename container_type::const_pointer;
+  using iterator = typename container_type::iterator;
+  using const_iterator = typename container_type::const_iterator;
+  using reverse_iterator = typename container_type::reverse_iterator;
+  using const_reverse_iterator = typename container_type::const_reverse_iterator;
+
+  constexpr reference at(E pos) {
+    if (auto index = index_type::at(pos)) {
+      return a[*index];
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::array::at Unrecognized position"));
+  }
+
+  constexpr const_reference at(E pos) const {
+    if (auto index = index_type::at(pos)) {
+      return a[*index];
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::array::at: Unrecognized position"));
+  }
+
+  [[nodiscard]] constexpr reference operator[](E pos) {
+    auto i = index_type::at(pos);
+    return MAGIC_ENUM_ASSERT(i), a[*i];
+  }
+
+  [[nodiscard]] constexpr const_reference operator[](E pos) const {
+    auto i = index_type::at(pos);
+    return MAGIC_ENUM_ASSERT(i), a[*i];
+  }
+
+  [[nodiscard]] constexpr reference front() noexcept { return a.front(); }
+
+  [[nodiscard]] constexpr const_reference front() const noexcept { return a.front(); }
+
+  [[nodiscard]] constexpr reference back() noexcept { return a.back(); }
+
+  [[nodiscard]] constexpr const_reference back() const noexcept { return a.back(); }
+
+  [[nodiscard]] constexpr pointer data() noexcept { return a.data(); }
+
+  [[nodiscard]] constexpr const_pointer data() const noexcept { return a.data(); }
+
+  [[nodiscard]] constexpr iterator begin() noexcept { return a.begin(); }
+
+  [[nodiscard]] constexpr const_iterator begin() const noexcept { return a.begin(); }
+
+  [[nodiscard]] constexpr const_iterator cbegin() const noexcept { return a.cbegin(); }
+
+  [[nodiscard]] constexpr iterator end() noexcept { return a.end(); }
+
+  [[nodiscard]] constexpr const_iterator end() const noexcept { return a.end(); }
+
+  [[nodiscard]] constexpr const_iterator cend() const noexcept { return a.cend(); }
+
+  [[nodiscard]] constexpr iterator rbegin() noexcept { return a.rbegin(); }
+
+  [[nodiscard]] constexpr const_iterator rbegin() const noexcept { return a.rbegin(); }
+
+  [[nodiscard]] constexpr const_iterator crbegin() const noexcept { return a.crbegin(); }
+
+  [[nodiscard]] constexpr iterator rend() noexcept { return a.rend(); }
+
+  [[nodiscard]] constexpr const_iterator rend() const noexcept { return a.rend(); }
+
+  [[nodiscard]] constexpr const_iterator crend() const noexcept { return a.crend(); }
+
+  [[nodiscard]] constexpr bool empty() const noexcept { return a.empty(); }
+
+  [[nodiscard]] constexpr size_type size() const noexcept { return a.size(); }
+
+  [[nodiscard]] constexpr size_type max_size() const noexcept { return a.max_size(); }
+
+  constexpr void fill(const V& value) {
+    for (auto& v : a) {
+      v = value;
+    }
+  }
+
+  constexpr void swap(array& other) noexcept(std::is_nothrow_swappable_v<V>) {
+    for (std::size_t i = 0; i < a.size(); ++i) {
+      auto v = std::move(other.a[i]);
+      other.a[i] = std::move(a[i]);
+      a[i] = std::move(v);
+    }
+  }
+
+  [[nodiscard]] friend constexpr bool operator==(const array& a1, const array& a2) { return detail::equal(a1, a2); }
+
+  [[nodiscard]] friend constexpr bool operator!=(const array& a1, const array& a2) { return !detail::equal(a1, a2); }
+
+  [[nodiscard]] friend constexpr bool operator<(const array& a1, const array& a2) { return detail::lexicographical_compare(a1, a2); }
+
+  [[nodiscard]] friend constexpr bool operator<=(const array& a1, const array& a2) { return !detail::lexicographical_compare(a2, a1); }
+
+  [[nodiscard]] friend constexpr bool operator>(const array& a1, const array& a2) { return detail::lexicographical_compare(a2, a1); }
+
+  [[nodiscard]] friend constexpr bool operator>=(const array& a1, const array& a2) { return !detail::lexicographical_compare(a1, a2); }
+
+  container_type a;
+};
+
+namespace detail {
+
+template <typename E, typename T, std::size_t N, std::size_t... I>
+constexpr array<E, std::remove_cv_t<T>> to_array_impl(T (&a)[N], std::index_sequence<I...>) {
+  return {{a[I]...}};
+}
+
+template <typename E, typename T, std::size_t N, std::size_t... I>
+constexpr array<E, std::remove_cv_t<T>> to_array_impl(T(&&a)[N], std::index_sequence<I...>) {
+  return {{std::move(a[I])...}};
+}
+
+} // namespace detail
+
+template <typename E, typename T, std::size_t N>
+constexpr std::enable_if_t<(enum_count<E>() == N), array<E, std::remove_cv_t<T>>> to_array(T (&a)[N]) {
+  return detail::to_array_impl<E>(a, std::make_index_sequence<N>{});
+}
+
+template <typename E, typename T, std::size_t N>
+constexpr std::enable_if_t<(enum_count<E>() == N), array<E, std::remove_cv_t<T>>> to_array(T(&&a)[N]) {
+  return detail::to_array_impl<E>(std::move(a), std::make_index_sequence<N>{});
+}
+
+template <typename E, typename... Ts>
+constexpr std::enable_if_t<(enum_count<E>() == sizeof...(Ts)), array<E, std::remove_cv_t<std::common_type_t<Ts...>>>> make_array(Ts&&... ts) {
+  return {{std::forward<Ts>(ts)...}};
+}
+
+inline constexpr detail::raw_access_t raw_access{};
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                         BITSET                                                            //
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename E, typename Index = default_indexing<E>>
+class bitset {
+  static_assert(std::is_enum_v<E>);
+  static_assert(std::is_trivially_constructible_v<Index>);
+  static_assert(enum_count<E>() == 0 || Index::at(enum_values<E>().front())); // check Index is constexpr
+
+  using base_type = std::conditional_t<enum_count<E>() <= 8,  std::uint_least8_t,
+                    std::conditional_t<enum_count<E>() <= 16, std::uint_least16_t,
+                    std::conditional_t<enum_count<E>() <= 32, std::uint_least32_t,
+                                                              std::uint_least64_t>>>;
+
+  static constexpr std::size_t bits_per_base = sizeof(base_type) * 8;
+  static constexpr std::size_t base_type_count = (enum_count<E>() > 0 ? (enum_count<E>() - 1) / bits_per_base + 1 : 0);
+  static constexpr std::size_t not_interested = base_type_count * bits_per_base - enum_count<E>();
+  static constexpr base_type last_value_max = (base_type{1} << (bits_per_base - not_interested)) - 1;
+
+  template <typename parent_t = bitset*>
+  class reference_impl {
+    friend class bitset;
+
+    parent_t parent;
+    std::size_t num_index;
+    base_type bit_index;
+
+    constexpr reference_impl(parent_t parent, std::size_t ix) noexcept : reference_impl(parent, std::pair{ix / bits_per_base, base_type{1} << (ix % bits_per_base)}) {}
+
+    constexpr reference_impl(parent_t parent, std::pair<std::size_t, base_type> ix) noexcept : parent(parent), num_index(std::get<0>(ix)), bit_index(std::get<1>(ix)) {}
+
+   public:
+    constexpr reference_impl& operator=(bool v) noexcept {
+      if (v) {
+        parent->a[num_index] |= bit_index;
+      } else {
+        parent->a[num_index] &= ~bit_index;
+      }
+      return *this;
+    }
+
+    constexpr reference_impl& operator=(const reference_impl& v) noexcept {
+      if (this == &v) {
+        return *this;
+      }
+      *this = static_cast<bool>(v);
+      return *this;
+    }
+
+    [[nodiscard]] constexpr explicit operator bool() const noexcept { return (parent->a[num_index] & bit_index) > 0; }
+
+    [[nodiscard]] constexpr bool operator~() const noexcept { return !static_cast<bool>(*this); }
+
+    constexpr reference_impl& flip() noexcept {
+      *this = ~*this;
+      return *this;
+    }
+  };
+
+  template <typename T>
+  [[nodiscard]] constexpr T to_(detail::raw_access_t) const {
+    T res{};
+    T flag{1};
+    for (std::size_t i = 0; i < size(); ++i, flag <<= 1) {
+      if (const_reference{this, i}) {
+        if (i >= sizeof(T) * 8) {
+          MAGIC_ENUM_THROW(std::overflow_error("magic_enum::containers::bitset::to: Cannot represent enum in this type"));
+        }
+        res |= flag;
+      }
+    }
+    return res;
+  }
+
+ public:
+  using index_type = Index;
+  using container_type = std::array<base_type, base_type_count>;
+  using reference = reference_impl<>;
+  using const_reference = reference_impl<const bitset*>;
+
+  constexpr explicit bitset(detail::raw_access_t = raw_access) noexcept : a{{}} {}
+
+  constexpr explicit bitset(detail::raw_access_t, unsigned long long val) : a{{}} {
+    unsigned long long bit{1};
+    for (std::size_t i = 0; i < (sizeof(val) * 8); ++i, bit <<= 1) {
+      if ((val & bit) > 0) {
+        if (i >= enum_count<E>()) {
+          MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::constructor: Upper bit set in raw number"));
+        }
+
+        reference{this, i} = true;
+      }
+    }
+  }
+
+  constexpr explicit bitset(detail::raw_access_t, string_view sv, string_view::size_type pos = 0, string_view::size_type n = string_view::npos, char_type zero = static_cast<char_type>('0'), char_type one = static_cast<char_type>('1'))
+      : a{{}} {
+    std::size_t i = 0;
+    for (auto c : sv.substr(pos, n)) {
+      if (c == one) {
+        if (i >= enum_count<E>()) {
+          MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::constructor: Upper bit set in raw string"));
+        }
+        reference{this, i} = true;
+      } else if (c != zero) {
+        MAGIC_ENUM_THROW(std::invalid_argument("magic_enum::containers::bitset::constructor: Unrecognized character in raw string"));
+      }
+      ++i;
+    }
+  }
+
+  constexpr explicit bitset(detail::raw_access_t, const char_type* str, std::size_t n = ~std::size_t{0}, char_type zero = static_cast<char_type>('0'), char_type one = static_cast<char_type>('1'))
+      : bitset(string_view{str, (std::min)(std::char_traits<char_type>::length(str), n)}, 0, n, zero, one) {}
+
+  constexpr bitset(std::initializer_list<E> starters) : a{{}} {
+    if constexpr (magic_enum::detail::subtype_v<E> == magic_enum::detail::enum_subtype::flags) {
+      for (auto& f : starters) {
+        *this |= bitset(f);
+      }
+    } else {
+      for (auto& f : starters) {
+        set(f);
+      }
+    }
+  }
+  template <typename V, std::enable_if_t<std::is_same_v<V, E> && magic_enum::detail::subtype_v<V> == magic_enum::detail::enum_subtype::flags, int> = 0>
+  constexpr explicit bitset(V starter) : a{{}} {
+    auto u = enum_underlying(starter);
+    for (E v : enum_values<E>()) {
+      if (auto ul = enum_underlying(v); (ul & u) != 0) {
+        u &= ~ul;
+        (*this)[v] = true;
+      }
+    }
+    if (u != 0) {
+      MAGIC_ENUM_THROW(std::invalid_argument("magic_enum::containers::bitset::constructor: Unrecognized enum value in flag"));
+    }
+  }
+
+  template <typename Cmp = std::equal_to<>>
+  constexpr explicit bitset(string_view sv, Cmp&& cmp = {}, char_type sep = static_cast<char_type>('|')) {
+    for (std::size_t to = 0; (to = magic_enum::detail::find(sv, sep)) != string_view::npos; sv.remove_prefix(to + 1)) {
+      if (auto v = enum_cast<E>(sv.substr(0, to), cmp)) {
+        set(v);
+      } else {
+        MAGIC_ENUM_THROW(std::invalid_argument("magic_enum::containers::bitset::constructor: Unrecognized enum value in string"));
+      }
+    }
+    if (!sv.empty()) {
+      if (auto v = enum_cast<E>(sv, cmp)) {
+        set(v);
+      } else {
+        MAGIC_ENUM_THROW(std::invalid_argument("magic_enum::containers::bitset::constructor: Unrecognized enum value in string"));
+      }
+    }
+  }
+
+  [[nodiscard]] friend constexpr bool operator==(const bitset& lhs, const bitset& rhs) noexcept { return detail::equal(lhs.a, rhs.a); }
+
+  [[nodiscard]] friend constexpr bool operator!=(const bitset& lhs, const bitset& rhs) noexcept { return !detail::equal(lhs.a, rhs.a); }
+
+  [[nodiscard]] constexpr bool operator[](E pos) const {
+    auto i = index_type::at(pos);
+    return MAGIC_ENUM_ASSERT(i), static_cast<bool>(const_reference(this, *i));
+  }
+
+  [[nodiscard]] constexpr reference operator[](E pos) {
+    auto i = index_type::at(pos);
+    return MAGIC_ENUM_ASSERT(i), reference{this, *i};
+  }
+
+  constexpr bool test(E pos) const {
+    if (auto i = index_type::at(pos)) {
+      return static_cast<bool>(const_reference(this, *i));
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::test: Unrecognized position"));
+  }
+
+  [[nodiscard]] constexpr bool all() const noexcept {
+    if constexpr (base_type_count == 0) {
+      return true;
+    }
+
+    for (std::size_t i = 0; i < base_type_count - (not_interested > 0); ++i) {
+      auto check = ~a[i];
+      if (check) {
+        return false;
+      }
+    }
+
+    if constexpr (not_interested > 0) {
+      return a[base_type_count - 1] == last_value_max;
+    }
+  }
+
+  [[nodiscard]] constexpr bool any() const noexcept {
+    for (auto& v : a) {
+      if (v > 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] constexpr bool none() const noexcept { return !any(); }
+
+  [[nodiscard]] constexpr std::size_t count() const noexcept {
+    std::size_t c = 0;
+    for (auto& v : a) {
+      c += detail::popcount(v);
+    }
+    return c;
+  }
+
+  [[nodiscard]] constexpr std::size_t size() const noexcept { return enum_count<E>(); }
+
+  [[nodiscard]] constexpr std::size_t max_size() const noexcept { return enum_count<E>(); }
+
+  constexpr bitset& operator&=(const bitset& other) noexcept {
+    for (std::size_t i = 0; i < base_type_count; ++i) {
+      a[i] &= other.a[i];
+    }
+    return *this;
+  }
+
+  constexpr bitset& operator|=(const bitset& other) noexcept {
+    for (std::size_t i = 0; i < base_type_count; ++i) {
+      a[i] |= other.a[i];
+    }
+    return *this;
+  }
+
+  constexpr bitset& operator^=(const bitset& other) noexcept {
+    for (std::size_t i = 0; i < base_type_count; ++i) {
+      a[i] ^= other.a[i];
+    }
+    return *this;
+  }
+
+  [[nodiscard]] constexpr bitset operator~() const noexcept {
+    bitset res;
+    for (std::size_t i = 0; i < base_type_count - (not_interested > 0); ++i) {
+      res.a[i] = ~a[i];
+    }
+
+    if constexpr (not_interested > 0) {
+      res.a[base_type_count - 1] = ~a[base_type_count - 1] & last_value_max;
+    }
+    return res;
+  }
+
+  constexpr bitset& set() noexcept {
+    for (std::size_t i = 0; i < base_type_count - (not_interested > 0); ++i) {
+      a[i] = ~base_type{0};
+    }
+
+    if constexpr (not_interested > 0) {
+      a[base_type_count - 1] = last_value_max;
+    }
+    return *this;
+  }
+
+  constexpr bitset& set(E pos, bool value = true) {
+    if (auto i = index_type::at(pos)) {
+      reference{this, *i} = value;
+      return *this;
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::set: Unrecognized position"));
+  }
+
+  constexpr bitset& reset() noexcept { return *this = bitset{}; }
+
+  constexpr bitset& reset(E pos) {
+    if (auto i = index_type::at(pos)) {
+      reference{this, *i} = false;
+      return *this;
+    }
+    MAGIC_ENUM_THROW(std::out_of_range("magic_enum::containers::bitset::reset: Unrecognized position"));
+  }
+
+  constexpr bitset& flip() noexcept { return *this = ~*this; }
+
+  [[nodiscard]] friend constexpr bitset operator&(const bitset& lhs, const bitset& rhs) noexcept {
+    bitset cp = lhs;
+    cp &= rhs;
+    return cp;
+  }
+
+  [[nodiscard]] friend constexpr bitset operator|(const bitset& lhs, const bitset& rhs) noexcept {
+    bitset cp = lhs;
+    cp |= rhs;
+    return cp;
+  }
+
+  [[nodiscard]] friend constexpr bitset operator^(const bitset& lhs, const bitset& rhs) noexcept {
+    bitset cp = lhs;
+    cp ^= rhs;
+    return cp;
+  }
+
+  template <typename V = E>
+  [[nodiscard]] constexpr explicit operator std::enable_if_t<magic_enum::detail::subtype_v<V> == magic_enum::detail::enum_subtype::flags, E>() const {
+    E res{};
+    for (const auto& e : enum_values<E>()) {
+      if (test(e)) {
+        res |= e;
+      }
+    }
+    return res;
+  }
+
+  [[nodiscard]] string to_string(char_type sep = static_cast<char_type>('|')) const {
+    string name;
+
+    for (const auto& e : enum_values<E>()) {
+      if (test(e)) {
+        if (!name.empty()) {
+          name.append(1, sep);
+        }
+        auto n = enum_name(e);
+        name.append(n.data(), n.size());
+      }
+    }
+    return name;
+  }
+
+  [[nodiscard]] string to_string(detail::raw_access_t, char_type zero = static_cast<char_type>('0'), char_type one = static_cast<char_type>('1')) const {
+    string name;
+    name.reserve(size());
+    for (std::size_t i = 0; i < size(); ++i) {
+      name.append(1, const_reference{this, i} ? one : zero);
+    }
+    return name;
+  }
+
+  [[nodiscard]] constexpr unsigned long long to_ullong(detail::raw_access_t raw) const { return to_<unsigned long long>(raw); }
+
+  [[nodiscard]] constexpr unsigned long long to_ulong(detail::raw_access_t raw) const { return to_<unsigned long>(raw); }
+
+  friend std::ostream& operator<<(std::ostream& o, const bitset& bs) { return o << bs.to_string(); }
+
+  friend std::istream& operator>>(std::istream& i, bitset& bs) {
+    string s;
+    if (i >> s; !s.empty()) {
+      bs = bitset(string_view{s});
+    }
+    return i;
+  }
+
+ private:
+  container_type a;
+};
+
+template <typename V, int = 0>
+explicit bitset(V starter) -> bitset<V>;
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//                                                           SET                                                             //
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+template <typename E, typename Cmp = std::less<E>>
+class set {
+  using index_type = detail::indexing<E, Cmp>;
+  struct Getter {
+    constexpr const E& operator()(const set*, const E* p) const noexcept { return *p; }
+  };
+  struct Predicate {
+    constexpr bool operator()(const set* h, const E* e) const noexcept { return h->a[*e]; }
+  };
+
+ public:
+  using container_type = bitset<E, index_type>;
+  using key_type = E;
+  using value_type = E;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using key_compare = Cmp;
+  using value_compare = Cmp;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using iterator = detail::FilteredIterator<const set*, const E*, Getter, Predicate>;
+  using const_iterator = detail::FilteredIterator<const set*, const E*, Getter, Predicate>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+  constexpr set() noexcept = default;
+
+  template <typename InputIt>
+  constexpr set(InputIt first, InputIt last) {
+    while (first != last) {
+      insert(*first++);
+    }
+  }
+
+  constexpr set(std::initializer_list<E> ilist) {
+    for (auto e : ilist) {
+      insert(e);
+    }
+  }
+  template <typename V, std::enable_if_t<std::is_same_v<V, E> && magic_enum::detail::subtype_v<V> == magic_enum::detail::enum_subtype::flags, int> = 0>
+  constexpr explicit set(V starter) {
+    auto u = enum_underlying(starter);
+    for (E v : enum_values<E>()) {
+      if ((enum_underlying(v) & u) != 0) {
+        insert(v);
+      }
+    }
+  }
+
+  constexpr set(const set&) noexcept = default;
+  constexpr set(set&&) noexcept = default;
+
+  constexpr set& operator=(const set&) noexcept = default;
+  constexpr set& operator=(set&&) noexcept = default;
+  constexpr set& operator=(std::initializer_list<E> ilist) {
+    for (auto e : ilist) {
+      insert(e);
+    }
+  }
+
+  constexpr const_iterator begin() const noexcept {
+    return const_iterator{this, index_type::begin(), index_type::end(), index_type::begin()};
+  }
+
+  constexpr const_iterator end() const noexcept {
+    return const_iterator{this, index_type::begin(), index_type::end(), index_type::end()};
+  }
+
+  constexpr const_iterator cbegin() const noexcept { return begin(); }
+
+  constexpr const_iterator cend() const noexcept { return end(); }
+
+  constexpr const_reverse_iterator rbegin() const noexcept { return {end()}; }
+
+  constexpr const_reverse_iterator rend() const noexcept { return {begin()}; }
+
+  constexpr const_reverse_iterator crbegin() const noexcept { return rbegin(); }
+
+  constexpr const_reverse_iterator crend() const noexcept { return rend(); }
+
+  [[nodiscard]] constexpr bool empty() const noexcept { return s == 0; }
+
+  [[nodiscard]] constexpr size_type size() const noexcept { return s; }
+
+  [[nodiscard]] constexpr size_type max_size() const noexcept { return a.max_size(); }
+
+  constexpr void clear() noexcept {
+    a.reset();
+    s = 0;
+  }
+
+  constexpr std::pair<iterator, bool> insert(const value_type& value) noexcept {
+    if (auto i = index_type::at(value)) {
+      typename container_type::reference ref = a[value];
+      bool r = !ref;
+      if (r) {
+        ref = true;
+        ++s;
+      }
+
+      return {iterator{this, index_type::begin(), index_type::end(), index_type::it(*i)}, r};
+    }
+    return {end(), false};
+  }
+
+  constexpr std::pair<iterator, bool> insert(value_type&& value) noexcept { return insert(value); }
+
+  constexpr iterator insert(const_iterator, const value_type& value) noexcept { return insert(value).first; }
+
+  constexpr iterator insert(const_iterator hint, value_type&& value) noexcept { return insert(hint, value); }
+
+  template <typename InputIt>
+  constexpr void insert(InputIt first, InputIt last) noexcept {
+    while (first != last) {
+      insert(*first++);
+    }
+  }
+
+  constexpr void insert(std::initializer_list<value_type> ilist) noexcept {
+    for (auto v : ilist) {
+      insert(v);
+    }
+  }
+
+  template <typename... Args>
+  constexpr std::pair<iterator, bool> emplace(Args&&... args) noexcept {
+    return insert({std::forward<Args>(args)...});
+  }
+
+  template <typename... Args>
+  constexpr iterator emplace_hint(const_iterator, Args&&... args) noexcept {
+    return emplace(std::forward<Args>(args)...).first;
+  }
+
+  constexpr iterator erase(const_iterator pos) noexcept {
+    erase(*pos++);
+    return pos;
+  }
+
+  constexpr iterator erase(const_iterator first, const_iterator last) noexcept {
+    while ((first = erase(first)) != last) {
+    }
+    return first;
+  }
+
+  constexpr size_type erase(const key_type& key) noexcept {
+    typename container_type::reference ref = a[key];
+    bool res = ref;
+    if (res) {
+      --s;
+    }
+    ref = false;
+    return res;
+  }
+
+  template <typename K, typename KC = key_compare>
+  constexpr std::enable_if_t<detail::is_transparent_v<KC>, size_type> erase(K&& x) noexcept {
+    size_type c = 0;
+    for (auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{}); first != last;) {
+      c += erase(*first++);
+    }
+    return c;
+  }
+
+  void swap(set& other) noexcept {
+    set cp = *this;
+    *this = other;
+    other = cp;
+  }
+
+  [[nodiscard]] constexpr size_type count(const key_type& key) const noexcept { return index_type::at(key) && a[key]; }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, size_type> count(const K& x) const {
+    size_type c = 0;
+    for (auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{}); first != last; ++first) {
+      c += count(*first);
+    }
+    return c;
+  }
+
+  [[nodiscard]] constexpr const_iterator find(const key_type& key) const noexcept {
+    if (auto i = index_type::at(key); i && a.test(key)) {
+      return const_iterator{this, index_type::begin(), index_type::end(), index_type::it(*i)};
+    }
+    return end();
+  }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, const_iterator> find(const K& x) const {
+    for (auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{}); first != last; ++first) {
+      if (a.test(*first)) {
+        return find(*first);
+      }
+    }
+    return end();
+  }
+
+  [[nodiscard]] constexpr bool contains(const key_type& key) const noexcept { return count(key); }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, bool> contains(const K& x) const noexcept {
+    return count(x) > 0;
+  }
+
+  [[nodiscard]] constexpr std::pair<const_iterator, const_iterator> equal_range(const key_type& key) const noexcept { return {lower_bound(key), upper_bound(key)}; }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, std::pair<const_iterator, const_iterator>> equal_range(const K& x) const noexcept {
+    return {lower_bound(x), upper_bound(x)};
+  }
+
+  [[nodiscard]] constexpr const_iterator lower_bound(const key_type& key) const noexcept {
+    if (auto i = index_type::at(key)) {
+      auto it = const_iterator{this, index_type::begin(), index_type::end(), index_type::it(*i)};
+      return a.test(key) ? it : std::next(it);
+    }
+    return end();
+  }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, const_iterator> lower_bound(const K& x) const noexcept {
+    auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{});
+    return first != last ? lower_bound(*first) : end();
+  }
+
+  [[nodiscard]] constexpr const_iterator upper_bound(const key_type& key) const noexcept {
+    if (auto i = index_type::at(key)) {
+      return std::next(const_iterator{this, index_type::begin(), index_type::end(), index_type::it(*i)});
+    }
+    return end();
+  }
+
+  template <typename K, typename KC = key_compare>
+  [[nodiscard]] constexpr std::enable_if_t<detail::is_transparent_v<KC>, const_iterator> upper_bound(const K& x) const noexcept {
+    auto [first, last] = detail::equal_range(index_type::begin(), index_type::end(), x, key_compare{});
+    return first != last ? upper_bound(*std::prev(last)) : end();
+  }
+
+  [[nodiscard]] constexpr key_compare key_comp() const { return {}; }
+
+  [[nodiscard]] constexpr value_compare value_comp() const { return {}; }
+
+  [[nodiscard]] constexpr friend bool operator==(const set& lhs, const set& rhs) noexcept { return lhs.a == rhs.a; }
+
+  [[nodiscard]] constexpr friend bool operator!=(const set& lhs, const set& rhs) noexcept { return lhs.a != rhs.a; }
+
+  [[nodiscard]] constexpr friend bool operator<(const set& lhs, const set& rhs) noexcept {
+    if (lhs.s < rhs.s) {
+      return true;
+    }
+    if (rhs.s < lhs.s) {
+      return false;
+    }
+
+    for (auto it = index_type::begin(); it != index_type::end(); ++it) {
+      if (auto c = rhs.contains(*it); c != lhs.contains(*it)) {
+        return c;
+      }
+    }
+    return false;
+  }
+
+  [[nodiscard]] constexpr friend bool operator<=(const set& lhs, const set& rhs) noexcept { return !(rhs < lhs); }
+
+  [[nodiscard]] constexpr friend bool operator>(const set& lhs, const set& rhs) noexcept { return rhs < lhs; }
+
+  [[nodiscard]] constexpr friend bool operator>=(const set& lhs, const set& rhs) noexcept { return !(lhs < rhs); }
+
+  template <typename Pred>
+  size_type erase_if(Pred pred) {
+    auto old_size = size();
+    for (auto i = begin(), last = end(); i != last;) {
+      if (pred(*i)) {
+        i = erase(i);
+      } else {
+        ++i;
+      }
+    }
+    return old_size - size();
+  }
+
+ private:
+  container_type a;
+  std::size_t s = 0;
+};
+
+template <typename V, int = 0>
+explicit set(V starter) -> set<V>;
+
+} // namespace magic_enum::containers
+
+namespace std {
+
+template <auto I, typename E, typename V, typename Index>
+constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < magic_enum::enum_count<E>()), V&> get(magic_enum::containers::array<E, V, Index>& a) noexcept {
+  return a.a[I];
+}
+
+template <auto I, typename E, typename V, typename Index>
+constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < magic_enum::enum_count<E>()), V&&> get(magic_enum::containers::array<E, V, Index>&& a) noexcept {
+  return std::move(a.a[I]);
+}
+
+template <auto I, typename E, typename V, typename Index>
+constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < magic_enum::enum_count<E>()), const V&> get(const magic_enum::containers::array<E, V, Index>& a) noexcept {
+  return a.a[I];
+}
+
+template <auto I, typename E, typename V, typename Index>
+constexpr std::enable_if_t<(std::is_integral_v<decltype(I)> && I < magic_enum::enum_count<E>()), const V&&> get(const magic_enum::containers::array<E, V, Index>&& a) noexcept {
+  return std::move(a.a[I]);
+}
+
+template <auto Enum, typename E, typename V, typename Index>
+constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && magic_enum::enum_contains(Enum), V&> get(magic_enum::containers::array<E, V, Index>& a) noexcept {
+  return a[Enum];
+}
+
+template <auto Enum, typename E, typename V, typename Index>
+constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && magic_enum::enum_contains(Enum), V&&> get(magic_enum::containers::array<E, V, Index>&& a) noexcept {
+  return std::move(a[Enum]);
+}
+
+template <auto Enum, typename E, typename V, typename Index>
+constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && magic_enum::enum_contains(Enum), const V&> get(const magic_enum::containers::array<E, V, Index>& a) noexcept {
+  return a[Enum];
+}
+
+template <auto Enum, typename E, typename V, typename Index>
+constexpr std::enable_if_t<std::is_same_v<decltype(Enum), E> && magic_enum::enum_contains(Enum), const V&&> get(const magic_enum::containers::array<E, V, Index>&& a) noexcept {
+  return std::move(a[Enum]);
+}
+
+} // namespace std
+
+#endif // NEARGYE_MAGIC_ENUM_CONTAINERS_HPP

--- a/third_party/magic_enum/magic_enum_flags.hpp
+++ b/third_party/magic_enum/magic_enum_flags.hpp
@@ -1,0 +1,203 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_FLAGS_HPP
+#define NEARGYE_MAGIC_ENUM_FLAGS_HPP
+
+#include "magic_enum.hpp"
+
+#if defined(__clang__)
+#  pragma clang diagnostic push
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized" // May be used uninitialized 'return {};'.
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#endif
+
+namespace magic_enum {
+
+// Returns name from enum-flags value.
+// If enum-flags value does not have name or value out of range, returns empty string.
+template <typename E>
+[[nodiscard]] auto enum_flags_name(E value, char_type sep = static_cast<char_type>('|')) -> detail::enable_if_t<E, string> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+  constexpr auto S = detail::enum_subtype::flags;
+
+  string name;
+  auto check_value = U{0};
+  for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+    if (const auto v = static_cast<U>(enum_value<D, S>(i)); (static_cast<U>(value) & v) != 0) {
+      if (const auto n = detail::names_v<D, S>[i]; !n.empty()) {
+        check_value |= v;
+        if (!name.empty()) {
+          name.append(1, sep);
+        }
+        name.append(n.data(), n.size());
+      } else {
+        return {}; // Value out of range.
+      }
+    }
+  }
+
+  if (check_value != 0 && check_value == static_cast<U>(value)) {
+    return name;
+  }
+  return {}; // Invalid value or out of range.
+}
+
+// Obtains enum-flags value from integer value.
+// Returns optional with enum-flags value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_flags_cast(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, optional<std::decay_t<E>>> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+  constexpr auto S = detail::enum_subtype::flags;
+
+  if constexpr (detail::count_v<D, S> == 0) {
+    static_cast<void>(value);
+    return {}; // Empty enum.
+  } else {
+    if constexpr (detail::is_sparse_v<D, S>) {
+      auto check_value = U{0};
+      for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+        if (const auto v = static_cast<U>(enum_value<D, S>(i)); (value & v) != 0) {
+          check_value |= v;
+        }
+      }
+
+      if (check_value != 0 && check_value == value) {
+        return static_cast<D>(value);
+      }
+    } else {
+      constexpr auto min = detail::min_v<D, S>;
+      constexpr auto max = detail::values_ors<D, S>();
+
+      if (value >= min && value <= max) {
+        return static_cast<D>(value);
+      }
+    }
+    return {}; // Invalid value or out of range.
+  }
+}
+
+// Obtains enum-flags value from name.
+// Returns optional with enum-flags value.
+template <typename E, typename BinaryPredicate = std::equal_to<>>
+[[nodiscard]] constexpr auto enum_flags_cast(string_view value, [[maybe_unused]] BinaryPredicate p = {}) noexcept(detail::is_nothrow_invocable<BinaryPredicate>()) -> detail::enable_if_t<E, optional<std::decay_t<E>>, BinaryPredicate> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+  constexpr auto S = detail::enum_subtype::flags;
+
+  if constexpr (detail::count_v<D, S> == 0) {
+    static_cast<void>(value);
+    return {}; // Empty enum.
+  } else {
+    auto result = U{0};
+    while (!value.empty()) {
+      const auto d = detail::find(value, '|');
+      const auto s = (d == string_view::npos) ? value : value.substr(0, d);
+      auto f = U{0};
+      for (std::size_t i = 0; i < detail::count_v<D, S>; ++i) {
+        if (detail::cmp_equal(s, detail::names_v<D, S>[i], p)) {
+          f = static_cast<U>(enum_value<D, S>(i));
+          result |= f;
+          break;
+        }
+      }
+      if (f == U{0}) {
+        return {}; // Invalid value or out of range.
+      }
+      value.remove_prefix((d == string_view::npos) ? value.size() : d + 1);
+    }
+
+    if (result != U{0}) {
+      return static_cast<D>(result);
+    }
+    return {}; // Invalid value or out of range.
+  }
+}
+
+// Checks whether enum-flags contains value with such value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_flags_contains(E value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  return static_cast<bool>(enum_flags_cast<D>(static_cast<U>(value)));
+}
+
+// Checks whether enum-flags contains value with such integer value.
+template <typename E>
+[[nodiscard]] constexpr auto enum_flags_contains(underlying_type_t<E> value) noexcept -> detail::enable_if_t<E, bool> {
+  using D = std::decay_t<E>;
+
+  return static_cast<bool>(enum_flags_cast<D>(value));
+}
+
+// Checks whether enum-flags contains enumerator with such name.
+template <typename E, typename BinaryPredicate = std::equal_to<>>
+[[nodiscard]] constexpr auto enum_flags_contains(string_view value, BinaryPredicate p = {}) noexcept(detail::is_nothrow_invocable<BinaryPredicate>()) -> detail::enable_if_t<E, bool, BinaryPredicate> {
+  using D = std::decay_t<E>;
+
+  return static_cast<bool>(enum_flags_cast<D>(value, std::move(p)));
+}
+
+// Checks whether `flags set` contains `flag`.
+// Note: If `flag` equals 0, it returns false, as 0 is not a flag.
+template <typename E>
+constexpr auto enum_flags_test(E flags, E flag) noexcept -> detail::enable_if_t<E, bool> {
+  using U = underlying_type_t<E>;
+
+  return static_cast<U>(flag) && ((static_cast<U>(flags) & static_cast<U>(flag)) == static_cast<U>(flag));
+}
+
+// Checks whether `lhs flags set` and `rhs flags set` have common flags.
+// Note: If `lhs flags set` or `rhs flags set` equals 0, it returns false, as 0 is not a flag, and therfore cannot have any matching flag.
+template <typename E>
+constexpr auto enum_flags_test_any(E lhs, E rhs) noexcept -> detail::enable_if_t<E, bool> {
+  using U = underlying_type_t<E>;
+
+  return (static_cast<U>(lhs) & static_cast<U>(rhs)) != 0;
+}
+
+} // namespace magic_enum
+
+#if defined(__clang__)
+#  pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
+
+#endif // NEARGYE_MAGIC_ENUM_FLAGS_HPP

--- a/third_party/magic_enum/magic_enum_format.hpp
+++ b/third_party/magic_enum/magic_enum_format.hpp
@@ -1,0 +1,110 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_FORMAT_HPP
+#define NEARGYE_MAGIC_ENUM_FORMAT_HPP
+
+#include "magic_enum.hpp"
+#include "magic_enum_flags.hpp"
+
+#if !defined(MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT)
+#  define MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT 1
+#  define MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT_AUTO_DEFINE
+#endif
+
+namespace magic_enum::customize {
+  // customize enum to enable/disable automatic std::format
+  template <typename E>
+  constexpr bool enum_format_enabled() noexcept {
+    return MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT;
+  }
+} // magic_enum::customize
+
+#if defined(__cpp_lib_format)
+
+#include <format>
+
+template <typename E>
+struct std::formatter<E, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && magic_enum::customize::enum_format_enabled<E>(), char>> : std::formatter<std::string_view, char> {
+  auto format(E e, format_context& ctx) const {
+    static_assert(std::is_same_v<char, string_view::value_type>, "formatter requires string_view::value_type type same as char.");
+    using D = std::decay_t<E>;
+
+    if constexpr (magic_enum::detail::supported<D>::value) {
+      if constexpr (magic_enum::detail::subtype_v<D> == magic_enum::detail::enum_subtype::flags) {
+        if (const auto name = magic_enum::enum_flags_name<D>(e); !name.empty()) {
+          return formatter<std::string_view, char>::format(std::string_view{name.data(), name.size()}, ctx);
+        }
+      } else {
+        if (const auto name = magic_enum::enum_name<D>(e); !name.empty()) {
+          return formatter<std::string_view, char>::format(std::string_view{name.data(), name.size()}, ctx);
+        }
+      }
+    }
+    return formatter<std::string_view, char>::format(std::to_string(magic_enum::enum_integer<D>(e)), ctx);
+  }
+};
+
+#endif
+
+#if defined(FMT_VERSION)
+
+#include <fmt/format.h>
+
+template <typename E>
+struct fmt::formatter<E, std::enable_if_t<std::is_enum_v<std::decay_t<E>> && magic_enum::customize::enum_format_enabled<E>(), char>> : fmt::formatter<std::string_view, char> {
+  auto format(E e, format_context& ctx) {
+    static_assert(std::is_same_v<char, string_view::value_type>, "formatter requires string_view::value_type type same as char.");
+    using D = std::decay_t<E>;
+
+    if constexpr (magic_enum::detail::supported<D>::value) {
+      if constexpr (magic_enum::detail::subtype_v<D> == magic_enum::detail::enum_subtype::flags) {
+        if (const auto name = magic_enum::enum_flags_name<D>(e); !name.empty()) {
+          return formatter<std::string_view, char>::format(std::string_view{name.data(), name.size()}, ctx);
+        }
+      } else {
+        if (const auto name = magic_enum::enum_name<D>(e); !name.empty()) {
+          return formatter<std::string_view, char>::format(std::string_view{name.data(), name.size()}, ctx);
+        }
+      }
+    }
+    return formatter<std::string_view, char>::format(std::to_string(magic_enum::enum_integer<D>(e)), ctx);
+  }
+};
+
+#endif
+
+#if defined(MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT_AUTO_DEFINE)
+#  undef MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT
+#  undef MAGIC_ENUM_DEFAULT_ENABLE_ENUM_FORMAT_AUTO_DEFINE
+#endif
+
+#endif // NEARGYE_MAGIC_ENUM_FORMAT_HPP

--- a/third_party/magic_enum/magic_enum_fuse.hpp
+++ b/third_party/magic_enum/magic_enum_fuse.hpp
@@ -1,0 +1,98 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_FUSE_HPP
+#define NEARGYE_MAGIC_ENUM_FUSE_HPP
+
+#include "magic_enum.hpp"
+
+namespace magic_enum {
+
+namespace detail {
+
+template <typename E, typename... Es>
+inline constexpr auto subtypes_v = subtype_v<E>;
+
+template <enum_subtype S, typename E>
+constexpr optional<std::uintmax_t> fuse_one_enum(optional<std::uintmax_t> hash, E value) noexcept {
+  if (hash) {
+    if (const auto index = enum_index(value)) {
+      return (*hash << log2(enum_count<E, S>() + 1)) | *index;
+    }
+  }
+  return {};
+}
+
+template <enum_subtype S, typename E>
+constexpr optional<std::uintmax_t> fuse_enum(E value) noexcept {
+  return fuse_one_enum<S>(0, value);
+}
+
+template <enum_subtype S, typename E, typename... Es>
+constexpr optional<std::uintmax_t> fuse_enum(E head, Es... tail) noexcept {
+  return fuse_one_enum<S>(fuse_enum<S>(tail...), head);
+}
+
+template <enum_subtype S, typename... Es>
+constexpr auto typesafe_fuse_enum(Es... values) noexcept {
+  enum class enum_fuse_t : std::uintmax_t;
+  const auto fuse = fuse_enum<S>(values...);
+  if (fuse) {
+    return optional<enum_fuse_t>{static_cast<enum_fuse_t>(*fuse)};
+  }
+  return optional<enum_fuse_t>{};
+}
+
+} // namespace magic_enum::detail
+
+// Returns a bijective mix of several enum values. This can be used to emulate 2D switch/case statements.
+template <detail::enum_subtype S, typename... Es>
+[[nodiscard]] constexpr auto enum_fuse(Es... values) noexcept {
+  static_assert((std::is_enum_v<std::decay_t<Es>> && ...), "magic_enum::enum_fuse requires enum type.");
+  static_assert(sizeof...(Es) >= 2, "magic_enum::enum_fuse requires at least 2 values.");
+  static_assert((detail::log2(enum_count<std::decay_t<Es>, S>() + 1) + ...) <= (sizeof(std::uintmax_t) * 8), "magic_enum::enum_fuse does not work for large enums");
+#if defined(MAGIC_ENUM_NO_TYPESAFE_ENUM_FUSE)
+  const auto fuse = detail::fuse_enum<S, std::decay_t<Es>...>(values...);
+#else
+  const auto fuse = detail::typesafe_fuse_enum<S, std::decay_t<Es>...>(values...);
+#endif
+  return MAGIC_ENUM_ASSERT(fuse), fuse;
+}
+
+// Returns a bijective mix of several enum values. This can be used to emulate 2D switch/case statements.
+template <typename... Es>
+[[nodiscard]] constexpr auto enum_fuse(Es... values) noexcept {
+  return enum_fuse<detail::subtypes_v<std::decay_t<Es>...>>(values...);
+}
+
+} // namespace magic_enum
+
+#endif // NEARGYE_MAGIC_ENUM_FUSE_HPP

--- a/third_party/magic_enum/magic_enum_iostream.hpp
+++ b/third_party/magic_enum/magic_enum_iostream.hpp
@@ -1,0 +1,115 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_IOSTREAM_HPP
+#define NEARGYE_MAGIC_ENUM_IOSTREAM_HPP
+
+#include "magic_enum.hpp"
+#include "magic_enum_flags.hpp"
+
+#include <iosfwd>
+
+namespace magic_enum {
+
+namespace ostream_operators {
+
+template <typename Char, typename Traits, typename E, detail::enable_if_t<E, int> = 0>
+std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os, E value) {
+  using D = std::decay_t<E>;
+  using U = underlying_type_t<D>;
+
+  if constexpr (detail::supported<D>::value) {
+    if constexpr (detail::subtype_v<D> == detail::enum_subtype::flags) {
+      if (const auto name = enum_flags_name<D>(value); !name.empty()) {
+        for (const auto c : name) {
+          os.put(c);
+        }
+        return os;
+      }
+    } else {
+      if (const auto name = enum_name<D>(value); !name.empty()) {
+        for (const auto c : name) {
+          os.put(c);
+        }
+        return os;
+      }
+    }
+  }
+  return (os << static_cast<U>(value));
+}
+
+template <typename Char, typename Traits, typename E, detail::enable_if_t<E, int> = 0>
+std::basic_ostream<Char, Traits>& operator<<(std::basic_ostream<Char, Traits>& os, optional<E> value) {
+  return value ? (os << *value) : os;
+}
+
+} // namespace magic_enum::ostream_operators
+
+namespace istream_operators {
+
+template <typename Char, typename Traits, typename E, detail::enable_if_t<E, int> = 0>
+std::basic_istream<Char, Traits>& operator>>(std::basic_istream<Char, Traits>& is, E& value) {
+  using D = std::decay_t<E>;
+
+  std::basic_string<Char, Traits> s;
+  is >> s;
+  if constexpr (detail::supported<D>::value) {
+    if constexpr (detail::subtype_v<D> == detail::enum_subtype::flags) {
+      if (const auto v = enum_flags_cast<D>(s)) {
+        value = *v;
+      } else {
+        is.setstate(std::basic_ios<Char>::failbit);
+      }
+    } else {
+      if (const auto v = enum_cast<D>(s)) {
+        value = *v;
+      } else {
+        is.setstate(std::basic_ios<Char>::failbit);
+      }
+    }
+  } else {
+    is.setstate(std::basic_ios<Char>::failbit);
+  }
+  return is;
+}
+
+} // namespace magic_enum::istream_operators
+
+namespace iostream_operators {
+
+using namespace ostream_operators;
+using namespace istream_operators;
+
+} // namespace magic_enum::iostream_operators
+
+} // namespace magic_enum
+
+#endif // NEARGYE_MAGIC_ENUM_IOSTREAM_HPP

--- a/third_party/magic_enum/magic_enum_switch.hpp
+++ b/third_party/magic_enum/magic_enum_switch.hpp
@@ -1,0 +1,202 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_SWITCH_HPP
+#define NEARGYE_MAGIC_ENUM_SWITCH_HPP
+
+#include "magic_enum.hpp"
+
+namespace magic_enum {
+
+namespace detail {
+
+struct default_result_type {};
+
+template <typename T>
+struct identity {
+  using type = T;
+};
+
+struct nonesuch {};
+
+template <typename F, typename V, bool = std::is_invocable_v<F, V>>
+struct invoke_result : identity<nonesuch> {};
+
+template <typename F, typename V>
+struct invoke_result<F, V, true> : std::invoke_result<F, V> {};
+
+template <typename F, typename V>
+using invoke_result_t = typename invoke_result<F, V>::type;
+
+template <typename E, enum_subtype S, typename F, std::size_t... I>
+constexpr auto common_invocable(std::index_sequence<I...>) noexcept {
+  static_assert(is_enum_v<E>, "magic_enum::detail::invocable_index requires enum type.");
+
+  if constexpr (count_v<E, S> == 0) {
+    return identity<nonesuch>{};
+  } else {
+    return std::common_type<invoke_result_t<F, enum_constant<values_v<E, S>[I]>>...>{};
+  }
+}
+
+template <typename E, enum_subtype S, typename Result, typename F>
+constexpr auto result_type() noexcept {
+  static_assert(is_enum_v<E>, "magic_enum::detail::result_type requires enum type.");
+
+  constexpr auto seq = std::make_index_sequence<count_v<E, S>>{};
+  using R = typename decltype(common_invocable<E, S, F>(seq))::type;
+  if constexpr (std::is_same_v<Result, default_result_type>) {
+    if constexpr (std::is_same_v<R, nonesuch>) {
+      return identity<void>{};
+    } else {
+      return identity<R>{};
+    }
+  } else {
+    if constexpr (std::is_convertible_v<R, Result>) {
+      return identity<Result>{};
+    } else if constexpr (std::is_convertible_v<Result, R>) {
+      return identity<R>{};
+    } else {
+      return identity<nonesuch>{};
+    }
+  }
+}
+
+template <typename E, enum_subtype S, typename Result, typename F, typename D = std::decay_t<E>, typename R = typename decltype(result_type<D, S, Result, F>())::type>
+using result_t = std::enable_if_t<std::is_enum_v<D> && !std::is_same_v<R, nonesuch>, R>;
+
+#if !defined(MAGIC_ENUM_ENABLE_HASH) && !defined(MAGIC_ENUM_ENABLE_HASH_SWITCH)
+
+template <typename T = void>
+inline constexpr auto default_result_type_lambda = []() noexcept(std::is_nothrow_default_constructible_v<T>) { return T{}; };
+
+template <>
+inline constexpr auto default_result_type_lambda<void> = []() noexcept {};
+
+template <typename R, typename F, typename... Args>
+constexpr R invoke_r(F&& f, Args&&... args) noexcept(std::is_nothrow_invocable_r_v<R, F, Args...>) {
+  if constexpr (std::is_void_v<R>) {
+    std::forward<F>(f)(std::forward<Args>(args)...);
+  } else {
+    return static_cast<R>(std::forward<F>(f)(std::forward<Args>(args)...));
+  }
+}
+
+template <std::size_t I, std::size_t End, typename R, typename E, enum_subtype S, typename F, typename Def>
+constexpr decltype(auto) constexpr_switch_impl(F&& f, E value, Def&& def) {
+  if constexpr(I < End) {
+    constexpr auto v = enum_constant<enum_value<E, I, S>()>{};
+    if (value == v) {
+      if constexpr (std::is_invocable_r_v<R, F, decltype(v)>) {
+        return invoke_r<R>(std::forward<F>(f), v);
+      } else {
+        return def();
+      }
+    } else {
+      return constexpr_switch_impl<I + 1, End, R, E, S>(std::forward<F>(f), value, std::forward<Def>(def));
+    }
+  } else {
+    return def();
+  }
+}
+
+template <typename R, typename E, enum_subtype S, typename F, typename Def>
+constexpr decltype(auto) constexpr_switch(F&& f, E value, Def&& def) {
+  static_assert(is_enum_v<E>, "magic_enum::detail::constexpr_switch requires enum type.");
+
+  if constexpr (count_v<E, S> == 0) {
+    return def();
+  } else {
+    return constexpr_switch_impl<0, count_v<E, S>, R, E, S>(std::forward<F>(f), value, std::forward<Def>(def));
+  }
+}
+#endif
+
+} // namespace magic_enum::detail
+
+template <typename Result = detail::default_result_type, typename E, detail::enum_subtype S = detail::subtype_v<E>, typename F, typename R = detail::result_t<E, S, Result, F>>
+constexpr decltype(auto) enum_switch(F&& f, E value) {
+  using D = std::decay_t<E>;
+  static_assert(std::is_enum_v<D>, "magic_enum::enum_switch requires enum type.");
+
+#if defined(MAGIC_ENUM_ENABLE_HASH) || defined(MAGIC_ENUM_ENABLE_HASH_SWITCH)
+  return detail::constexpr_switch<&detail::values_v<D, S>, detail::case_call_t::value>(
+      std::forward<F>(f),
+      value,
+      detail::default_result_type_lambda<R>);
+#else
+  return detail::constexpr_switch<R, D, S>(
+      std::forward<F>(f),
+      value,
+      detail::default_result_type_lambda<R>);
+#endif
+}
+
+template <typename Result = detail::default_result_type, detail::enum_subtype S, typename E, typename F, typename R = detail::result_t<E, S, Result, F>>
+constexpr decltype(auto) enum_switch(F&& f, E value) {
+  return enum_switch<Result, E, S>(std::forward<F>(f), value);
+}
+
+template <typename Result, typename E, detail::enum_subtype S = detail::subtype_v<E>, typename F, typename R = detail::result_t<E, S, Result, F>>
+constexpr decltype(auto) enum_switch(F&& f, E value, Result&& result) {
+  using D = std::decay_t<E>;
+  static_assert(std::is_enum_v<D>, "magic_enum::enum_switch requires enum type.");
+
+#if defined(MAGIC_ENUM_ENABLE_HASH) || defined(MAGIC_ENUM_ENABLE_HASH_SWITCH)
+  return detail::constexpr_switch<&detail::values_v<D, S>, detail::case_call_t::value>(
+      std::forward<F>(f),
+      value,
+      [&result]() -> R { return std::forward<Result>(result); });
+#else
+  return detail::constexpr_switch<R, D, S>(
+      std::forward<F>(f),
+      value,
+      [&result]() -> R { return std::forward<Result>(result); });
+#endif
+}
+
+template <typename Result, detail::enum_subtype S, typename E, typename F, typename R = detail::result_t<E, S, Result, F>>
+constexpr decltype(auto) enum_switch(F&& f, E value, Result&& result) {
+  return enum_switch<Result, E, S>(std::forward<F>(f), value, std::forward<Result>(result));
+}
+
+} // namespace magic_enum
+
+template <>
+struct std::common_type<magic_enum::detail::nonesuch, magic_enum::detail::nonesuch> : magic_enum::detail::identity<magic_enum::detail::nonesuch> {};
+
+template <typename T>
+struct std::common_type<T, magic_enum::detail::nonesuch> : magic_enum::detail::identity<T> {};
+
+template <typename T>
+struct std::common_type<magic_enum::detail::nonesuch, T> : magic_enum::detail::identity<T> {};
+
+#endif // NEARGYE_MAGIC_ENUM_SWITCH_HPP

--- a/third_party/magic_enum/magic_enum_utility.hpp
+++ b/third_party/magic_enum/magic_enum_utility.hpp
@@ -1,0 +1,137 @@
+//  __  __             _        ______                          _____
+// |  \/  |           (_)      |  ____|                        / ____|_     _
+// | \  / | __ _  __ _ _  ___  | |__   _ __  _   _ _ __ ___   | |   _| |_ _| |_
+// | |\/| |/ _` |/ _` | |/ __| |  __| | '_ \| | | | '_ ` _ \  | |  |_   _|_   _|
+// | |  | | (_| | (_| | | (__  | |____| | | | |_| | | | | | | | |____|_|   |_|
+// |_|  |_|\__,_|\__, |_|\___| |______|_| |_|\__,_|_| |_| |_|  \_____|
+//                __/ | https://github.com/Neargye/magic_enum
+//               |___/  version 0.9.3
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2019 - 2023 Daniil Goncharov <neargye@gmail.com>.
+//
+// Permission is hereby  granted, free of charge, to any  person obtaining a copy
+// of this software and associated  documentation files (the "Software"), to deal
+// in the Software  without restriction, including without  limitation the rights
+// to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+// copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+// IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+// FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+// AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+// LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef NEARGYE_MAGIC_ENUM_UTILITY_HPP
+#define NEARGYE_MAGIC_ENUM_UTILITY_HPP
+
+#include "magic_enum.hpp"
+
+namespace magic_enum {
+
+namespace detail {
+
+template <typename E, enum_subtype S, typename F, std::size_t... I>
+constexpr auto for_each(F&& f, std::index_sequence<I...>) {
+  constexpr bool has_void_return = (std::is_void_v<std::invoke_result_t<F, enum_constant<values_v<E, S>[I]>>> || ...);
+  constexpr bool all_same_return = (std::is_same_v<std::invoke_result_t<F, enum_constant<values_v<E, S>[0]>>, std::invoke_result_t<F, enum_constant<values_v<E, S>[I]>>> && ...);
+
+  if constexpr (has_void_return) {
+    (f(enum_constant<values_v<E, S>[I]>{}), ...);
+  } else if constexpr (all_same_return) {
+    return std::array{f(enum_constant<values_v<E, S>[I]>{})...};
+  } else {
+    return std::tuple{f(enum_constant<values_v<E, S>[I]>{})...};
+  }
+}
+
+template <typename E, enum_subtype S, typename F,std::size_t... I>
+constexpr bool all_invocable(std::index_sequence<I...>) {
+  if constexpr (count_v<E, S> == 0) {
+    return false;
+  } else {
+    return (std::is_invocable_v<F, enum_constant<values_v<E, S>[I]>> && ...);
+  }
+}
+
+} // namespace magic_enum::detail
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>, typename F, detail::enable_if_t<E, int> = 0>
+constexpr auto enum_for_each(F&& f) {
+  using D = std::decay_t<E>;
+  static_assert(std::is_enum_v<D>, "magic_enum::enum_for_each requires enum type.");
+  constexpr auto sep = std::make_index_sequence<detail::count_v<D, S>>{};
+
+  if constexpr (detail::all_invocable<D, S, F>(sep)) {
+    return detail::for_each<D, S>(std::forward<F>(f), sep);
+  } else {
+    static_assert(detail::always_false_v<D>, "magic_enum::enum_for_each requires invocable of all enum value.");
+  }
+}
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_next_value(E value, std::ptrdiff_t n = 1) noexcept -> detail::enable_if_t<E, optional<std::decay_t<E>>> {
+  using D = std::decay_t<E>;
+  constexpr std::ptrdiff_t count = detail::count_v<D, S>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    const std::ptrdiff_t index = (static_cast<std::ptrdiff_t>(*i) + n);
+    if (index >= 0 && index < count) {
+      return enum_value<D, S>(index);
+    }
+  }
+  return {};
+}
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_next_value_circular(E value, std::ptrdiff_t n = 1) noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  constexpr std::ptrdiff_t count = detail::count_v<D, S>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    const std::ptrdiff_t index = ((((static_cast<std::ptrdiff_t>(*i) + n) % count) + count) % count);
+    if (index >= 0 && index < count) {
+      return enum_value<D, S>(index);
+    }
+  }
+  return MAGIC_ENUM_ASSERT(false), value;
+}
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_prev_value(E value, std::ptrdiff_t n = 1) noexcept -> detail::enable_if_t<E, optional<std::decay_t<E>>> {
+  using D = std::decay_t<E>;
+  constexpr std::ptrdiff_t count = detail::count_v<D, S>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    const std::ptrdiff_t index = (static_cast<std::ptrdiff_t>(*i) - n);
+    if (index >= 0 && index < count) {
+      return enum_value<D, S>(index);
+    }
+  }
+  return {};
+}
+
+template <typename E, detail::enum_subtype S = detail::subtype_v<E>>
+[[nodiscard]] constexpr auto enum_prev_value_circular(E value, std::ptrdiff_t n = 1) noexcept -> detail::enable_if_t<E, std::decay_t<E>> {
+  using D = std::decay_t<E>;
+  constexpr std::ptrdiff_t count = detail::count_v<D, S>;
+
+  if (const auto i = enum_index<D, S>(value)) {
+    const std::ptrdiff_t index = ((((static_cast<std::ptrdiff_t>(*i) - n) % count) + count) % count);
+    if (index >= 0 && index < count) {
+      return enum_value<D, S>(index);
+    }
+  }
+  return MAGIC_ENUM_ASSERT(false), value;
+}
+
+} // namespace magic_enum
+
+#endif // NEARGYE_MAGIC_ENUM_UTILITY_HPP

--- a/third_party/refl-cpp/refl.hpp
+++ b/third_party/refl-cpp/refl.hpp
@@ -1,0 +1,4788 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Veselin Karaganev (@veselink1) and Contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef REFL_INCLUDE_HPP
+#define REFL_INCLUDE_HPP
+
+#include <stddef.h> // size_t
+#include <cstring>
+#include <array>
+#include <utility> // std::move, std::forward
+#include <optional>
+#include <tuple>
+#include <type_traits>
+#include <ostream>
+#include <sstream>
+#include <iomanip> // std::quoted
+#include <memory>
+#include <complex>
+
+#ifdef _MSC_VER
+// Disable VS warning for "Not enough arguments for macro"
+// (emitted when a REFL_ macro is not provided any attributes)
+#pragma warning( disable : 4003 )
+#endif
+
+#if defined(__clang__)
+  #if __has_feature(cxx_rtti)
+    #define REFL_RTTI_ENABLED
+  #endif
+#elif defined(__GNUG__)
+  #if defined(__GXX_RTTI)
+    #define REFL_RTTI_ENABLED
+  #endif
+#elif defined(_MSC_VER)
+  #if defined(_CPPRTTI)
+    #define REFL_RTTI_ENABLED
+  #endif
+#endif
+
+/**
+ * @brief The top-level refl-cpp namespace
+ * It contains a few core refl-cpp namespaces and directly exposes core classes and functions.
+ * <ul>
+ * <li>util - utility functions (for_each, map_to_tuple, etc.)</li>
+ * <li>trait - type-traits and other operations on types (is_function_v, map_t, etc.)</li>
+ * <li>runtime - utility functions and classes that always have a runtime overhead (proxy<T>, debug_str, etc.)</li>
+ * <li>member - contains the empty classes member and function (used for tagging)</li>
+ * <li>descriptor - contains the non-specialized member types (type|field_descriptor<T, N>, and operations on them (get_property, get_display_name, etc.))</li>
+ * </ul>
+ *
+ * using util::type_list; <br>
+ * using descriptor::type_descriptor; <br>
+ * using descriptor::field_descriptor; <br>
+ * using descriptor::function_descriptor; <br>
+ * using util::const_string; <br>
+ * using util::make_const_string; <br>
+ */
+namespace refl
+{
+    /**
+     * @brief Contains utility types and functions for working with those types.
+     */
+    namespace util
+    {
+        /**
+         * Converts a compile-time available const char* value to a const_string<N>.
+         * The argument must be a *core constant expression* and be null-terminated.
+         *
+         * @see refl::util::const_string
+         */
+#define REFL_MAKE_CONST_STRING(CString) \
+    (::refl::util::detail::copy_from_unsized<::refl::util::detail::strlen(CString)>(CString))
+
+        /**
+         * Represents a compile-time string. Used in refl-cpp
+         * for representing names of reflected types and members.
+         * Supports constexpr concatenation and substring,
+         * and is explicitly-convertible to const char* and std::string.
+         * REFL_MAKE_CONST_STRING can be used to create an instance from a literal string.
+         *
+         * @typeparam <N> The length of the string excluding the terminating '\0' character.
+         * @see refl::descriptor::base_member_descriptor::name
+         */
+        template <size_t N>
+        struct const_string
+        {
+            /** The largest positive value size_t can hold. */
+            static constexpr size_t npos = static_cast<size_t>(-1);
+
+            /** The length of the string excluding the terminating '\0' character. */
+            static constexpr size_t size = N;
+
+            /**
+             * The statically-sized character buffer used for storing the string.
+             */
+            char data[N + 1];
+
+            /**
+             * Creates an empty const_string.
+             */
+            constexpr const_string() noexcept
+                : data{}
+            {
+            }
+
+            /**
+             * Creates a copy of a const_string.
+             */
+            constexpr const_string(const const_string<N>& other) noexcept
+                : const_string(other, std::make_index_sequence<N>())
+            {
+            }
+
+            /**
+             * Creates a const_string by copying the contents of data.
+             */
+            constexpr const_string(const char(&data)[N + 1]) noexcept
+                : const_string(data, std::make_index_sequence<N>())
+            {
+            }
+
+            /**
+             * Explicitly converts to const char*.
+             */
+            explicit constexpr operator const char*() const noexcept
+            {
+                return data;
+            }
+
+            /**
+             * Explicitly converts to std::string.
+             */
+            explicit operator std::string() const noexcept
+            {
+                return data;
+            }
+
+            /**
+             * Returns a pointer to the contained zero-terminated string.
+             */
+            constexpr const char* c_str() const noexcept
+            {
+                return data;
+            }
+
+            /**
+             * Returns the contained string as an std::string.
+             */
+            std::string str() const noexcept
+            {
+                return data;
+            }
+
+            /**
+             * A constexpr version of std::string::substr.
+             *
+             * \code{.cpp}
+             * make_const_string("Hello, World!").template substr<0, 4>() -> (const_string<4>) "Hell"
+             * make_const_string("Hello, World!").template substr<1, 4>() -> (const_string<3>) "ell"
+             * \endcode
+             */
+            template <size_t Pos, size_t Count = npos>
+            constexpr auto substr() const noexcept
+            {
+                static_assert(Pos <= N);
+                constexpr size_t NewSize = (std::min)(Count, N - Pos);
+
+                char buf[NewSize + 1]{};
+                for (size_t i = 0; i < NewSize; i++) {
+                    buf[i] = data[Pos + i];
+                }
+
+                return const_string<NewSize>(buf);
+            }
+
+            /**
+             * Searches the string for the first occurrence of the character and returns its position.
+             *
+             * \code{.cpp}
+             * make_const_string("Hello, World!").find('e') -> 1
+             * make_const_string("Hello, World!").find('z') -> static_cast<size_t>(-1)
+             * \endcode
+             */
+            constexpr auto find(char ch, size_t pos = 0) const noexcept
+            {
+                for (size_t i = pos; i < N; i++) {
+                    if (data[i] == ch) {
+                        return i;
+                    }
+                }
+                return npos;
+            }
+
+            /**
+             * Searches the string for the last occurrence of the character and returns its position.
+             *
+             * \code{.cpp}
+             * make_const_string("Hello, World!").rfind('o') -> 8
+             * make_const_string("Hello, World!").rfind('z') -> static_cast<size_t>(-1)
+             * \endcode
+             */
+            constexpr auto rfind(char ch, size_t pos = npos) const noexcept
+            {
+                for (size_t i = (pos == npos ? N - 1 : pos); i + 1 > 0; i--) {
+                    if (data[i] == ch) {
+                        return i;
+                    }
+                }
+                return npos;
+            }
+
+        private:
+
+            /**
+             * Creates a copy of a const_string.
+             */
+            template <size_t... Idx>
+            constexpr const_string(const const_string<N>& other, std::index_sequence<Idx...>) noexcept
+                : data{ other.data[Idx]... }
+            {
+            }
+
+            /**
+             * Creates a const_string by copying the contents of data.
+             */
+            template <size_t... Idx>
+            constexpr const_string(const char(&data)[sizeof...(Idx) + 1], std::index_sequence<Idx...>) noexcept
+                : data{ data[Idx]... }
+            {
+            }
+
+        };
+
+        /**
+         * Creates an empty instance of const_string<N>
+         *
+         * @see refl::util::const_string
+         */
+        constexpr const_string<0> make_const_string() noexcept
+        {
+            return {};
+        }
+
+        /**
+         * Creates an instance of const_string<N>
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N>
+        constexpr const_string<N - 1> make_const_string(const char(&str)[N]) noexcept
+        {
+            return str;
+        }
+
+        /**
+         * Creates an instance of const_string<N>
+         *
+         * @see refl::util::const_string
+         */
+        constexpr const_string<1> make_const_string(char ch) noexcept
+        {
+            const char str[2]{ ch, '\0' };
+            return make_const_string(str);
+        }
+
+        /**
+         * Concatenates two const_strings together.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr const_string<N + M> operator+(const const_string<N>& a, const const_string<M>& b) noexcept
+        {
+            char data[N + M + 1] { };
+            for (size_t i = 0; i < N; i++)
+                data[i] = a.data[i];
+            for (size_t i = 0; i < M; i++)
+                data[N + i] = b.data[i];
+            return data;
+        }
+
+        /**
+         * Concatenates a const_string with a C-style string.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr const_string<N + M - 1> operator+(const const_string<N>& a, const char(&b)[M]) noexcept
+        {
+            return a + make_const_string(b);
+        }
+
+        /**
+         * Concatenates a C-style string with a const_string.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr const_string<N + M - 1> operator+(const char(&a)[N], const const_string<M>& b) noexcept
+        {
+            return make_const_string(a) + b;
+        }
+
+        /**
+         * Compares two const_strings for equality.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr bool operator==(const const_string<N>& a, const const_string<M>& b) noexcept
+        {
+            if constexpr (N != M) {
+                return false;
+            }
+            else {
+                for (size_t i = 0; i < M; i++) {
+                    if (a.data[i] != b.data[i]) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        /**
+         * Compares two const_strings for equality.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr bool operator!=(const const_string<N>& a, const const_string<M>& b) noexcept
+        {
+            return !(a == b);
+        }
+
+        /**
+         * Compares a const_string with a C-style string for equality.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr bool operator==(const const_string<N>& a, const char(&b)[M]) noexcept
+        {
+            return a == make_const_string(b);
+        }
+
+        /**
+         * Compares a const_string with a C-style string for equality.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr bool operator!=(const const_string<N>& a, const char(&b)[M]) noexcept
+        {
+            return a != make_const_string(b);
+        }
+
+        /**
+         * Compares a C-style string with a const_string for equality.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr bool operator==(const char(&a)[N], const const_string<M>& b) noexcept
+        {
+            return make_const_string(a) == b;
+        }
+
+        /**
+         * Compares a C-style string with a const_string for equality.
+         *
+         * @see refl::util::const_string
+         */
+        template <size_t N, size_t M>
+        constexpr bool operator!=(const char(&a)[N], const const_string<M>& b) noexcept
+        {
+            return make_const_string(a) != b;
+        }
+
+        template <size_t N>
+        constexpr std::ostream& operator<<(std::ostream& os, const const_string<N>& str) noexcept
+        {
+            return os << str.c_str();
+        }
+
+        namespace detail
+        {
+            constexpr size_t strlen(const char* const str)
+            {
+                return *str ? 1 + strlen(str + 1) : 0;
+            }
+
+            template <size_t N>
+            constexpr const_string<N> copy_from_unsized(const char* const str)
+            {
+                const_string<N> cstr;
+                for (size_t i = 0; i < N; i++) {
+                    cstr.data[i] = str[i];
+                }
+                return cstr;
+            }
+        } // namespace detail
+
+        /**
+         * Represents a compile-time list of types provided as variadic template parameters.
+         * type_list is an empty TrivialType. Instances of it can freely be created to communicate
+         * the list of represented types. type_lists support many standard operations that are
+         * implicitly available with ADL-lookup. type_list is used by refl-cpp mostly to represent
+         * the list of refl::field_descriptor, refl::function_descriptor specializations that
+         * allow the compile-time reflection of a type's members.
+         *
+         * @see refl::util::for_each
+         * @see refl::util::map_to_array
+         * @see refl::util::map_to_tuple
+         * @see refl::member_list
+         *
+         * # Examples
+         * ```
+         * for_each(type_list<int, float>(), [](auto) { ... });
+         * ```
+         */
+        template <typename... Ts>
+        struct type_list
+        {
+            /** The number of types in this type_list */
+            static constexpr intptr_t size = sizeof...(Ts);
+        };
+
+        template <typename T>
+        struct type_list<T>
+        {
+            typedef T type;
+            static constexpr intptr_t size = 1;
+        };
+
+        template <typename T>
+        using type_tag = type_list<T>;
+
+    } // namespace util
+
+    using util::const_string;
+    using util::make_const_string;
+    using util::type_list;
+    using util::type_tag;
+
+    /**
+     * The contents of the refl::detail::macro_exports namespace
+     * is implicitly available in the context of REFL_TYPE/FIELD/FUNC macros.
+     * It is used to export the refl::attr:: standard attributes.
+     */
+    namespace detail
+    {
+        namespace macro_exports
+        {
+        }
+    }
+
+} // namespace refl
+
+/**
+ * refl_impl is an internal namespace that should not be used by the users of refl-cpp.
+ */
+namespace refl_impl
+{
+    /**
+     * Contains the generated metadata types.
+     * (i.e. type_info__)
+     */
+    namespace metadata
+    {
+        // Import everyting from macro_exports here to make it visible in REFL_ macro context.
+        using namespace refl::detail::macro_exports;
+
+        /**
+         * The core reflection metadata type.
+         * type_info__ holds data for a type T.
+         *
+         * The non-specialized type_info__ type has a member typedef invalid_marker
+         * that can be used to detect it.
+         *
+         * Specializations of this type should provide all members of this
+         * generic definition, except invalid_marker.
+         *
+         * @typeparam <T> The reflected type.
+         */
+        template <typename T>
+        struct type_info__
+        {
+            /** Used for detecting this non-specialized type_info__ instance. */
+            struct invalid_marker{};
+
+            /**
+             * This is a placeholder definition of which no type instances should be created.
+             */
+            template <size_t, typename>
+            struct member;
+
+            /** The number of reflected members of the target type T. */
+            static constexpr size_t member_count{ 0 };
+
+            /** This is a placeholder definition which shold not be referenced by well-formed programs. */
+            static constexpr refl::const_string<0> name{ "" };
+
+            /** This is a placeholder definition which shold not be referenced by well-formed programs. */
+            static constexpr std::tuple<> attributes{ };
+        };
+
+        /**
+         * Specializes type_info__ so that a type's const-qualification is effectively discarded.
+         */
+        template <typename T>
+        struct type_info__<const T> : public type_info__<T> {};
+
+        /**
+         * Specializes type_info__ so that a type's volatile-qualification is effectively discarded.
+         */
+        template <typename T>
+        struct type_info__<volatile T> : public type_info__<T> {};
+
+        /**
+         * Specializes type_info__ so that a type's const-volatile-qualification is effectively discarded.
+         */
+        template <typename T>
+        struct type_info__<const volatile T> : public type_info__<T> {};
+
+    } // namespace metadata
+
+} // namespace refl_impl
+
+namespace refl
+{
+    namespace detail
+    {
+        template <typename T>
+        using type_info = refl_impl::metadata::type_info__<T>;
+
+        template <typename T, size_t N>
+        using member_info = typename type_info<T>::template member<N>;
+    } // namespace detail
+
+    /**
+     * @brief Contains tag types denoting the different types of reflectable members.
+     *
+     * This namespace contains a number of empty types that correspond to
+     * the different member types that refl-cpp supports reflection over.
+     */
+    namespace member
+    {
+        /**
+         * An empty type which is equivalent to refl::member_descriptor_base::member_type
+         * when the reflected member is a field.
+         *
+         * @see refl::descriptor::field_descriptor
+         */
+        struct field {};
+
+        /**
+         * An empty type which is equivalent to refl::member_descriptor_base::member_type
+         * when the reflected member is a function.
+         *
+         * @see refl::descriptor::function_descriptor
+         */
+        struct function {};
+    }
+
+    namespace descriptor
+    {
+        template <typename>
+        class type_descriptor;
+
+        template <typename, size_t>
+        class field_descriptor;
+
+        template <typename, size_t>
+        class function_descriptor;
+    } // namespace descriptor
+
+    /**
+     * @brief Provides type-level operations for refl-cpp related use-cases.
+     *
+     * The refl::trait namespace provides type-level operations useful
+     * for compile-time metaprogramming.
+     */
+    namespace trait
+    {/**
+         * Removes all reference and cv-qualifiers from T.
+         * Equivalent to std::remove_cvref which is not currently
+         * available on all C++17 compilers.
+         */
+        template <typename T>
+        struct remove_qualifiers
+        {
+            typedef std::remove_cv_t<std::remove_reference_t<T>> type;
+        };
+
+        /**
+         * Removes all reference and cv-qualifiers from T.
+         * Equivalent to std::remove_cvref_t which is not currently
+         * available on all C++17 compilers.
+         */
+        template <typename T>
+        using remove_qualifiers_t = typename remove_qualifiers<T>::type;
+
+        namespace detail
+        {
+            /** SFIANE support for detecting whether there is a type_info__ specialization for T. */
+            template <typename T>
+            decltype(typename refl::detail::type_info<T>::invalid_marker{}, std::false_type{}) is_reflectable_test(int);
+
+            /** SFIANE support for detecting whether there is a type_info__ specialization for T. */
+            template <typename T>
+            std::true_type is_reflectable_test(...);
+        } // namespace detail
+
+        /**
+         * Checks whether there is reflection metadata for the type T.
+         * Inherits from std::bool_constant<>
+         *
+         * @see REFL_TYPE
+         * @see REFL_AUTO
+         * @see refl::is_reflectable
+         */
+        template <typename T>
+        struct is_reflectable : decltype(detail::is_reflectable_test<T>(0))
+        {
+        };
+
+        /**
+         * Checks whether there is reflection metadata for the type T.
+         * Inherits from std::bool_constant<>
+         *
+         * @see refl::trait::is_reflectable
+         */
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_reflectable_v{ is_reflectable<T>::value };
+
+        namespace detail
+        {
+            /** SFIANE support for detecting whether the type T supports member .begin() and .end() operations. */
+            template <typename U>
+            [[maybe_unused]] static auto is_container_test(int) -> decltype(std::declval<U>().begin(), std::declval<U>().end(), std::true_type{});
+
+            /** SFIANE support for detecting whether the type T supports member .begin() and .end() operations. */
+            template <typename U>
+            [[maybe_unused]] static std::false_type is_container_test(...);
+        }
+
+        /**
+         * Checks whether objects of the type T support member .begin() and .end() operations.
+         */
+        template <typename T>
+        struct is_container : decltype(detail::is_container_test<T>(0))
+        {
+        };
+
+        /**
+         * Checks whether objects of the type T support member .begin() and .end() operations.
+         */
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_container_v{ is_container<T>::value };
+
+        namespace detail
+        {
+
+            template <size_t D, size_t N, typename... Ts>
+            struct get;
+
+            template <size_t D, size_t N>
+            struct get<D, N>
+            {
+                static_assert(N > 0, "Missing arguments list for get<N, Ts...>!");
+            };
+
+            template <size_t N, typename T, typename... Ts>
+            struct get<1, N, T, Ts...> : public get<
+                                             (N > 16 ? (N > 64 ? 64 : 16) : 1),
+                                             N - 1, Ts...>
+            {
+            };
+
+            template <typename T, typename... Ts>
+            struct get<1, 0, T, Ts...>
+            {
+                typedef T type;
+            };
+
+            template <typename T, typename... Ts>
+            struct get<16, 0, T, Ts...>
+            {
+                typedef T type;
+            };
+
+            template <typename T, typename... Ts>
+            struct get<64, 0, T, Ts...>
+            {
+                typedef T type;
+            };
+
+            template <
+                size_t N, typename T0, typename T1, typename T2, typename T3,
+                typename T4, typename T5, typename T6, typename T7, typename T8,
+                typename T9, typename T10, typename T11, typename T12,
+                typename T13, typename T14, typename T15, typename... Ts>
+            struct get<
+                16, N, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+                T13, T14, T15, Ts...> : get<1, N - 16, Ts...>
+            {
+            };
+
+            template <
+                size_t N, typename T0, typename T1, typename T2, typename T3,
+                typename T4, typename T5, typename T6, typename T7, typename T8,
+                typename T9, typename T10, typename T11, typename T12,
+                typename T13, typename T14, typename T15, typename T16,
+                typename T17, typename T18, typename T19, typename T20,
+                typename T21, typename T22, typename T23, typename T24,
+                typename T25, typename T26, typename T27, typename T28,
+                typename T29, typename T30, typename T31, typename T32,
+                typename T33, typename T34, typename T35, typename T36,
+                typename T37, typename T38, typename T39, typename T40,
+                typename T41, typename T42, typename T43, typename T44,
+                typename T45, typename T46, typename T47, typename T48,
+                typename T49, typename T50, typename T51, typename T52,
+                typename T53, typename T54, typename T55, typename T56,
+                typename T57, typename T58, typename T59, typename T60,
+                typename T61, typename T62, typename T63, typename... Ts>
+            struct get<
+                64, N, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12,
+                T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25,
+                T26, T27, T28, T29, T30, T31, T32, T33, T34, T35, T36, T37, T38,
+                T39, T40, T41, T42, T43, T44, T45, T46, T47, T48, T49, T50, T51,
+                T52, T53, T54, T55, T56, T57, T58, T59, T60, T61, T62, T63,
+                Ts...> : get<1, N - 64, Ts...>
+            {
+            };
+
+            template <size_t N, typename...>
+            struct skip;
+
+            template <size_t N, typename T, typename... Ts>
+            struct skip<N, T, Ts...> : skip<N - 1, Ts...>
+            {
+            };
+
+            template <typename T, typename... Ts>
+            struct skip<0, T, Ts...>
+            {
+                typedef type_list<T, Ts...> type;
+            };
+
+            template <>
+            struct skip<0>
+            {
+                typedef type_list<> type;
+            };
+        }
+
+        /// \private
+        template <size_t, typename>
+        struct get;
+
+        /**
+         * Provides a member typedef type which is the
+         * N-th type in the provided type_list.
+         *
+         * \code{.cpp}
+         * typename get<0, type_list<int, float>>::type -> int
+         * typename get<1, type_list<int, float>>::type -> float
+         * \endcode
+         */
+        template <size_t N, typename... Ts>
+        struct get<N, type_list<Ts...>> : detail::get<1, N, Ts...>
+        {
+        };
+
+        /**
+         * The N-th type in the provided type_list.
+         * @see get
+         */
+        template <size_t N, typename TypeList>
+        using get_t = typename get<N, TypeList>::type;
+
+        /// \private
+        template <size_t, typename>
+        struct skip;
+
+        /**
+         * Skips the first N types in the provided type_list.
+         * Provides a member typedef equivalent to the resuling type_list.
+         *
+         * \code{.cpp}
+         * typename skip<1, type_list<int, float, double>>::type -> type_list<float, double>
+         * typename skip<0, type_list<int, float, double>>::type -> type_list<int, float, double>
+         * \endcode
+         */
+        template <size_t N, typename... Ts>
+        struct skip<N, type_list<Ts...>> : detail::skip<N, Ts...>
+        {
+        };
+
+        /**
+         * Skips the first N types in the provided type_list.
+         * @see skip
+         */
+        template <size_t N, typename TypeList>
+        using skip_t = typename skip<N, TypeList>::type;
+
+        /// \private
+        template <typename>
+        struct as_type_list;
+
+        /**
+         * Provides a member typedef type which is a type_list with
+         * template type parameters equivalent to the type parameters of the provided
+         * type. The provided type must be a template instance.
+         *
+         * \code{.cpp}
+         * typename as_type_list<std::tuple<int, float>>::type -> type_list<int, float>
+         * \endcode
+         */
+        template <template <typename...> typename T, typename... Ts>
+        struct as_type_list<T<Ts...>>
+        {
+            typedef type_list<Ts...> type;
+        };
+
+        /// \private
+        template <typename T>
+        struct as_type_list : as_type_list<remove_qualifiers_t<T>>
+        {
+        };
+
+        /**
+         * A typedef for a type_list with
+         * template type parameters equivalent to the type parameters of the provided
+         * type. The provided type must be a template instance.
+         * @see as_type_list
+         */
+        template <typename T>
+        using as_type_list_t = typename as_type_list<T>::type;
+
+        /// \private
+        template <typename>
+        struct as_tuple;
+
+        /**
+         * Provides a member typedef which is a std::tuple specialization with
+         * template type parameters equivalent to the type parameters of the provided
+         * type. The provided type must be a template specialization.
+         *
+         * \code{.cpp}
+         * typename as_tuple<type_list<int, float>>::type -> std::tuple<int, float>
+         * \endcode
+         */
+        template <template <typename...> typename T, typename... Ts>
+        struct as_tuple<T<Ts...>>
+        {
+            typedef std::tuple<Ts...> type;
+        };
+
+        /// \private
+        template <typename T>
+        struct as_tuple : as_tuple<remove_qualifiers_t<T>>
+        {
+        };
+
+        /**
+         * A typedef for a std::tuple specialization with
+         * template type parameters equivalent to the type parameters of the provided
+         * type. The provided type must be a template specialization.
+         * @see as_tuple
+         */
+        template <typename T>
+        using as_tuple_t = typename as_tuple<T>::type;
+
+        /**
+         * Accesses first type in the list.
+         */
+        template <typename TypeList>
+        using first = get<0, TypeList>;
+
+        /**
+         * Accesses last type in the list.
+         * @see last
+         */
+        template <typename TypeList>
+        using first_t = typename first<TypeList>::type;
+
+        /**
+         * Accesses last type in the list.
+         */
+        template <typename TypeList>
+        using last = get<TypeList::size - 1, TypeList>;
+
+        /**
+         * Accesses last type in the list.
+         * @see last
+         */
+        template <typename TypeList>
+        using last_t = typename last<TypeList>::type;
+
+        /**
+         * Returns all but the first element of the list.
+         */
+        template <typename TypeList>
+        using tail = skip<1, TypeList>;
+
+        /**
+         * Returns all but the first element of the list.
+         * @see tail
+         */
+        template <typename TypeList>
+        using tail_t = typename tail<TypeList>::type;
+
+        namespace detail
+        {
+            template <typename, size_t, typename>
+            struct take;
+
+            template <typename... Us>
+            struct take<type_list<Us...>, 0, type_list<>>
+            {
+                using type = type_list<Us...>;
+            };
+
+            template <typename... Us, typename T, typename... Ts>
+            struct take<type_list<Us...>, 0, type_list<T, Ts...>>
+            {
+                using type = type_list<Us...>;
+            };
+
+            template <size_t N, typename... Us, typename T, typename... Ts>
+            struct take<type_list<Us...>, N, type_list<T, Ts...>>
+            {
+                using type = typename take<type_list<Us..., T>, N - 1, type_list<Ts...>>::type;
+            };
+        }
+
+        /**
+         * Returns the first N elements of the list.
+         */
+        template <size_t N, typename TypeList>
+        using take = detail::take<type_list<>, N, TypeList>;
+
+        /**
+         * Returns the first N elements of the list.
+         */
+        template <size_t N, typename TypeList>
+        using take_t = typename take<N, TypeList>::type;
+
+        /**
+         * Returns all but the last element of the list.
+         */
+        template <typename TypeList>
+        using init = take<TypeList::size - 1, TypeList>;
+
+        /**
+         * Returns all but the last element of the list.
+         * @see tail
+         */
+        template <typename TypeList>
+        using init_t = typename init<TypeList>::type;
+
+        namespace detail
+        {
+            template <typename, typename>
+            struct reverse_impl;
+
+            template <typename... Us>
+            struct reverse_impl<type_list<Us...>, type_list<>>
+            {
+                using type = type_list<Us...>;
+            };
+
+            template <typename... Us, typename T, typename... Ts>
+            struct reverse_impl<type_list<Us...>, type_list<T, Ts...>>
+            {
+                using type = typename reverse_impl<type_list<T, Us...>, type_list<Ts...>>::type;
+            };
+        } // namespace detail
+
+        /**
+         * Reverses a list of types.
+         *
+         * \code{.cpp}
+         * typename reverse<type_list<int, float>>::type -> type_list<float, int>
+         * \endcode
+         */
+        template <typename TypeList>
+        struct reverse : detail::reverse_impl<type_list<>, TypeList>
+        {
+        };
+
+        /**
+         * Reverses a list of types.
+         * @see reverse
+         */
+        template <typename TypeList>
+        using reverse_t = typename reverse<TypeList>::type;
+
+        /**
+         * Concatenates N lists together.
+         *
+         * \code{.cpp}
+         * typename concat<type_list<int, float>, type_list<double>, type_list<long>>::type -> type_list<int, float, double, long>
+         * \endcode
+         */
+        template <typename...>
+        struct concat;
+
+        /// \private
+        template <>
+        struct concat<>
+        {
+            using type = type_list<>;
+        };
+
+        /// \private
+        template <typename... Ts>
+        struct concat<type_list<Ts...>>
+        {
+            using type = type_list<Ts...>;
+        };
+
+        /**
+         * Concatenates two lists together.
+         */
+        /// \private
+        template <typename... Ts, typename... Us>
+        struct concat<type_list<Ts...>, type_list<Us...>>
+        {
+            using type = type_list<Ts..., Us...>;
+        };
+
+        /**
+         * Concatenates N lists together.
+         */
+        /// \private
+        template <typename TypeList1, typename TypeList2, typename... TypeLists>
+        struct concat<TypeList1, TypeList2, TypeLists...> : concat<typename concat<TypeList1, TypeList2>::type, TypeLists...>
+        {
+        };
+
+        /**
+         * Concatenates two lists together.
+         * @see concat
+         */
+        template <typename... Ts>
+        using concat_t = typename concat<Ts...>::type;
+
+        /**
+         * Appends a type to the list.
+         */
+        template <typename T, typename TypeList>
+        struct append : concat<TypeList, type_list<T>>
+        {
+        };
+
+        /**
+         * Appends a type to the list.
+         * @see prepend
+         */
+        template <typename T, typename TypeList>
+        using append_t = typename append<T, TypeList>::type;
+
+        template <typename, typename>
+        struct prepend;
+
+        /**
+         * Prepends a type to the list.
+         */
+        template <typename T, typename TypeList>
+        struct prepend : concat<type_list<T>, TypeList>
+        {
+        };
+
+        /**
+         * Prepends a type to the list.
+         * @see prepend
+         */
+        template <typename T, typename TypeList>
+        using prepend_t = typename prepend<T, TypeList>::type;
+
+        namespace detail
+        {
+            template <template<typename> typename, typename...>
+            struct filter_impl;
+
+            template <template<typename> typename Predicate>
+            struct filter_impl<Predicate>
+            {
+                using type = type_list<>;
+            };
+
+            template <template<typename> typename Predicate, typename Head, typename... Tail>
+            struct filter_impl<Predicate, Head, Tail...>
+            {
+                using type = std::conditional_t<Predicate<Head>::value,
+                    prepend_t<Head, typename filter_impl<Predicate, Tail...>::type>,
+                    typename filter_impl<Predicate, Tail...>::type
+                >;
+            };
+
+            template <template<typename> typename, typename...>
+            struct map_impl;
+
+            template <template<typename> typename Mapper>
+            struct map_impl<Mapper>
+            {
+                using type = type_list<>;
+            };
+
+            template <template<typename> typename Mapper, typename Head, typename ...Tail>
+            struct map_impl<Mapper, Head, Tail...>
+            {
+                using type = typename prepend<typename Mapper<Head>::type,
+                    typename map_impl<Mapper, Tail...>::type>::type;
+            };
+        }
+
+        /// \private
+        template <template<typename> typename, typename>
+        struct filter;
+
+        /**
+         * Filters a type_list according to a predicate template.
+         *
+         * \code{.cpp}
+         * typename filter<std::is_reference, type_list<int, float&, double>>::type -> type_list<float&>
+         * \endcode
+         */
+        template <template<typename> typename Predicate, typename... Ts>
+        struct filter<Predicate, type_list<Ts...>>
+        {
+            using type = typename detail::filter_impl<Predicate, Ts...>::type;
+        };
+
+        /**
+         * Filters a type_list according to a predicate template
+         * with a static boolean member named "value" (e.g. std::is_trivial)
+         * @see filter
+         */
+        template <template<typename> typename Predicate, typename TypeList>
+        using filter_t = typename filter<Predicate, TypeList>::type;
+
+        /// \private
+        template <template<typename> typename, typename>
+        struct map;
+
+        /**
+         * Transforms a type_list according to a predicate template.
+         *
+         * \code{.cpp}
+         * typename map<std::add_reference, type_list<int, float&, double>>::type -> type_list<int&, float&, double&>
+         * \endcode
+         */
+        template <template<typename> typename Mapper, typename... Ts>
+        struct map<Mapper, type_list<Ts...>>
+        {
+            using type = typename detail::map_impl<Mapper, Ts...>::type;
+        };
+
+        /**
+         * Transforms a type_list according to a predicate template
+         * with a typedef named "type" (e.g. std::remove_reference)
+         * @see map
+         */
+        template <template<typename> typename Mapper, typename... Ts>
+        using map_t = typename map<Mapper, Ts...>::type;
+
+        namespace detail
+        {
+            template <typename T>
+            struct is_instance : public std::false_type {};
+
+            template <template<typename...> typename T, typename... Args>
+            struct is_instance<T<Args...>> : public std::true_type {};
+        } // namespace detail
+
+        /**
+         * Detects whether T is a template specialization.
+         * Inherits from std::bool_constant<>.
+         *
+         * \code{.cpp}
+         * is_instance<type_list<>>::value -> true
+         * is_instance<int>::value -> false
+         * \endcode
+         */
+        template <typename T>
+        struct is_instance : detail::is_instance<T>
+        {
+        };
+
+        /**
+         * Detects whether T is a template specialization.
+         * @see is_instance
+         */
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_instance_v{ is_instance<T>::value };
+
+        namespace detail
+        {
+            /**
+             * Checks if T == U<Args...>.
+             * If U<Args...> != T or is invalid the result is false.
+             */
+            template <typename T, template<typename...> typename U, typename... Args>
+            struct is_same_template
+            {
+                template <template<typename...> typename V, typename = V<Args...>>
+                static auto test(int) -> std::is_same<V<Args...>, T>;
+
+                template <template<typename...> typename V>
+                static std::false_type test(...);
+
+                static constexpr bool value{decltype(test<U>(0))::value};
+            };
+
+            template <template<typename...> typename T, typename U>
+            struct is_instance_of : public std::false_type {};
+
+            template <template<typename...> typename T, template<typename...> typename U, typename... Args>
+            struct is_instance_of<T, U<Args...>> : public is_same_template<U<Args...>, T, Args...>
+            {
+            };
+        }
+
+        /**
+         * Detects whther the type U is a template specialization of T.
+         * (e.g. is_instance_of<std::vector<>, std::vector<int>>)
+         * Inherits from std::bool_constant<>.
+         *
+         * \code{.cpp}
+         * is_instance_of<type_list, type_list<int>>::value -> true
+         * is_instance_of<type_list, std::tuple<int>>::value -> false
+         * \endcode
+         */
+        template <template<typename...>typename T, typename U>
+        struct is_instance_of : detail::is_instance_of<T, std::remove_cv_t<U>>
+        {
+        };
+
+        /**
+         * Detects whther the type U is a template specialization of T.
+         * @see is_instance_of_v
+         */
+        template <template<typename...>typename T, typename U>
+        [[maybe_unused]] static constexpr bool is_instance_of_v{ is_instance_of<T, U>::value };
+
+        /// \private
+        template <typename, typename>
+        struct contains;
+
+        /**
+         * Checks whether T is contained in the list of types.
+         * Inherits from std::bool_constant<>.
+         *
+         * \code{.cpp}
+         * contains<int, type_list<int, float>>::value -> true
+         * contains<double, type_list<int, float>>::value -> false
+         * \endcode
+         */
+        template <typename T, typename... Ts>
+        struct contains<T, type_list<Ts...>> : std::disjunction<std::is_same<std::remove_cv_t<T>, std::remove_cv_t<Ts>>...>
+        {
+        };
+
+        /**
+         * Checks whether T is contained in the list of types.
+         * @see contains
+         */
+        template <typename T, typename TypeList>
+        [[maybe_unused]] static constexpr bool contains_v = contains<T, TypeList>::value;
+
+        /// \private
+        template <template<typename...> typename, typename>
+        struct contains_instance;
+
+        /**
+         * Checks whether an instance of the template T is contained in the list of types.
+         * Inherits from std::bool_constant<>.
+         *
+         * \code{.cpp}
+         * contains_instance<std::tuple, type_list<int, float, std::tuple<short, double>>>::value -> true
+         * contains_instance<std::vector, type_list<int, float, std::tuple<short, double>>>::value -> false
+         * \endcode
+         */
+        template <template<typename...> typename T, typename... Ts>
+        struct contains_instance<T, type_list<Ts...>> : std::disjunction<trait::is_instance_of<T, std::remove_cv_t<Ts>>...>
+        {
+        };
+
+        /**
+         * Checks whether an instance of the template T is contained in the list of types.
+         * @see contains_instance
+         */
+        template <template<typename...> typename T, typename TypeList>
+        [[maybe_unused]] static constexpr bool contains_instance_v = contains_instance<T, TypeList>::value;
+
+        /// \private
+        template <typename, typename>
+        struct contains_base;
+
+        /**
+         * Checks whether a type deriving from T is contained in the list of types.
+         * Inherits from std::bool_constant<>.
+         *
+         * \code{.cpp}
+         * struct Base {};
+         * struct Derived : Base {};
+         * contains_base<Base, type_list<int, float, Derived>>::value -> true
+         * contains_base<Base, type_list<int, float, Base>>::value -> true
+         * contains_base<int, type_list<int, float, Derived>>::value -> false
+         * \endcode
+         */
+        template <typename T, typename... Ts>
+        struct contains_base<T, type_list<Ts...>> : std::disjunction<std::is_base_of<std::remove_cv_t<T>, std::remove_cv_t<Ts>>...>
+        {
+        };
+
+        /**
+         * Checks whether a type deriving from T is contained in the list of types.
+         * @see contains_base
+         */
+        template <typename T, typename TypeList>
+        [[maybe_unused]] static constexpr bool contains_base_v = contains_base<T, TypeList>::value;
+
+        namespace detail
+        {
+            template <typename T, ptrdiff_t N, typename... Ts>
+            constexpr ptrdiff_t index_of() noexcept
+            {
+                if constexpr (sizeof...(Ts) <= N) return -1;
+                else if constexpr (std::is_same_v<T, trait::get_t<N, type_list<Ts...>>>) return N;
+                else return index_of<T, N + 1, Ts...>();
+            }
+
+            template <typename T, ptrdiff_t N, typename... Ts>
+            constexpr ptrdiff_t index_of_base() noexcept
+            {
+                if constexpr (sizeof...(Ts) <= N) return -1;
+                else if constexpr (std::is_base_of_v<T, trait::get_t<N, type_list<Ts...>>>) return N;
+                else return index_of_base<T, N + 1, Ts...>();
+            }
+
+            template <template<typename...> typename T, ptrdiff_t N, typename... Ts>
+            constexpr ptrdiff_t index_of_instance() noexcept
+            {
+                if constexpr (sizeof...(Ts) <= N) return -1;
+                else if constexpr (is_instance_of_v<T, trait::get_t<N, type_list<Ts...>>>) return N;
+                else return index_of_instance<T, N + 1, Ts...>();
+            }
+
+            // This variable template was introduced to fix the build on VS2017, which
+            // chokes when invoking index_of_instance() directly from struct index_of_instance.
+            template <template<typename...> typename T, ptrdiff_t N, typename... Ts>
+            static constexpr ptrdiff_t index_of_instance_v = index_of_instance<T, N, Ts...>();
+        } // namespace detail
+
+        /// \private
+        template <typename, typename>
+        struct index_of;
+
+        /**
+         * The index of the type in the type list, -1 if it doesn't exist.
+         * @see contains
+         */
+        template <typename T, typename... Ts>
+        struct index_of<T, type_list<Ts...>> : std::integral_constant<ptrdiff_t, detail::index_of<T, 0, Ts...>()>
+        {
+        };
+
+        /**
+         * The index of the type in the type list, -1 if it doesn't exist.
+         * @see index_of
+         */
+        template <typename T, typename TypeList>
+        static constexpr ptrdiff_t index_of_v = index_of<T, TypeList>::value;
+
+        /// \private
+        template <typename, typename>
+        struct index_of_base;
+
+        /**
+         * The index of the type in the type list that is derived from T, -1 if it doesn't exist.
+         * @see contains_base
+         */
+        template <typename T, typename... Ts>
+        struct index_of_base<T, type_list<Ts...>> : std::integral_constant<ptrdiff_t, detail::index_of_base<T, 0, Ts...>()>
+        {
+        };
+
+        /**
+         * The index of the type in the type list that is derived from T, -1 if it doesn't exist.
+         * @see index_of_base
+         */
+        template <typename T, typename TypeList>
+        static constexpr ptrdiff_t index_of_base_v = index_of_base<T, TypeList>::value;
+
+        /// \private
+        template <template<typename...> typename, typename>
+        struct index_of_instance;
+
+        /**
+         * The index of the type in the type list that is a template instance of T, -1 if it doesn't exist.
+         * @see contains_instance
+         */
+        template <template<typename...> typename T, typename... Ts>
+        struct index_of_instance<T, type_list<Ts...>> : std::integral_constant<ptrdiff_t, detail::index_of_instance_v<T, 0, Ts...>>
+        {
+        };
+
+        /**
+         * The index of the type in the type list that is a template instance of T, -1 if it doesn't exist.
+         * @see index_of_instance
+         */
+        template <template<typename...> typename T, typename TypeList>
+        static constexpr ptrdiff_t index_of_instance_v = index_of_instance<T, TypeList>::value;
+
+        namespace detail
+        {
+            template <typename, typename>
+            struct unique_impl;
+
+            template <typename UniqueList>
+            struct unique_impl<UniqueList, type_list<>>
+            {
+                using type = UniqueList;
+            };
+
+            template <typename UniqueList, typename T, typename... Ts>
+            struct unique_impl<UniqueList, type_list<T, Ts...>> :
+                std::conditional_t<contains_v<T, UniqueList>,
+                    unique_impl<UniqueList, type_list<Ts...>>,
+                    unique_impl<append_t<T, UniqueList>, type_list<Ts...>>>
+            {
+            };
+        } // namespace detail
+
+        /**
+         * Creates a new list containing the repeating elements in the source list only once.
+         *
+         * \code{.cpp}
+         * typename unique<type_list<int, float, int>>::type -> type_list<int, float>
+         * \endcode
+         */
+        template <typename T>
+        struct unique : detail::unique_impl<type_list<>, T>
+        {
+        };
+
+        /**
+         * Creates a new list containing the repeating elements in the source list only once.
+         */
+        template <typename T>
+        using unique_t = typename unique<T>::type;
+
+    } // namespace trait
+
+    namespace util
+    {
+        /**
+         * Ignores all parameters. Can take an optional template parameter
+         * specifying the return type of ignore. The return object is iniailized by {}.
+         */
+        template <typename T = int, typename... Ts>
+        constexpr int ignore(Ts&&...) noexcept
+        {
+            return {};
+        }
+
+        /**
+         * Returns the input paratemeter as-is. Useful for expanding variadic
+         * template lists when only one arguments is known to be present.
+         */
+        template <typename T>
+        constexpr decltype(auto) identity(T&& t) noexcept
+        {
+            return std::forward<T>(t);
+        }
+
+        /**
+         * Adds const to the input reference.
+         */
+        template <typename T>
+        constexpr const T& make_const(const T& value) noexcept
+        {
+            return value;
+        }
+
+        /**
+         * Adds const to the input reference.
+         */
+        template <typename T>
+        constexpr const T& make_const(T& value) noexcept
+        {
+            return value;
+        }
+
+        /**
+        * Creates an array of type 'T' from the provided tuple.
+        * The common type T needs to be specified, in order to prevent any
+        * errors when using the overload taking an empty std::tuple (as there is no common type then).
+        */
+        template <typename T, typename... Ts>
+        constexpr std::array<T, sizeof...(Ts)> to_array(const std::tuple<Ts...>& tuple) noexcept
+        {
+            return std::apply([](auto&& ... args) -> std::array<T, sizeof...(Ts)> { return { std::forward<decltype(args)>(args)... }; }, tuple);
+        }
+
+        /**
+         * Creates an empty array of type 'T.
+         */
+        /// \private
+        template <typename T>
+        constexpr std::array<T, 0> to_array(const std::tuple<>&) noexcept
+        {
+            return {};
+        }
+
+        namespace detail
+        {
+            template <typename T, size_t... Idx>
+            constexpr auto to_tuple([[maybe_unused]] const std::array<T, sizeof...(Idx)>& array, std::index_sequence<Idx...>) noexcept
+            {
+                if constexpr (sizeof...(Idx) == 0) return std::tuple<>{};
+                else return std::make_tuple(std::get<Idx>(array)...);
+            }
+        }
+
+        /**
+         * Creates a tuple from the provided array.
+         */
+        template <typename T, size_t N>
+        constexpr auto to_tuple(const std::array<T, N>& array) noexcept
+        {
+            return detail::to_tuple<T>(array, std::make_index_sequence<N>{});
+        }
+
+        /**
+         * Creates a matching std::tuple from a type_list.
+         * Types in the type_list must be Trivial.
+         */
+        template <typename... Ts>
+        constexpr std::tuple<Ts...> as_tuple(type_list<Ts...>) noexcept
+        {
+            static_assert((... && std::is_trivial_v<Ts>), "Non-trivial types in type_list as not allowed!");
+            return {};
+        }
+
+        /**
+         * Creates a matching type_list from a std::tuple.
+         */
+        template <typename... Ts>
+        constexpr type_list<Ts...> as_type_list(const std::tuple<Ts...>&) noexcept
+        {
+            return {};
+        }
+
+        namespace detail
+        {
+            template <typename F, typename T>
+            constexpr auto invoke_optional_index(F&& f, T&& t, size_t idx, int) -> decltype(f(std::forward<T>(t), idx))
+            {
+                return f(std::forward<T>(t), idx);
+            }
+
+            template <typename F, typename T>
+            constexpr auto invoke_optional_index(F&& f, T&& t, size_t, ...) -> decltype(f(std::forward<T>(t)))
+            {
+                return f(std::forward<T>(t));
+            }
+
+            template <typename F, typename... Carry>
+            constexpr auto eval_in_order_to_tuple(type_list<>, std::index_sequence<>, F&&, Carry&&... carry)
+            {
+                if constexpr (sizeof...(Carry) == 0) return std::tuple<>{};
+                else return std::make_tuple(std::forward<Carry>(carry)...);
+            }
+
+            // This workaround is needed since C++ does not specify
+            // the order in which function arguments are evaluated and this leads
+            // to incorrect order of evaluation (noticeable when using indexes).
+            // Otherwise we could simply do std::make_tuple(f(Ts{}, Idx)...).
+            template <typename F, typename T, typename... Ts, size_t I, size_t... Idx, typename... Carry>
+            constexpr auto eval_in_order_to_tuple(type_list<T, Ts...>, std::index_sequence<I, Idx...>, F&& f, Carry&&... carry)
+            {
+                static_assert(std::is_trivial_v<T>, "Argument is a non-trivial type!");
+
+                auto&& result = invoke_optional_index(f, T{}, I, 0);
+                return eval_in_order_to_tuple(
+                    type_list<Ts...>{},
+                    std::index_sequence<Idx...>{},
+                    std::forward<F>(f),
+                    std::forward<Carry>(carry)..., // carry the previous results over
+                    std::forward<decltype(result)>(result) // pass the current result after them
+                );
+            }
+
+            template <typename F>
+            constexpr void eval_in_order(type_list<>, std::index_sequence<>, [[maybe_unused]]F&& f)
+            {
+            }
+
+            // This workaround is needed since C++ does not specify
+            // the order in which function arguments are evaluated and this leads
+            // to incorrect order of evaluation (noticeable when using indexes).
+            template <typename F, typename T, typename... Ts, size_t I, size_t... Idx>
+            constexpr void eval_in_order(type_list<T, Ts...>, std::index_sequence<I, Idx...>, F&& f)
+            {
+                static_assert(std::is_trivial_v<T>, "Argument is a non-trivial type!");
+
+                invoke_optional_index(f, T{}, I, 0);
+                return eval_in_order(
+                    type_list<Ts...>{},
+                    std::index_sequence<Idx...>{},
+                    std::forward<F>(f)
+                );
+            }
+        }
+
+        /**
+         * Applies function F to each type in the type_list, aggregating
+         * the results in a tuple. F can optionally take an index of type size_t.
+         *
+         * \code{.cpp}
+         * map_to_tuple(reflect_types(type_list<int, float, double>{}), [](auto td) {
+         *   return get_name(td);
+         * })
+         *   -> std::tuple{const_string{"int"}, const_string{"float"}, const_string{"double"}}
+         * \endcode
+         */
+        template <typename F, typename... Ts>
+        constexpr auto map_to_tuple(type_list<Ts...> list, F&& f)
+        {
+            return detail::eval_in_order_to_tuple(list, std::make_index_sequence<sizeof...(Ts)>{}, std::forward<F>(f));
+        }
+
+        /**
+         * Applies function F to each type in the type_list, aggregating
+         * the results in an array. F can optionally take an index of type size_t.
+         *
+         * \code{.cpp}
+         * map_to_array<std::string>(reflect_types(type_list<int, float, double>{}), [](auto td) {
+         *   return get_name(td).str();
+         * })
+         *   -> std::array{std::string{"int"}, std::string{"float"}, std::string{"double"}}
+         * \endcode
+         */
+        template <typename T, typename F, typename... Ts>
+        constexpr auto map_to_array(type_list<Ts...> list, F&& f)
+        {
+            return to_array<T>(map_to_tuple(list, std::forward<F>(f)));
+        }
+
+        /**
+         * Applies function F to each type in the type_list.
+         * F can optionally take an index of type size_t.
+         *
+         * \code{.cpp}
+         * for_each(reflect_types(type_list<int, float, double>{}), [](auto td) {
+         *   std::cout << get_name(td) << '\n';
+         * });
+         * \endcode
+         */
+        template <typename F, typename... Ts>
+        constexpr void for_each(type_list<Ts...> list, F&& f)
+        {
+            detail::eval_in_order(list, std::make_index_sequence<sizeof...(Ts)>{}, std::forward<F>(f));
+        }
+
+        /*
+         * Returns the initial_value unchanged.
+         */
+        /// \private
+        template <typename R, typename F, typename... Ts>
+        constexpr R accumulate(type_list<>, F&&, R&& initial_value)
+        {
+            return std::forward<R>(initial_value);
+        }
+
+        /*
+        * Applies an accumulation function F to each type in the type_list.
+        * Note: Breaking changes introduced in v0.7.0:
+        *   Behaviour changed to imitate std::accumulate.
+        *   F can now no longer take a second index argument.
+        */
+        template <typename R, typename F, typename T, typename... Ts>
+        constexpr auto accumulate(type_list<T, Ts...>, F&& f, R&& initial_value)
+        {
+            static_assert(std::is_trivial_v<T>, "Argument is a non-trivial type!");
+
+            return accumulate(type_list<Ts...> {},
+                std::forward<F>(f),
+                std::forward<std::invoke_result_t<F&&, R&&, T&&>>(
+                    f(std::forward<R>(initial_value), T {})));
+        }
+
+        /**
+         * Counts the number of times the predicate F returns true.
+        * Note: Breaking changes introduced in v0.7.0:
+        *   F can now no longer take a second index argument.
+         */
+        template <typename F, typename... Ts>
+        constexpr size_t count_if(type_list<Ts...> list, F&& f)
+        {
+            return accumulate<size_t>(list,
+                [&](size_t acc, const auto& t) -> size_t { return acc + (f(t) ? 1 : 0); },
+                0);
+        }
+
+        namespace detail
+        {
+            template <typename, bool...>
+            struct apply_mask;
+
+            template <>
+            struct apply_mask<type_list<>>
+            {
+                using type = type_list<>;
+            };
+
+            template <typename T, typename... Ts, bool... Bs>
+            struct apply_mask<type_list<T, Ts...>, true, Bs...>
+            {
+                static_assert(std::is_trivial_v<T>, "Argument is a non-trivial type!");
+                using type = trait::prepend_t<T, typename apply_mask<type_list<Ts...>, Bs...>::type>;
+            };
+
+            template <typename T, typename... Ts, bool... Bs>
+            struct apply_mask<type_list<T, Ts...>, false, Bs...> : apply_mask<type_list<Ts...>, Bs...>
+            {
+                static_assert(std::is_trivial_v<T>, "Argument is a non-trivial type!");
+            };
+
+            template <typename F, typename... Ts>
+            constexpr auto filter([[maybe_unused]] F f, type_list<Ts...>)
+            {
+                return typename apply_mask<type_list<Ts...>, f(Ts{})...>::type{};
+            }
+        }
+
+        /**
+         * Filters the list according to a *constexpr* predicate.
+         * Calling f(Ts{})... should be valid in a constexpr context.
+         *
+         * \code{.cpp}
+         * filter(reflect_types(type_list<int, long, float>{}), [](auto td) {
+         *   return std::is_integral_v<typename decltype(td)::type>;
+         * })
+         *   -> type_list<type_descriptor<int>, type_descriptor<long>>
+         * \endcode
+         */
+        template <typename F, typename... Ts>
+        constexpr auto filter(type_list<Ts...> list, F&& f)
+        {
+            return decltype(detail::filter(std::forward<F>(f), list))();
+        }
+
+        /**
+         * Returns the first instance that matches the *constexpr* predicate.
+         * Calling f(Ts{})... should be valid in a constexpr context.
+         */
+        template <typename F, typename... Ts>
+        constexpr auto find_first(type_list<Ts...> list, F&& f)
+        {
+            using result_list = decltype(detail::filter(std::forward<F>(f), list));
+            static_assert(result_list::size != 0, "find_first did not match anything!");
+            return trait::get_t<0, result_list>{};
+        }
+
+        /**
+         * Returns the only instance that matches the *constexpr* predicate.
+         * If there is no match or multiple matches, fails with static_assert.
+         * Calling f(Ts{})... should be valid in a constexpr context.
+         */
+        template <typename F, typename... Ts>
+        constexpr auto find_one(type_list<Ts...> list, F&& f)
+        {
+            using result_list = decltype(detail::filter(std::forward<F>(f), list));
+            static_assert(result_list::size != 0, "find_one did not match anything!");
+            static_assert(result_list::size == 1, "Cannot resolve multiple matches in find_one!");
+            return trait::get_t<0, result_list>{};
+        }
+
+        /**
+         * Returns true if any item in the list matches the predicate.
+         * Calling f(Ts{})... should be valid in a constexpr context.
+         */
+        template <typename F, typename... Ts>
+        constexpr bool contains(type_list<Ts...> list, F&& f)
+        {
+            using result_list = decltype(detail::filter(std::forward<F>(f), list));
+            return result_list::size > 0;
+        }
+
+        /**
+         * Returns true if the type_list contains the specified type.
+         * @see refl::trait::contains
+         */
+        template <typename T, typename... Ts>
+        constexpr bool contains(type_list<Ts...>)
+        {
+            return trait::contains_v<T, type_list<Ts...>>;
+        }
+
+        /**
+         * Returns true if the tuple contains the specified type or a supertype.
+         * @see refl::trait::contains_base
+         */
+        template <typename T, typename... Ts>
+        constexpr bool contains_base(const std::tuple<Ts...>&)
+        {
+            return trait::contains_base_v<T, type_list<Ts...>>;
+        }
+
+        /**
+         * Returns true if the tuple contains an instance of the specified type.
+         * @see refl::trait::contains_instance
+         */
+        template <template <typename...> typename T, typename... Ts>
+        constexpr bool contains_instance(const std::tuple<Ts...>&)
+        {
+            return trait::contains_instance_v<T, type_list<Ts...>>;
+        }
+
+        /**
+         * Applies a function to the elements of the type_list.
+         *
+         * \code{.cpp}
+         * apply(reflect_types(type_list<int, long, float>{}), [](auto td_int, auto td_long, auto td_float) {
+         *   return get_name(td_int) + " " +get_name(td_long) + " " + get_name(td_float);
+         * })
+         *   -> "int long float"
+         * \endcode
+         */
+        template <typename... Ts, typename F>
+        constexpr auto apply(type_list<Ts...>, F&& f)
+        {
+            return f(Ts{}...);
+        }
+
+        /** A synonym for std::get<N>(tuple). */
+        template <size_t N, typename... Ts>
+        constexpr auto& get(std::tuple<Ts...>& ts) noexcept
+        {
+            return std::get<N>(ts);
+        }
+
+        /** A synonym for std::get<N>(tuple). */
+        template <size_t N, typename... Ts>
+        constexpr const auto& get(const std::tuple<Ts...>& ts) noexcept
+        {
+            return std::get<N>(ts);
+        }
+
+        /** A synonym for std::get<T>(tuple). */
+        template <typename T, typename... Ts>
+        constexpr T& get(std::tuple<Ts...>& ts) noexcept
+        {
+            return std::get<T>(ts);
+        }
+
+        /** A synonym for std::get<T>(tuple). */
+        template <typename T, typename... Ts>
+        constexpr const T& get(const std::tuple<Ts...>& ts) noexcept
+        {
+            return std::get<T>(ts);
+        }
+
+        /** Returns the value of type U, where U is a template instance of T. */
+        template <template<typename...> typename T, typename... Ts>
+        constexpr auto& get_instance(std::tuple<Ts...>& ts) noexcept
+        {
+            static_assert((... || trait::is_instance_of_v<T, Ts>), "The tuple does not contain a type that is a template instance of T!");
+            constexpr size_t idx = static_cast<size_t>(trait::index_of_instance_v<T, type_list<Ts...>>);
+            return std::get<idx>(ts);
+        }
+
+        /** Returns the value of type U, where U is a template instance of T. */
+        template <template<typename...> typename T, typename... Ts>
+        constexpr const auto& get_instance(const std::tuple<Ts...>& ts) noexcept
+        {
+            static_assert((... || trait::is_instance_of_v<T, Ts>), "The tuple does not contain a type that is a template instance of T!");
+            constexpr size_t idx = static_cast<size_t>(trait::index_of_instance_v<T, type_list<Ts...>>);
+            return std::get<idx>(ts);
+        }
+
+        /**
+         * Converts a type_list of types to a type_list of the type_descriptors for these types.
+         *
+         * \code{.cpp}
+         * reflect_types(type_list<int, float>{}) -> type_list<type_descriptor<int>, type_descriptor<float>>{}
+         * \endcode
+         */
+        template <typename... Ts>
+        constexpr type_list<descriptor::type_descriptor<Ts>...> reflect_types(type_list<Ts...>) noexcept
+        {
+            return {};
+        }
+
+        /**
+         * Converts a type_list of type_descriptors to a type_list of the target types.
+         *
+         * \code{.cpp}
+         * unreflect_types(type_list<type_descriptor<int>, type_descriptor<float>>{}) -> type_list<int, float>{}
+         * \endcode
+         */
+        template <typename... Ts>
+        constexpr type_list<Ts...> unreflect_types(type_list<descriptor::type_descriptor<Ts>...>) noexcept
+        {
+            return {};
+        }
+    } // namespace util
+
+    /**
+     * @brief Contains the definitions of the built-in attributes
+     *
+     * Contains the definitions of the built-in attributes which
+     * are implicitly available in macro context as well as the
+     * attr::usage namespace which contains constraints
+     * for user-provieded attributes.
+     *
+     * # Examples
+     * ```
+     * REFL_TYPE(Point, debug(custom_printer))
+     *     REFL_FIELD(x)
+     *     REFL_FIELD(y)
+     * REFL_END
+     * ```
+     */
+    namespace attr
+    {
+        /**
+         * @brief Contains a number of constraints applicable to refl-cpp attributes.
+         *
+         * Contains base types which create compile-time constraints
+         * that are verified by refl-cpp. These base-types must be inherited
+         * by custom attribute types.
+         */
+        namespace usage
+        {
+            /**
+             * Specifies that an attribute type inheriting from this type can
+             * only be used with REFL_TYPE()
+             */
+            struct type {};
+
+            /**
+             * Specifies that an attribute type inheriting from this type can
+             * only be used with REFL_FUNC()
+             */
+            struct function {};
+
+            /**
+             * Specifies that an attribute type inheriting from this type can
+             * only be used with REFL_FIELD()
+             */
+            struct field {};
+
+            /**
+             * Specifies that an attribute type inheriting from this type can
+             * only be used with REFL_FUNC or REFL_FIELD.
+             */
+            struct member : public function, public field{};
+
+            /**
+             * Specifies that an attribute type inheriting from this type can
+             * only be used with any one of REFL_TYPE, REFL_FIELD, REFL_FUNC.
+             */
+            struct any : public member, public type {};
+        }
+
+        /**
+         * Used to decorate a function that serves as a property.
+         * Takes an optional friendly name.
+         */
+        struct property : public usage::function
+        {
+            const std::optional<const char*> friendly_name;
+
+            constexpr property() noexcept
+                : friendly_name{}
+            {
+            }
+
+            constexpr property(const char* friendly_name) noexcept
+                : friendly_name(friendly_name)
+            {
+            }
+        };
+
+        /**
+         * Used to specify how a type should be displayed in debugging contexts.
+         */
+        template <typename F>
+        struct debug : public usage::any
+        {
+            const F write;
+
+            constexpr debug(F write)
+                : write(write)
+            {
+            }
+        };
+
+        /**
+         * Used to specify the base types of the target type.
+         */
+        template <typename... Ts>
+        struct base_types : usage::type
+        {
+            /** An alias for a type_list of the base types. */
+            typedef type_list<Ts...> list_type;
+
+            /** An instance of a type_list of the base types. */
+            static constexpr list_type list{ };
+        };
+
+        /**
+         * Used to specify the base types of the target type.
+         */
+        template <typename... Ts>
+        [[maybe_unused]] static constexpr base_types<Ts...> bases{ };
+    } // namespace attr
+
+
+    namespace detail
+    {
+        namespace macro_exports
+        {
+            using attr::property;
+            using attr::debug;
+            using attr::bases;
+        }
+    }
+
+    namespace trait
+    {
+        namespace detail
+        {
+            template <typename T>
+            auto member_type_test(int) -> decltype(typename T::member_type{}, std::true_type{});
+
+            template <typename T>
+            std::false_type member_type_test(...);
+        }
+
+        /**
+         * A trait for detecting whether the type 'T' is a member descriptor.
+         */
+        template <typename T>
+        struct is_member : decltype(detail::member_type_test<T>(0))
+        {
+        };
+
+        /**
+         * A trait for detecting whether the type 'T' is a member descriptor.
+         */
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_member_v{ is_member<T>::value };
+
+        namespace detail
+        {
+            template <typename T>
+            struct is_field_2 : std::is_base_of<typename T::member_type, member::field>
+            {
+            };
+        }
+
+        /**
+         * A trait for detecting whether the type 'T' is a field descriptor.
+         */
+        template <typename T>
+        struct is_field : std::conjunction<is_member<T>, detail::is_field_2<T>>
+        {
+        };
+
+        /**
+         * A trait for detecting whether the type 'T' is a field descriptor.
+         */
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_field_v{ is_field<T>::value };
+
+        namespace detail
+        {
+            template <typename T>
+            struct is_function_2 : std::is_base_of<typename T::member_type, member::function>
+            {
+            };
+        }
+
+        /**
+         * A trait for detecting whether the type 'T' is a function descriptor.
+         */
+        template <typename T>
+        struct is_function : std::conjunction<is_member<T>, detail::is_function_2<T>>
+        {
+        };
+
+        /**
+         * A trait for detecting whether the type 'T' is a function descriptor.
+         */
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_function_v{ is_function<T>::value };
+
+        /**
+         * Detects whether the type T is a type_descriptor.
+         * Inherits from std::bool_constant<>.
+         */
+        template <typename T>
+        struct is_type : is_instance_of<descriptor::type_descriptor, T>
+        {
+        };
+
+        /**
+         * Detects whether the type T is a type_descriptor.
+         * @see is_type
+         */
+        template <typename T>
+        [[maybe_unused]] constexpr bool is_type_v{ is_type<T>::value };
+
+        /**
+         * A trait for detecting whether the type 'T' is a refl-cpp descriptor.
+         */
+        template <typename T>
+        struct is_descriptor : std::disjunction<is_type<T>, is_member<T>>
+        {
+        };
+
+        /**
+         * A trait for detecting whether the type 'T' is a refl-cpp descriptor.
+         */
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_descriptor_v{ is_descriptor<T>::value };
+
+
+        /** Checks whether T is marked as a property. */
+        template <typename T>
+        struct is_property : std::bool_constant<
+            trait::is_function_v<T> && trait::contains_v<attr::property, typename T::attribute_types>>
+        {
+        };
+
+        /** Checks whether T is marked as a property. */
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_property_v{ is_property<T>::value };
+    } // namespace trait
+
+    /**
+     * @brief Contains the basic reflection primitives
+     * as well as functions operating on those primitives
+     */
+    namespace descriptor
+    {
+        namespace detail
+        {
+            template <typename Member>
+            struct static_field_invoker
+            {
+                static constexpr auto invoke() -> decltype(*Member::pointer)
+                {
+                    return *Member::pointer;
+                }
+
+                template <typename U, typename M = Member, std::enable_if_t<M::is_writable, int> = 0>
+                static constexpr auto invoke(U&& value) -> decltype(*Member::pointer = std::forward<U>(value))
+                {
+                    return *Member::pointer = std::forward<U>(value);
+                }
+            };
+
+            template <typename Member>
+            struct instance_field_invoker
+            {
+                template <typename T>
+                static constexpr auto invoke(T&& target) -> decltype(target.*(Member::pointer))
+                {
+                    return target.*(Member::pointer);
+                }
+
+                template <typename T, typename U, typename M = Member, std::enable_if_t<M::is_writable, int> = 0>
+                static constexpr auto invoke(T&& target, U&& value) -> decltype(target.*(Member::pointer) = std::forward<U>(value))
+                {
+                    return target.*(Member::pointer) = std::forward<U>(value);
+                }
+            };
+
+            template <typename Member>
+            static_field_invoker<Member> field_type_switch(std::true_type);
+
+            template <typename Member>
+            instance_field_invoker<Member> field_type_switch(std::false_type);
+
+            template <typename Member>
+            constexpr decltype(nullptr) get_function_pointer(...)
+            {
+                return nullptr;
+            }
+
+            template <typename Member>
+            constexpr auto get_function_pointer(int) -> decltype(Member::pointer())
+            {
+                return Member::pointer();
+            }
+
+            template <typename Member, typename Pointer>
+            constexpr decltype(nullptr) resolve_function_pointer(...)
+            {
+                return nullptr;
+            }
+
+            template <typename Member, typename Pointer>
+            constexpr auto resolve_function_pointer(int) -> decltype(Member::template resolve<Pointer>())
+            {
+                return Member::template resolve<Pointer>();
+            }
+
+            template <typename T, size_t N>
+            using make_descriptor = std::conditional_t<refl::trait::is_field_v<refl::detail::member_info<T, N>>,
+                field_descriptor<T, N>,
+                std::conditional_t<refl::trait::is_function_v<refl::detail::member_info<T, N>>,
+                    function_descriptor<T, N>,
+                    void
+                >>;
+
+            template <typename T>
+            type_list<> enumerate_members(std::index_sequence<>);
+
+            template <typename T, size_t... Idx>
+            type_list<make_descriptor<T, Idx>...> enumerate_members(std::index_sequence<Idx...>);
+
+            template <typename T>
+            struct declared_member_list
+            {
+                static_assert(refl::trait::is_reflectable_v<T>, "This type does not support reflection!");
+                using type = decltype(enumerate_members<T>(std::make_index_sequence<refl::detail::type_info<T>::member_count>{}));
+            };
+
+            template <typename T>
+            using attribute_types = trait::as_type_list_t<std::remove_cv_t<decltype(refl::detail::type_info<T>::attributes)>>;
+
+            template <typename>
+            struct flatten;
+
+            template <typename... TypeLists>
+            struct flatten<type_list<TypeLists...>> : trait::concat<TypeLists...>
+            {
+            };
+
+            template <typename T, typename Base>
+            static constexpr void validate_base()
+            {
+                static_assert(std::is_base_of_v<Base, T>, "Base is not a base type of T!");
+            }
+
+            template <typename T, typename... Bases>
+            static constexpr void validate_bases(type_list<Bases...>)
+            {
+                util::ignore((validate_base<T, Bases>(), 0)...);
+            }
+
+            template <typename T>
+            static constexpr auto get_declared_base_type_list()
+            {
+                if constexpr (trait::contains_instance_v<attr::base_types, attribute_types<T>>) {
+                    using base_types_type = trait::remove_qualifiers_t<decltype(util::get_instance<attr::base_types>(refl::detail::type_info<T>::attributes))>;
+                    validate_bases<T>(base_types_type::list);
+                    return typename base_types_type::list_type{};
+                }
+                else {
+                    return type_list<>{};
+                }
+            }
+
+            template <typename T>
+            struct declared_base_type_list
+            {
+                using type = decltype(get_declared_base_type_list<T>());
+            };
+
+            template <typename T>
+            struct base_type_list;
+
+            template <typename T>
+            static constexpr auto get_base_type_list()
+            {
+                if constexpr (trait::contains_instance_v<attr::base_types, attribute_types<T>>) {
+                    using declared_bases = typename declared_base_type_list<T>::type;
+                    using rec_bases = typename flatten<trait::map_t<base_type_list, declared_bases>>::type;
+                    return trait::unique_t<trait::concat_t<declared_bases, rec_bases>>{};
+                }
+                else {
+                    return type_list<>{};
+                }
+            }
+
+            template <typename T>
+            struct base_type_list
+            {
+                using type = decltype(get_base_type_list<T>());
+            };
+
+            template <typename T>
+            struct member_list : flatten<trait::map_t<declared_member_list, trait::prepend_t<T, typename base_type_list<T>::type>>>
+            {
+            };
+
+        } // namespace detail
+
+        /** A type_list of the declared member descriptors of the target type T. */
+        template <typename T>
+        using declared_member_list = typename detail::declared_member_list<T>::type;
+
+        /** A type_list of the declared and inherited member descriptors of the target type T. */
+        template <typename T>
+        using member_list = typename detail::member_list<T>::type;
+
+        /**
+         * @brief The base type for member descriptors.
+         */
+        template <typename T, size_t N>
+        class member_descriptor_base
+        {
+        protected:
+
+            typedef refl::detail::member_info<T, N> member;
+
+        public:
+
+            /**
+             * An alias for the declaring type of the reflected member.
+             *
+             * \code{.cpp}
+             * struct Foo { const int* x; };
+             * REFL_AUTO(type(Foo), field(x))
+             *
+             * get_t<0, member_list<Foo>>::declaring_type -> Foo
+             * \endcode
+             */
+            typedef T declaring_type;
+
+            /** An alias specifying the member type of member. */
+            typedef typename member::member_type member_type;
+
+            /**
+             * An alias specifying the types of the attributes of the member. (Removes CV-qualifiers.)
+             * \copydetails refl::descriptor::get_attribute_types
+             */
+            typedef trait::as_type_list_t<std::remove_cv_t<decltype(member::attributes)>> attribute_types;
+
+            /**
+             * The type_descriptor of the declaring type.
+             * \copydetails refl::descriptor::get_declarator
+             */
+            static constexpr type_descriptor<T> declarator{ };
+
+            /**
+             * The name of the reflected member.
+             * \copydetails refl::descriptor::get_name
+             */
+            static constexpr auto name{ member::name };
+
+            /**
+             * The attributes of the reflected member.
+             * \copydetails refl::descriptor::get_attributes
+             */
+            static constexpr auto attributes{ member::attributes };
+
+        };
+
+        /**
+         * @brief Represents a reflected field.
+         */
+        template <typename T, size_t N>
+        class field_descriptor : public member_descriptor_base<T, N>
+        {
+            using typename member_descriptor_base<T, N>::member;
+            static_assert(trait::is_field_v<member>);
+
+        public:
+
+            /**
+             * Type value type of the member.
+             *
+             * \code{.cpp}
+             * struct Foo { const int* x; };
+             * REFL_AUTO(type(Foo), field(x))
+             *
+             * get_t<0, member_list<Foo>>::value_type -> const int*
+             * \endcode
+             */
+            typedef typename member::value_type value_type;
+
+            /**
+             * Whether the field is static or not.
+             * \copydetails refl::descriptor::is_static
+             */
+            static constexpr bool is_static{ !std::is_member_object_pointer_v<decltype(member::pointer)> };
+
+            /**
+             * Whether the field is const or not.
+             * @see refl::descriptor::is_const
+             */
+            static constexpr bool is_writable{ !std::is_const_v<value_type> };
+
+            /**
+             * A member pointer to the reflected field of the appropriate type.
+             * \copydetails refl::descriptor::get_pointer
+             */
+            static constexpr auto pointer{ member::pointer };
+
+        private:
+
+            using invoker = decltype(detail::field_type_switch<field_descriptor>(std::bool_constant<is_static>{}));
+
+        public:
+
+            /**
+             * Returns the value of the field. (for static fields).
+             * \copydetails refl::descriptor::invoke
+             */
+            template <decltype(nullptr) = nullptr>
+            static constexpr decltype(auto) get() noexcept
+            {
+                return *member::pointer;
+            }
+
+            /**
+             * Returns the value of the field. (for instance fields).
+             * \copydetails refl::descriptor::invoke
+             */
+            template <typename U>
+            static constexpr decltype(auto) get(U&& target) noexcept
+            {
+                return target.*(member::pointer);
+            }
+
+            /**
+             * A synonym for get().
+             * \copydetails refl::descriptor::invoke
+             */
+            template <typename... Args>
+            constexpr auto operator()(Args&&... args) const noexcept -> decltype(invoker::invoke(std::forward<Args>(args)...))
+            {
+                return invoker::invoke(std::forward<Args>(args)...);
+            }
+
+        };
+
+        /**
+         * @brief Represents a reflected function.
+         */
+        template <typename T, size_t N>
+        class function_descriptor : public member_descriptor_base<T, N>
+        {
+            using typename member_descriptor_base<T, N>::member;
+            static_assert(trait::is_function_v<member>);
+
+        public:
+
+            /**
+             * Invokes the function with the given arguments.
+             * If the function is an instance function, a reference
+             * to the instance is provided as first argument.
+             * \copydetails refl::descriptor::invoke
+             */
+            template <typename... Args>
+            static constexpr auto invoke(Args&&... args) -> decltype(member::invoke(std::declval<Args>()...))
+            {
+                return member::invoke(std::forward<Args>(args)...);
+            }
+
+            /**
+             * The return type of an invocation of this member with Args... (as if by invoke(...)).
+             * \copydetails refl::descriptor::return_type
+             */
+            template <typename... Args>
+            using return_type = decltype(member::invoke(std::declval<Args>()...));
+
+            /**
+             * A synonym for invoke(args...).
+             * \copydetails refl::descriptor::invoke
+             */
+            template <typename... Args>
+            constexpr auto operator()(Args&&... args) const -> decltype(invoke(std::declval<Args>()...))
+            {
+                return invoke(std::forward<Args>(args)...);
+            }
+
+            /**
+             * Returns a pointer to a non-overloaded function.
+             * \copydetails refl::descriptor::get_pointer
+             */
+            static constexpr auto pointer{ detail::get_function_pointer<member>(0) };
+
+            /**
+             * Whether the pointer member was correctly resolved to a concrete implementation.
+             * If this field is false, resolve() would need to be called instead.
+             * \copydetails refl::descriptor::is_resolved
+             */
+            static constexpr bool is_resolved{ !std::is_same_v<decltype(pointer), const decltype(nullptr)> };
+
+            /**
+             * Whether the pointer can be resolved as with the specified type.
+             * \copydetails refl::descriptor::can_resolve
+             */
+            template <typename Pointer>
+            static constexpr bool can_resolve()
+            {
+                return !std::is_same_v<decltype(resolve<Pointer>()), decltype(nullptr)>;
+            }
+
+            /**
+             * Resolves the function pointer as being of type Pointer.
+             * Required when taking a pointer to an overloaded function.
+             *
+             * \copydetails refl::descriptor::resolve
+             */
+            template <typename Pointer>
+            static constexpr auto resolve()
+            {
+                return detail::resolve_function_pointer<member, Pointer>(0);
+            }
+
+        };
+
+        /** Represents a reflected type. */
+        template <typename T>
+        class type_descriptor
+        {
+        private:
+
+            static_assert(refl::trait::is_reflectable_v<T>, "This type does not support reflection!");
+
+            typedef refl::detail::type_info<T> type_info;
+
+        public:
+
+            /**
+             * The reflected type T.
+             *
+             * \code{.cpp}
+             * struct Foo {};
+             * REFL_AUTO(type(Foo))
+             *
+             * type_descriptor<Foo>::type -> Foo
+             * \endcode
+             */
+            typedef T type;
+
+            /**
+             * The declared base types (via base_types<Ts...> attribute) of T.
+             * \copydetails refl::descriptor::get_declared_base_types
+             */
+            typedef typename detail::declared_base_type_list<T>::type declared_base_types;
+
+            /**
+             * The declared and inherited base types of T.
+             * \copydetails refl::descriptor::get_base_types
+             */
+            typedef typename detail::base_type_list<T>::type base_types;
+
+            /**
+             * A synonym for declared_member_list<T>.
+             * \copydetails refl::descriptor::declared_member_list
+             */
+            typedef declared_member_list<T> declared_member_types;
+
+            /**
+             * A synonym for member_list<T>.
+             * \copydetails refl::descriptor::member_list
+             */
+            typedef member_list<T> member_types;
+
+            /**
+             * An alias specifying the types of the attributes of the member. (Removes CV-qualifiers.)
+             * \copydetails refl::descriptor::get_attribute_types
+             */
+            typedef detail::attribute_types<T> attribute_types;
+
+            /**
+             * The declared base types (via base_types<Ts...> attribute) of T.
+             * \copydetails refl::descriptor::get_declared_base_types
+             */
+            static constexpr declared_base_types declared_bases{};
+
+            /**
+             * The declared  and inherited base types of T.
+             * \copydetails refl::descriptor::get_base_types
+             */
+            static constexpr base_types bases{};
+
+            /**
+             * The list of declared member descriptors.
+             * \copydetails refl::descriptor::get_declared_members
+             */
+            static constexpr declared_member_types declared_members{  };
+
+            /**
+             * The list of declared and inherited member descriptors.
+             * \copydetails refl::descriptor::get_members
+             */
+            static constexpr member_types members{  };
+
+            /**
+             * The name of the reflected type.
+             * \copydetails refl::descriptor::get_name
+             */
+            static constexpr const auto name{ type_info::name };
+
+            /**
+             * The attributes of the reflected type.
+             * \copydetails refl::descriptor::get_attributes
+              */
+            static constexpr const auto attributes{ type_info::attributes };
+
+        };
+
+        /**
+         * Returns the full name of the descriptor
+         *
+         * \code{.cpp}
+         * namespace ns {
+         *   struct Foo {
+         *     int x;
+         *   };
+         * }
+         * REFL_AUTO(type(ns::Foo), field(x))
+         *
+         * get_name(reflect<Foo>()) -> "ns::Foo"
+         * get_name(get_t<0, member_list<Foo>>()) -> "x"
+         * \endcode
+         */
+        template <typename Descriptor>
+        constexpr auto get_name(Descriptor d) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return d.name;
+        }
+
+        /**
+         * Returns a const reference to the descriptor's attribute tuple.
+         *
+         * \code{.cpp}
+         * struct Foo {};
+         * REFL_AUTO(type(Foo, bases<>, ns::serializable()))
+         *
+         * get_attributes(reflect<Foo>()) -> const std::tuple<attr::base_types<>, ns::serializable>&
+         * \endcode
+         */
+        template <typename Descriptor>
+        constexpr const auto& get_attributes(Descriptor d) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return d.attributes;
+        }
+
+        /**
+         * Returns a type_list of the descriptor's attribute types.
+         *
+         * \code{.cpp}
+         * struct Foo {};
+         * REFL_AUTO(type(Foo, bases<>, ns::serializable()))
+         *
+         * get_attribute_types(reflect<Foo>()) -> type_list<attr::base_types<>, ns::serializable>
+         * \endcode
+         */
+        template <typename Descriptor>
+        constexpr auto get_attribute_types(Descriptor d) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return trait::as_type_list_t<std::remove_cv_t<decltype(d.attributes)>>{};
+        }
+
+        /**
+         * Returns a type_list of the declared base types of the type.
+         * Combine with reflect_types to obtain type_descriptors for those types.
+         * @see reflect_types
+         *
+         * \code{.cpp}
+         * struct Animal {};
+         * REFL_AUTO(type(Animal))
+         * struct Mammal : Animal {};
+         * REFL_AUTO(type(Mammal, bases<Animal>))
+         * struct Dog : Mammal {}:
+         * REFL_AUTO(type(Dog, bases<Mammal>))
+         *
+         * get_base_types(reflect<Dog>()) -> type_list<Mammal>
+         * \endcode
+         */
+        template <typename TypeDescriptor>
+        constexpr auto get_declared_base_types(TypeDescriptor t) noexcept
+        {
+            static_assert(trait::is_type_v<TypeDescriptor>);
+            return t.declared_bases;
+        }
+
+        /**
+         * Returns a type_list of the declared and inherited base types of the type.
+         * Combine with reflect_types to obtain type_descriptors for those types.
+         * @see reflect_types
+         *
+         * \code{.cpp}
+         * struct Animal {};
+         * REFL_AUTO(type(Animal))
+         * struct Mammal : Animal {};
+         * REFL_AUTO(type(Mammal, bases<Animal>))
+         * struct Dog : Mammal {}:
+         * REFL_AUTO(type(Dog, bases<Mammal>))
+         *
+         * get_base_types(reflect<Dog>()) -> type_list<Mammal, Animal>
+         * \endcode
+         */
+        template <typename TypeDescriptor>
+        constexpr auto get_base_types(TypeDescriptor t) noexcept
+        {
+            static_assert(trait::is_type_v<TypeDescriptor>);
+            return t.bases;
+        }
+
+        /**
+         * Returns a type_list of the declared members of the type.
+         *
+         * \code{.cpp}
+         * struct Base {
+         *  int val;
+         * };
+         * struct Foo : Base {
+         *   int bar, baz;
+         * };
+         * REFL_AUTO(type(Foo, bases<Base>), field(bar), field(baz))
+         * get_declared_members(reflect<Foo>()) -> type_list<field_descriptor<Foo, 0> /bar/, field_descriptor<Foo, 1> /baz/>
+         * \endcode
+         */
+        template <typename TypeDescriptor>
+        constexpr auto get_declared_members(TypeDescriptor t) noexcept
+        {
+            static_assert(trait::is_type_v<TypeDescriptor>);
+            return t.declared_members;
+        }
+
+        /**
+         * Returns a type_list of the declared and inherited members of the type.
+         *
+         * \code{.cpp}
+         * struct Base {
+         *  int val;
+         * };
+         * struct Foo : Base {
+         *   int bar, baz;
+         * };
+         * REFL_AUTO(type(Foo, bases<Base>), field(bar), field(baz))
+         * get_members(reflect<Foo>()) -> type_list<field_descriptor<Foo, 0> /bar/, field_descriptor<Foo, 1> /baz/, field_descriptor<Base, 0> /val/>
+         * \endcode
+         */
+        template <typename TypeDescriptor>
+        constexpr auto get_members(TypeDescriptor t) noexcept
+        {
+            static_assert(trait::is_type_v<TypeDescriptor>);
+            return t.members;
+        }
+
+        /**
+         * Returns the type_descriptor of declaring type of the member.
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   int bar;
+         * };
+         * REFL_AUTO(type(Foo), field(bar)
+         * get_declarator(get_t<0, member_list<Foo>>()) -> type_descriptor<Foo>{}
+         * \endcode
+         */
+        template <typename MemberDescriptor>
+        constexpr auto get_declarator(MemberDescriptor d) noexcept
+        {
+            static_assert(trait::is_member_v<MemberDescriptor>);
+            return d.declarator;
+        }
+
+        /**
+         * Returns a pointer to the reflected field/function.
+         * When the member is a function, the return value might be nullptr
+         * if the type of the function pointer cannot be resolved.
+         * @see is_resolved
+         * @see can_resolve
+         * @see resolve
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   int bar;
+         *   static int baz;
+         * };
+         * REFL_AUTO(type(Foo), field(bar), field(baz))
+         * get_pointer(get_t<0, member_list<Foo>>()) -> (int Foo::*) &Foo::bar
+         * get_pointer(get_t<1, member_list<Foo>>()) -> (int*) &Foo::baz
+         * \endcode
+         */
+        template <typename MemberDescriptor>
+        constexpr auto get_pointer(MemberDescriptor d) noexcept
+        {
+            static_assert(trait::is_member_v<MemberDescriptor>);
+            return d.pointer;
+        }
+
+        /**
+         * Invokes the member with the specified arguments.
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   int bar = 1;
+         *   static int baz = 5;
+         *   void foobar(int x) { return x * 2; }
+         *   static void foobaz(int x) { return x * 3; }
+         * };
+         * REFL_AUTO(type(Foo), field(bar), field(baz), func(foobar), func(foobaz))
+         * invoke(get_t<0, member_list<Foo>(), Foo()) -> 1 (Foo().bar)
+         * invoke(get_t<1, member_list<Foo>>()) -> 5 (Foo::baz)
+         * invoke(get_t<2, member_list<Foo>(), Foo(), 10) -> 20 (Foo().foobar())
+         * invoke(get_t<3, member_list<Foo>>()) -> 30 (Foo::foobaz())
+         * \endcode
+         */
+        template <typename MemberDescriptor, typename... Args>
+        constexpr auto invoke(MemberDescriptor d, Args&&... args) noexcept -> decltype(d(std::forward<Args>(args)...))
+        {
+            return d(std::forward<Args>(args)...);
+        }
+
+        /**
+         * Checks whether the field is declared as static.
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   int bar;
+         *   static int baz;
+         * };
+         * REFL_AUTO(type(Foo), field(bar), field(baz))
+         * is_static(get_t<0, member_list<Foo>>()) -> false
+         * is_static(get_t<1, member_list<Foo>>()) -> true
+         * \endcode
+         */
+        template <typename FieldDescriptor>
+        constexpr auto is_static(FieldDescriptor d) noexcept
+        {
+            static_assert(trait::is_field_v<FieldDescriptor>);
+            return d.is_static;
+        }
+
+        /**
+         * Checks whether the value type of the field is const-qualified.
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   int bar;
+         *   const int baz;
+         * };
+         * REFL_AUTO(type(Foo), field(bar), field(baz))
+         * is_const(get_t<0, member_list<Foo>>()) -> false
+         * is_const(get_t<1, member_list<Foo>>()) -> true
+         * \endcode
+         */
+        template <typename FieldDescriptor>
+        constexpr auto is_const(FieldDescriptor d) noexcept
+        {
+            static_assert(trait::is_field_v<FieldDescriptor>);
+            return d.is_const;
+        }
+
+        /**
+         * The return type when invoking the specified descriptor using the provided argument types.
+         * Argument coversion will be applied as per C++ rules.
+         */
+        template <typename FunctionDescriptor, typename... Args>
+        using result_type = typename FunctionDescriptor::template result_type<Args...>;
+
+        /**
+         * Checks whether the function pointer was automatically resolved.
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   void bar();
+         *   void bar(int);
+         *   void baz();
+         * };
+         * REFL_AUTO(type(Foo), func(bar), func(baz))
+         * is_resolved(get_t<0, member_list<Foo>>()) -> false
+         * is_resolved(get_t<1, member_list<Foo>>()) -> true
+         * \endcode
+         */
+        template <typename FunctionDescriptor>
+        constexpr auto is_resolved(FunctionDescriptor d) noexcept
+        {
+            static_assert(trait::is_function_v<FunctionDescriptor>);
+            return d.is_resolved;
+        }
+
+        /**
+         * Checks whether the function pointer can be resolved as
+         * a pointer of the specified type.
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   void bar();
+         *   void bar(int);
+         * };
+         * REFL_AUTO(type(Foo), func(bar))
+         * can_resolve<void(Foo::*)()>(get_t<0, member_list<Foo>>()) -> true
+         * can_resolve<void(Foo::*)(int)>(get_t<0, member_list<Foo>>()) -> true
+         * can_resolve<void(Foo::*)(std::string)>(get_t<0, member_list<Foo>>()) -> false
+         * \endcode
+         */
+        template <typename Pointer, typename FunctionDescriptor>
+        constexpr auto can_resolve(FunctionDescriptor d) noexcept
+        {
+            static_assert(trait::is_function_v<FunctionDescriptor>);
+            return d.template can_resolve<Pointer>();
+        }
+
+        /**
+         * Resolves the function pointer as a pointer of the specified type.
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   void bar();
+         *   void bar(int);
+         * };
+         * REFL_AUTO(type(Foo), func(bar))
+         * resolve<void(Foo::*)()>(get_t<0, member_list<Foo>>()) -> <&Foo::bar()>
+         * resolve<void(Foo::*)(int)>(get_t<0, member_list<Foo>>()) -> <&Foo::bar(int)>
+         * resolve<void(Foo::*)(std::string)>(get_t<0, member_list<Foo>>()) -> nullptr
+         * \endcode
+         */
+        template <typename Pointer, typename FunctionDescriptor>
+        constexpr auto resolve(FunctionDescriptor d) noexcept
+        {
+            static_assert(trait::is_function_v<FunctionDescriptor>);
+            return d.template resolve<Pointer>();
+        }
+
+        /**
+         * Checks whether T is a field descriptor.
+         *
+         * @see refl::descriptor::field_descriptor
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(Foo), func(bar), field(baz))
+         * is_function(get_t<0, member_list<Foo>>()) -> false
+         * is_function(get_t<1, member_list<Foo>>()) -> true
+         * \endcode
+         */
+        template <typename Descriptor>
+        constexpr bool is_field(Descriptor) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return trait::is_field_v<Descriptor>;
+        }
+
+        /**
+         * Checks whether T is a function descriptor.
+         *
+         * @see refl::descriptor::function_descriptor
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(Foo), func(bar), field(baz))
+         * is_function(get_t<0, member_list<Foo>>()) -> true
+         * is_function(get_t<1, member_list<Foo>>()) -> false
+         * \endcode
+         */
+        template <typename Descriptor>
+        constexpr bool is_function(Descriptor) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return trait::is_function_v<Descriptor>;
+        }
+
+        /**
+         * Checks whether T is a type descriptor.
+         *
+         * @see refl::descriptor::type_descriptor
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(Foo))
+         * is_type(reflect<Foo>>()) -> true
+         * \endcode
+         */
+        template <typename Descriptor>
+        constexpr bool is_type(Descriptor) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return trait::is_type_v<Descriptor>;
+        }
+
+        /**
+         * Checks whether T has an attribute of type A.
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(User), func(get_name, property()), func(set_name, property()))
+         * has_attribute<attr::property>(get_t<0, member_list<User>>{}) -> true
+         * \endcode
+         */
+        template <typename A, typename Descriptor>
+        constexpr bool has_attribute(Descriptor) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return trait::contains_base_v<A, typename Descriptor::attribute_types>;
+        }
+
+        /**
+         * Checks whether T has an attribute of that is a template instance of A.
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(Random, debug{ [](auto os, auto){ os << "[Random]"; } }))
+         * has_attribute<attr::debug>(reflect<Random>()) -> true
+         * \endcode
+         */
+        template <template<typename...> typename A, typename Descriptor>
+        constexpr bool has_attribute(Descriptor) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return trait::contains_instance_v<A, typename Descriptor::attribute_types>;
+        }
+
+        /**
+         * Returns the value of the attribute A on T.
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(User), func(get_name, property()), func(set_name, property()))
+         * get_attribute<attr::property>(get_t<0, member_list<User>>{}) -> property{ friendly_name = nullopt }
+         * \endcode
+         */
+        template <typename A, typename Descriptor>
+        constexpr const A& get_attribute(Descriptor d) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return util::get<A>(d.attributes);
+        }
+
+        /**
+         * Returns the value of the attribute A on T.
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(Random, debug{ [](auto os, auto){ os << "[Random]"; } }))
+         * get_attribute<attr::debug>(reflect<Random>()) -> instance of debug<LambdaType>
+         * \endcode
+         */
+        template <template<typename...> typename A, typename Descriptor>
+        constexpr const auto& get_attribute(Descriptor d) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return util::get_instance<A>(d.attributes);
+        }
+
+        /**
+         * Checks whether T is a member descriptor marked with the property attribute.
+         *
+         * @see refl::attr::property
+         * @see refl::descriptor::get_property
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(User), func(get_name, property("user_name")), func(set_name, property()))
+         * is_property(get_t<0, member_list<User>>{}) -> true
+         * \endcode
+         */
+        template <typename MemberDescriptor>
+        constexpr bool is_property(MemberDescriptor d) noexcept
+        {
+            static_assert(trait::is_member_v<MemberDescriptor>);
+            return has_attribute<attr::property>(d);
+        }
+
+        /**
+         * Gets the property attribute.
+         *
+         * @see refl::attr::property
+         * @see refl::descriptor::is_property
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(User), func(get_name, property("user_name")), func(set_name, property()))
+         * *get_property(get_t<0, member_list<User>>{}).friendly_name -> "user_name"
+         * \endcode
+         */
+        template <typename FunctionDescriptor>
+        constexpr attr::property get_property(FunctionDescriptor d) noexcept
+        {
+            static_assert(trait::is_function_v<FunctionDescriptor>);
+            return get_attribute<attr::property>(d);
+        }
+
+        namespace detail
+        {
+            struct placeholder
+            {
+                template <typename T>
+                operator T() const;
+            };
+        } // namespace detail
+
+        /**
+         * Checks if T is a 0-arg const-qualified member function with a property attribute or a field.
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(User), func(get_name, property()), func(set_name, property()))
+         * is_readable(get_t<0, member_list<User>>{}) -> true
+         * is_readable(get_t<1, member_list<User>>{}) -> false
+         * \endcode
+         */
+        template <typename MemberDescriptor>
+        constexpr bool is_readable(MemberDescriptor) noexcept
+        {
+            static_assert(trait::is_member_v<MemberDescriptor>);
+            if constexpr (trait::is_property_v<MemberDescriptor>) {
+                if constexpr (std::is_invocable_v<MemberDescriptor, const typename MemberDescriptor::declaring_type&>) {
+                    using return_type = typename MemberDescriptor::template return_type<const typename MemberDescriptor::declaring_type&>;
+                    return !std::is_void_v<return_type>;
+                }
+                else {
+                    return false;
+                }
+            }
+            else {
+                return trait::is_field_v<MemberDescriptor>;
+            }
+        }
+
+        /**
+         * Checks if T is a 1-arg non-const-qualified member function with a property attribute or a non-const field.
+         *
+         * \code{.cpp}
+         * struct User { std::string get_name() const; }
+         * REFL_AUTO(type(User), func(get_name, property()), func(set_name, property()))
+         * is_writable(get_t<0, member_list<User>>{}) -> false
+         * is_writable(get_t<1, member_list<User>>{}) -> true
+         * \endcode
+         */
+        template <typename MemberDescriptor>
+        constexpr bool is_writable(MemberDescriptor) noexcept
+        {
+            static_assert(trait::is_member_v<MemberDescriptor>);
+            if constexpr (trait::is_property_v<MemberDescriptor>) {
+                return std::is_invocable_v<MemberDescriptor, typename MemberDescriptor::declaring_type&, detail::placeholder>;
+            }
+            else if constexpr (trait::is_field_v<MemberDescriptor>) {
+                return !std::is_const_v<typename trait::remove_qualifiers_t<MemberDescriptor>::value_type>;
+            }
+            else {
+                return false;
+            }
+        }
+
+        namespace detail
+        {
+            template <typename T>
+            struct get_type_descriptor
+            {
+                typedef type_descriptor<T> type;
+            };
+        } // namespace detail
+
+        /**
+         * Checks if a type has a bases attribute.
+         *
+         * @deprecated Use has_base_types in combination with reflect_types instead.
+         * @see refl::attr::bases
+         * @see refl::descriptor::get_bases
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(Dog, bases<Animal>))
+         * has_bases(reflect<Dog>()) -> true
+         * \endcode
+         */
+        template <typename TypeDescriptor>
+        [[deprecated]] constexpr auto has_bases(TypeDescriptor t) noexcept
+        {
+            static_assert(trait::is_type_v<TypeDescriptor>);
+            return has_attribute<attr::base_types>(t);
+        }
+
+        /**
+         * Returns a list of the type_descriptor<T>s of the base types of the target,
+         * as specified by the bases<A, B, ...> attribute.
+         *
+         * @deprecated Use get_base_types in combination with reflect_types instead.
+         * @see refl::attr::bases
+         * @see refl::descriptor::has_bases
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(Dog, bases<Animal>))
+         * get_bases(reflect<Dog>()) -> type_list<type_descriptor<Animal>>
+         * \endcode
+         */
+        template <typename TypeDescriptor>
+        [[deprecated]] constexpr auto get_bases(TypeDescriptor t) noexcept
+        {
+            static_assert(trait::is_type_v<TypeDescriptor>);
+            static_assert(has_bases(t), "Target type does not have a bases<A, B, ...> attribute.");
+
+            constexpr auto bases = get_attribute<attr::base_types>(t);
+            using base_types = typename decltype(bases)::list_type;
+            return trait::map_t<detail::get_type_descriptor, base_types>{};
+        }
+
+        /**
+         * Returns the unqualified name of the type, discarding the namespace and typenames (if a template type).
+         *
+         * \code{.cpp}
+         * get_simple_name(reflect<std::vector<float>>()) -> "vector"
+         * \endcode
+         */
+        template <typename TypeDescriptor>
+        constexpr auto get_simple_name(TypeDescriptor t)
+        {
+            static_assert(trait::is_type_v<TypeDescriptor>);
+            constexpr size_t template_start = t.name.find('<');
+            constexpr size_t scope_last = t.name.rfind(':', template_start);
+            if constexpr (scope_last == const_string<0>::npos) {
+                return t.name;
+            }
+            else {
+                return t.name.template substr<scope_last + 1, template_start - scope_last - 1>();
+            }
+        }
+
+        /**
+         * Returns the debug name of T (In the form of 'declaring_type::member_name') as a const_string.
+         *
+         * \code{.cpp}
+         * REFL_AUTO(type(Point), field(x), field(y))
+         * get_debug_name_const(get_t<0, member_list<Point>>{}) -> "Point::x"
+         * \endcode
+         */
+        template <typename MemberDescriptor>
+        constexpr auto get_debug_name_const(MemberDescriptor d)
+        {
+            static_assert(trait::is_member_v<MemberDescriptor>);
+            return d.declarator.name + "::" + d.name;
+        }
+
+        /**
+         * Returns the debug name of T. (In the form of 'declaring_type::member_name').
+         * \code{.cpp}
+         * REFL_AUTO(type(Point), field(x), field(y))
+         * get_debug_name(get_t<0, member_list<Point>>{}) -> "Point::x"
+         * \endcode
+         */
+        template <typename MemberDescriptor>
+        const char* get_debug_name(MemberDescriptor d)
+        {
+            static_assert(trait::is_member_v<MemberDescriptor>);
+            static const std::string name(get_debug_name_const(d).str());
+            return name.c_str();
+        }
+
+        namespace detail
+        {
+            constexpr bool is_upper(char ch)
+            {
+                return ch >= 'A' && ch <= 'Z';
+            }
+
+            constexpr char to_upper(char ch)
+            {
+                return ch >= 'a' && ch <= 'z'
+                    ? char(ch + ('A' - 'a'))
+                    : ch;
+            }
+
+            constexpr char to_lower(char ch)
+            {
+                return ch >= 'A' && ch <= 'Z'
+                    ? char(ch + ('a' - 'A'))
+                    : ch;
+            }
+
+            template <typename T, bool PreferUpper>
+            constexpr auto normalize_bare_accessor_name()
+            {
+                constexpr auto str = T::name.template substr<3>();
+                if constexpr (str.data[0] == '_') {
+                    return str.template substr<1>();
+                }
+                else if constexpr (!PreferUpper && str.data[0] >= 'A' && str.data[0] <= 'Z') {
+                    return make_const_string(to_lower(str.data[0])) + str.template substr<1>();
+                }
+                else if constexpr (PreferUpper) {
+                    return make_const_string(to_upper(str.data[0])) + str.template substr<1>();
+                }
+                else {
+                    return str;
+                }
+            }
+
+            template <typename T>
+            constexpr auto normalize_accessor_name(const T)
+            {
+                constexpr T t{};
+                if constexpr (t.name.size > 3) {
+                    constexpr auto prefix = t.name.template substr<0, 3>();
+                    constexpr bool cont_snake_or_camel = (t.name.size > 4 && t.name.data[3] == '_' && !is_upper(t.name.data[4])) || is_upper(t.name.data[3]);
+                    constexpr bool cont_pascal = is_upper(t.name.data[3]);
+
+                    if constexpr ((is_readable(T{}) && ((prefix == "Get" && cont_pascal) || (prefix == "get" && cont_snake_or_camel)))
+                        || (is_writable(T{}) && ((prefix == "Set" && cont_pascal) || (prefix == "set" && cont_snake_or_camel)))) {
+                        constexpr bool prefer_upper = is_upper(prefix.data[0]);
+                        return normalize_bare_accessor_name<T, prefer_upper>();
+                    }
+                    else {
+                        return t.name;
+                    }
+                }
+                else {
+                    return t.name;
+                }
+            }
+
+            template <typename T>
+            constexpr auto get_display_name(const T t) noexcept
+            {
+                if constexpr (trait::is_property_v<T>) {
+                    if constexpr (util::get<attr::property>(t.attributes).friendly_name) {
+                        return REFL_MAKE_CONST_STRING(*util::get<attr::property>(t.attributes).friendly_name);
+                    }
+                    else {
+                        return detail::normalize_accessor_name(t);
+                    }
+                }
+                else {
+                    return t.name;
+                }
+            }
+
+            template <template <typename, size_t> typename MemberDescriptor, typename T, size_t N>
+            constexpr size_t get_member_index(MemberDescriptor<T, N>) noexcept
+            {
+                return N;
+            }
+
+            // Compilers only instantiate templates once per set of template parameters.
+            // Since each lambda is it's distinct type, and since we end up filtering
+            // by these predicates in several places in the codebase, it is better to have
+            // these lamdas defined here, to increase the likelihood that a template
+            // instantiation of `util::filter` can be reused.
+            static constexpr auto is_readable_p = [](auto m) { return is_readable(m); };
+            static constexpr auto is_writable_p = [](auto m) { return is_writable(m); };
+
+            template <typename Member>
+            static constexpr auto display_name_equals_p = [](auto m) {
+                return get_display_name_const(m) == get_display_name_const(Member{});
+            };
+
+            template <typename WritableMember>
+            static constexpr bool has_reader_search(WritableMember)
+            {
+#ifdef REFL_DISALLOW_SEARCH_FOR_RW
+                static_assert(WritableMember::name.data[0] == 0,
+                    "REFL_DISALLOW_SEARCH_FOR_RW is defined. Make sure your property getters and setter are defined one after the other!");
+#endif
+                using member_types = typename type_descriptor<typename WritableMember::declaring_type>::declared_member_types;
+                // Fallback to a slow linear search.
+                using property_types = typename trait::filter_t<trait::is_property, member_types>;
+                constexpr auto readable_properties = filter(property_types{}, detail::is_readable_p);
+                return contains(readable_properties, display_name_equals_p<WritableMember>);
+            }
+
+            template <typename ReadableMember>
+            static constexpr bool has_writer_search(ReadableMember)
+            {
+#ifdef REFL_DISALLOW_SEARCH_FOR_RW
+                static_assert(ReadableMember::name.data[0] == 0,
+                    "REFL_DISALLOW_SEARCH_FOR_RW is defined. Make sure your property getters and setter are defined one after the other!");
+#endif
+                using member_types = typename type_descriptor<typename ReadableMember::declaring_type>::declared_member_types;
+                // Fallback to a slow linear search.
+                using property_types = typename trait::filter_t<trait::is_property, member_types>;
+                constexpr auto writable_properties = filter(property_types{}, detail::is_writable_p);
+                return contains(writable_properties, display_name_equals_p<ReadableMember>);
+            }
+
+            template <typename WritableMember>
+            static constexpr auto get_reader_search(WritableMember)
+            {
+#ifdef REFL_DISALLOW_SEARCH_FOR_RW
+                static_assert(WritableMember::name.data[0] == 0,
+                    "REFL_DISALLOW_SEARCH_FOR_RW is defined. Make sure your property getters and setter are defined one after the other!");
+#endif
+                using member_types = typename type_descriptor<typename WritableMember::declaring_type>::declared_member_types;
+                // Fallback to a slow linear search.
+                using property_types = typename trait::filter_t<trait::is_property, member_types>;
+                constexpr auto readable_properties = filter(property_types{}, detail::is_readable_p);
+                return find_one(readable_properties, display_name_equals_p<WritableMember>);
+            }
+
+            template <typename ReadableMember>
+            static constexpr auto get_writer_search(ReadableMember)
+            {
+#ifdef REFL_DISALLOW_SEARCH_FOR_RW
+                static_assert(ReadableMember::name.data[0] == 0,
+                    "REFL_DISALLOW_SEARCH_FOR_RW is defined. Make sure your property getters and setter are defined one after the other!");
+#endif
+                using member_types = typename type_descriptor<typename ReadableMember::declaring_type>::declared_member_types;
+                // Fallback to a slow linear search.
+                using property_types = typename trait::filter_t<trait::is_property, member_types>;
+                constexpr auto writable_properties = filter(property_types{}, detail::is_writable_p);
+                return find_one(writable_properties, display_name_equals_p<ReadableMember>);
+            }
+        } // namespace detail
+
+        /**
+         * Returns the display name of T.
+         * Uses the friendly_name of the property attribute, or the normalized name if no friendly_name was provided.
+         *
+         * \code{.cpp}
+         * struct Foo {
+         *   int get_foo() const;
+         *   int GetFoo() const;
+         *   int get_non_const() /missing const/;
+         *   int get_custom() const;
+         * };
+         * REFL_AUTO(
+         *   type(Foo),
+         *   func(get_foo, property()),
+         *   func(GetFoo, property()),
+         *   func(get_non_const, property()),
+         *   func(get_custom, property("value")),
+         * )
+         *
+         * get_display_name(get_t<0, member_list<Foo>>{}) -> "foo"
+         * get_display_name(get_t<1, member_list<Foo>>{}) -> "Foo"
+         * get_display_name(get_t<2, member_list<Foo>>{}) -> "get_non_const"
+         * get_display_name(get_t<3, member_list<Foo>>{}) -> "value"
+         * \endcode
+         */
+        template <typename Descriptor>
+        const char* get_display_name(Descriptor d) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            static const std::string name(detail::get_display_name(d));
+            return name.c_str();
+        }
+
+        /**
+         * Returns the display name of T as a const_string<N>.
+         * Uses the friendly_name of the property attribute, or the normalized name if no friendly_name was provided.
+         * @see get_display_name
+         */
+        template <typename Descriptor>
+        constexpr auto get_display_name_const(Descriptor d) noexcept
+        {
+            static_assert(trait::is_descriptor_v<Descriptor>);
+            return detail::get_display_name(d);
+        }
+
+        /**
+         * Checks if there exists a member that has the same display name as the one provied and is writable.
+         * For getter methods with a property attribute, the return value will be true if there exists a
+         * reflected setter method with a property with the same display name (property name normalization applies automatically).
+         * For fields, returns true only if the field is writable.
+         */
+        template <typename ReadableMember>
+        constexpr bool has_writer(ReadableMember member)
+        {
+            static_assert(is_writable(member) || is_property(member));
+            if constexpr (is_writable(member)) {
+                return true;
+            }
+            else {
+                [[maybe_unused]] constexpr auto match = [](auto m) {
+                    return is_property(m) && is_writable(m) && get_display_name_const(m) == get_display_name_const(ReadableMember{});
+                };
+
+                using member_types = typename type_descriptor<typename ReadableMember::declaring_type>::declared_member_types;
+                constexpr auto member_index = detail::get_member_index(member);
+
+                // Optimisation for the getter defined after setter pattern.
+                if constexpr (member_index != 0) {
+                    using likely_match = trait::get_t<member_index - 1, member_types>;
+                    if constexpr (match(likely_match{})) {
+                        return true;
+                    }
+                }
+
+                // Optimisation for the getter defined after setter pattern.
+                if constexpr (member_index != member_types::size - 1) {
+                    using likely_match = trait::get_t<member_index + 1, member_types>;
+                    if constexpr (match(likely_match{})) {
+                        return true;
+                    }
+                    else {
+                        return detail::has_writer_search(member);
+                    }
+                }
+                else {
+                    return detail::has_writer_search(member);
+                }
+            }
+        }
+
+        /**
+         * Checks if there exists a member that has the same display name as the one provied and is readable.
+         * For setter methods with a property attribute, the return value will be true if there exists a
+         * reflected getter method with a property with the same display name (property name normalization applies automatically).
+         * For fields, returns true.
+         */
+        template <typename WritableMember>
+        constexpr bool has_reader(WritableMember member)
+        {
+            static_assert(is_readable(member) || is_property(member));
+            if constexpr (is_readable(member)) {
+                return true;
+            }
+            else {
+                [[maybe_unused]] constexpr auto match = [](auto m) {
+                    return is_property(m) && is_readable(m) && get_display_name_const(m) == get_display_name_const(WritableMember{});
+                };
+
+                using member_types = typename type_descriptor<typename WritableMember::declaring_type>::declared_member_types;
+                constexpr auto member_index = detail::get_member_index(member);
+
+                // Optimisation for the getter defined after setter pattern.
+                if constexpr (member_index != member_types::size - 1) {
+                    using likely_match = trait::get_t<member_index + 1, member_types>;
+                    if constexpr (match(likely_match{})) {
+                        return true;
+                    }
+                }
+
+                // Optimisation for the getter defined after setter pattern.
+                if constexpr (member_index != 0) {
+                    using likely_match = trait::get_t<member_index - 1, member_types>;
+                    if constexpr (match(likely_match{})) {
+                        return true;
+                    }
+                    else {
+                        return detail::has_reader_search(member);
+                    }
+                }
+                else {
+                    return detail::has_reader_search(member);
+                }
+            }
+        }
+
+        /**
+         * Returns a member that has the same display name as the one provied and is writable.
+         * For getter methods with a property attribute, the return value will the
+         * reflected setter method with a property with the same display name (property name normalization applies automatically).
+         * For fields, returns the same descriptor if writable.
+         */
+        template <typename ReadableMember>
+        constexpr auto get_writer(ReadableMember member)
+        {
+            static_assert(is_writable(member) || is_property(member));
+            if constexpr (is_writable(member)) {
+                return member;
+            }
+            else if constexpr (has_writer(member)) {
+                constexpr auto match = [](auto m) {
+                    return is_property(m) && is_writable(m) && get_display_name_const(m) == get_display_name_const(ReadableMember{});
+                };
+
+                using member_types = typename type_descriptor<typename ReadableMember::declaring_type>::declared_member_types;
+                constexpr auto member_index = detail::get_member_index(member);
+
+                // Optimisation for the getter defined after setter pattern.
+                if constexpr (member_index != 0) {
+                    using likely_match = trait::get_t<member_index - 1, member_types>;
+                    if constexpr (match(likely_match{})) {
+                        return likely_match{};
+                    }
+                }
+
+                // Optimisation for the getter defined after setter pattern.
+                if constexpr (member_index != member_types::size - 1) {
+                    using likely_match = trait::get_t<member_index + 1, member_types>;
+                    if constexpr (match(likely_match{})) {
+                        return likely_match{};
+                    }
+                    else {
+                        return detail::get_writer_search(member);
+                    }
+                }
+                else {
+                    return detail::get_writer_search(member);
+                }
+            }
+            else {
+                static_assert(has_writer(member), "The property is not writable (could not find a setter method)!");
+            }
+        }
+
+        /**
+         * Returns a member that has the same display name as the one provied and is readable.
+         * For setter methods with a property attribute, the return value will be a
+         * reflected getter method with a property with the same display name (property name normalization applies automatically).
+         * For fields, returns the same descriptor.
+         */
+        template <typename WritableMember>
+        constexpr auto get_reader(WritableMember member)
+        {
+            static_assert(is_readable(member) || is_property(member));
+            if constexpr (is_readable(member)) {
+                return member;
+            }
+            else if constexpr (has_reader(member)) {
+                constexpr auto match = [](auto m) {
+                    return is_property(m) && is_readable(m) && get_display_name_const(m) == get_display_name_const(WritableMember{});
+                };
+
+                using member_types = typename type_descriptor<typename WritableMember::declaring_type>::declared_member_types;
+                constexpr auto member_index = detail::get_member_index(member);
+
+                // Optimisation for the getter defined after setter pattern.
+                if constexpr (member_index != member_types::size - 1) {
+                    using likely_match = trait::get_t<member_index + 1, member_types>;
+                    if constexpr (match(likely_match{})) {
+                        return likely_match{};
+                    }
+                }
+
+                // Optimisation for the getter defined after setter pattern.
+                if constexpr (member_index != 0) {
+                    using likely_match = trait::get_t<member_index - 1, member_types>;
+                    if constexpr (match(likely_match{})) {
+                        return likely_match{};
+                    }
+                    else {
+                        return detail::get_reader_search(member);
+                    }
+                }
+                else {
+                    return detail::get_reader_search(member);
+                }
+            }
+            else {
+                static_assert(has_reader(member), "The property is not readable (could not find a getter method)!");
+            }
+        }
+
+    } // namespace descriptor
+
+    using descriptor::member_list;
+    using descriptor::declared_member_list;
+    using descriptor::field_descriptor;
+    using descriptor::function_descriptor;
+    using descriptor::type_descriptor;
+
+    /** Returns true if the type T is reflectable. */
+    template <typename T>
+    constexpr bool is_reflectable() noexcept
+    {
+        return trait::is_reflectable_v<T>;
+    }
+
+    /** Returns true if the non-qualified type T is reflectable.*/
+    template <typename T>
+    constexpr bool is_reflectable(const T&) noexcept
+    {
+        return trait::is_reflectable_v<T>;
+    }
+
+    /** Returns the type descriptor for the type T. */
+    template<typename T>
+    constexpr type_descriptor<T> reflect() noexcept
+    {
+        return {};
+    }
+
+    /** Returns the type descriptor for the non-qualified type T. */
+    template<typename T>
+    constexpr type_descriptor<T> reflect(const T&) noexcept
+    {
+        return {};
+    }
+
+#ifndef REFL_DETAIL_FORCE_EBO
+#ifdef _MSC_VER
+#define REFL_DETAIL_FORCE_EBO __declspec(empty_bases)
+#else
+#define REFL_DETAIL_FORCE_EBO
+#endif
+#endif
+
+    /**
+     * @brief Contains utilities that can have runtime-overhead (like proxy, debug, invoke)
+     */
+    namespace runtime
+    {
+        template <typename Derived, typename Target>
+        struct REFL_DETAIL_FORCE_EBO proxy;
+
+        namespace detail
+        {
+            template <typename T>
+            struct get_member_info;
+
+            template <typename T, size_t N>
+            struct get_member_info<refl::function_descriptor<T, N>>
+            {
+                using type = refl::detail::member_info<T, N>;
+            };
+
+            template <typename T, size_t N>
+            struct get_member_info<refl::field_descriptor<T, N>>
+            {
+                using type = refl::detail::member_info<T, N>;
+            };
+
+            template <typename T, typename U>
+            constexpr T& static_ref_cast(U& value) noexcept
+            {
+                return static_cast<T&>(value);
+            }
+
+            template <typename T, typename U>
+            constexpr const T& static_ref_cast(const U& value) noexcept
+            {
+                return static_cast<const T&>(value);
+            }
+
+            template <typename... Results>
+            constexpr type_list<Results...> get_members_skip_shadowed(type_list<>, type_list<Results...>)
+            {
+                return {};
+            }
+
+            template <typename Member, typename... Members, typename... Results>
+            constexpr auto get_members_skip_shadowed(type_list<Member, Members...>, type_list<Results...>)
+            {
+                if constexpr ((... || (Results::name == Member::name))) {
+                    return get_members_skip_shadowed(type_list<Members...>{}, type_list<Results...>{});
+                }
+                else {
+                    return get_members_skip_shadowed(type_list<Members...>{}, type_list<Results..., Member>{});
+                }
+            }
+
+            template <typename T>
+            using members_skip_shadowed = decltype(get_members_skip_shadowed(member_list<T>{}, type_list<>{}));
+
+            /** Implements a proxy for a reflected function. */
+            template <typename Derived, typename Func>
+            struct REFL_DETAIL_FORCE_EBO function_proxy : public get_member_info<Func>::type::template remap<function_proxy<Derived, Func>>
+            {
+                function_proxy()
+                {
+                }
+
+                template <typename Self, typename... Args>
+                static constexpr decltype(auto) invoke_impl(Self&& self, Args&& ... args)
+                {
+                    return Derived::template invoke_impl<Func>(static_ref_cast<Derived>(self), std::forward<Args>(args)...);
+                }
+            };
+
+            template <typename, typename>
+            struct REFL_DETAIL_FORCE_EBO function_proxies;
+
+            /** Implements a proxy for all reflected functions. */
+            template <typename Derived, typename... Members>
+            struct REFL_DETAIL_FORCE_EBO function_proxies<Derived, type_list<Members...>> : public function_proxy<Derived, Members>...
+            {
+            };
+
+            /** Implements a proxy for a reflected field. */
+            template <typename Derived, typename Field>
+            struct REFL_DETAIL_FORCE_EBO field_proxy : public get_member_info<Field>::type::template remap<field_proxy<Derived, Field>>
+            {
+                field_proxy()
+                {
+                }
+
+                template <typename Self, typename... Args>
+                static constexpr decltype(auto) invoke_impl(Self&& self, Args&& ... args)
+                {
+                    return Derived::template invoke_impl<Field>(static_ref_cast<Derived>(self), std::forward<Args>(args)...);
+                }
+            };
+
+
+            template <typename, typename>
+            struct REFL_DETAIL_FORCE_EBO field_proxies;
+
+            /** Implements a proxy for all reflected fields. */
+            template <typename Derived, typename... Members>
+            struct REFL_DETAIL_FORCE_EBO field_proxies<Derived, type_list<Members...>> : public field_proxy<Derived, Members>...
+            {
+            };
+
+            template <typename T>
+            using functions = trait::filter_t<trait::is_function, members_skip_shadowed<T>>;
+
+            template <typename T>
+            using fields = trait::filter_t<trait::is_field, members_skip_shadowed<T>>;
+
+        } // namespace detail
+
+        /**
+         * @brief A proxy object that has a static interface identical to the reflected functions and fields of the target.
+         *
+         * A proxy object that has a static interface identical to the reflected functions and fields of the target.
+         * Users should inherit from this class and specify an invoke_impl(Member member, Args&&... args) function.
+         *
+         * # Examples:
+         * \code{.cpp}
+         * template <typename T>
+         * struct dummy_proxy : refl::runtime::proxy<dummy_proxy<T>, T> {
+         *     template <typename Member, typename Self, typename... Args>
+         *     static int invoke_impl(Self&& self, Args&&... args) {
+         *          std::cout << get_debug_name(Member()) << " called with " << sizeof...(Args) << " parameters!\n";
+         *          return 0;
+         *     }
+         * };
+         * \endcode
+         */
+        template <typename Derived, typename Target>
+        struct REFL_DETAIL_FORCE_EBO proxy
+            : public detail::function_proxies<proxy<Derived, Target>, detail::functions<Target>>
+            , public detail::field_proxies<proxy<Derived, Target>, detail::fields<Target>>
+        {
+            static_assert(
+                sizeof(detail::function_proxies<proxy<Derived, Target>, detail::functions<Target>>) == 1 &&
+                sizeof(detail::field_proxies<proxy<Derived, Target>, detail::fields<Target>>) == 1,
+                "Multiple inheritance EBO did not kick in! "
+                "You could try defining the REFL_DETAIL_FORCE_EBO macro appropriately to enable it on the required types. "
+                "Default for MSC is `__declspec(empty_bases)`.");
+
+            static_assert(
+                trait::is_reflectable_v<Target>,
+                "Target type must be reflectable!");
+
+            typedef Target target_type;
+
+            constexpr proxy() noexcept {}
+
+        private:
+
+            template <typename P, typename F>
+            friend struct detail::function_proxy;
+
+            template <typename P, typename F>
+            friend struct detail::field_proxy;
+
+            // Called by one of the function_proxy/field_proxy bases.
+            template <typename Member, typename Self, typename... Args>
+            static constexpr decltype(auto) invoke_impl(Self&& self, Args&& ... args)
+            {
+                return Derived::template invoke_impl<Member>(detail::static_ref_cast<Derived>(self), std::forward<Args>(args)...);
+            }
+
+        };
+
+    } // namespace runtime
+
+    namespace trait
+    {
+        template <typename>
+        struct is_proxy;
+
+        template <typename T>
+        struct is_proxy
+        {
+        private:
+            template <typename Derived, typename Target>
+            static std::true_type test(runtime::proxy<Derived, Target>*);
+            static std::false_type test(...);
+        public:
+            static constexpr bool value{ !std::is_reference_v<T> && decltype(test(std::declval<remove_qualifiers_t<T>*>()))::value };
+        };
+
+        template <typename T>
+        [[maybe_unused]] static constexpr bool is_proxy_v{ is_proxy<T>::value };
+    }
+
+    namespace runtime
+    {
+        template <typename CharT, typename T>
+        void debug(std::basic_ostream<CharT>& os, const T& value, bool compact = false);
+
+        namespace detail
+        {
+            template <typename CharT, typename T, typename = decltype(std::declval<std::basic_ostream<CharT>&>() << std::declval<T>())>
+            std::true_type is_ostream_printable_test(int);
+
+            template <typename CharT, typename T>
+            std::false_type is_ostream_printable_test(...);
+
+            template <typename CharT, typename T>
+            constexpr bool is_ostream_printable_v{ decltype(is_ostream_printable_test<CharT, T>(0))::value };
+
+            namespace
+            {
+                [[maybe_unused]] int next_depth(int depth)
+                {
+                    return depth == -1 || depth > 8
+                        ? -1
+                        : depth + 1;
+                }
+            }
+
+            template <typename CharT>
+            void indent(std::basic_ostream<CharT>& os, int depth)
+            {
+                for (int i = 0; i < depth; i++) {
+                    os << "    ";
+                }
+            }
+
+            template <typename CharT, typename T>
+            void debug_impl(std::basic_ostream<CharT>& os, const T& value, [[maybe_unused]] int depth);
+
+            template <typename CharT, typename T>
+            void debug_detailed(std::basic_ostream<CharT>& os, const T& value, int depth)
+            {
+                using type_descriptor = type_descriptor<T>;
+                bool compact = depth == -1;
+                // print type with members enclosed in braces
+                os << type_descriptor::name << " { ";
+                if (!compact) os << '\n';
+
+                constexpr auto readable_members = filter(type_descriptor::members, [](auto member) { return is_readable(member); });
+                for_each(readable_members, [&](auto member, [[maybe_unused]] auto index) {
+                    int new_depth = next_depth(depth);
+
+                    indent(os, new_depth);
+                    os << get_display_name(member) << " = ";
+
+                    if constexpr (util::contains_instance<attr::debug>(member.attributes)) {
+                        // use the debug attribute to print
+                        auto debug_attr = util::get_instance<attr::debug>(member.attributes);
+                        debug_attr.write(os, value);
+                    }
+                    else {
+                        debug_impl(os, member(value), new_depth);
+                    }
+
+                    if (!compact || index + 1 != readable_members.size) {
+                        os << ", ";
+                    }
+                    if (!compact) {
+                        indent(os, depth);
+                        os << '\n';
+                    }
+                });
+
+                if (compact) os << ' ';
+                indent(os, depth);
+                os << '}';
+            }
+
+            template <typename CharT, typename T>
+            void debug_reflectable(std::basic_ostream<CharT>& os, const T& value, [[maybe_unused]] int depth)
+            {
+                using type_descriptor = type_descriptor<T>;
+                if constexpr (trait::contains_instance_v<attr::debug, typename type_descriptor::attribute_types>) {
+                    // use the debug attribute to print
+                    auto debug_attr = util::get_instance<attr::debug>(type_descriptor::attributes);
+                    debug_attr.write(os, value);
+                }
+                else if constexpr (detail::is_ostream_printable_v<CharT, T>) {
+                    // type supports printing natively, just use that
+                    os << value;
+                }
+                else {
+                    debug_detailed(os, value, depth);
+                }
+            }
+
+            template <typename CharT, typename T>
+            void debug_container(std::basic_ostream<CharT>& os, const T& value, int depth)
+            {
+                bool compact = depth == -1;
+                os << "[";
+
+                auto end = value.end();
+                for (auto it = value.begin(); it != end; ++it)
+                {
+                    if (!compact) os << '\n';
+                    int new_depth = next_depth(depth);
+                    indent(os, new_depth);
+
+                    debug_impl(os, *it, new_depth);
+                    if (std::next(it, 1) != end) {
+                        os << ", ";
+                    }
+                    else if (!compact) {
+                        os << '\n';
+                    }
+                }
+
+                indent(os, depth);
+                os << "]";
+            }
+
+            template <typename CharT, typename T>
+            void debug_impl(std::basic_ostream<CharT>& os, const T& value, [[maybe_unused]] int depth)
+            {
+                using no_pointer_t = std::remove_pointer_t<T>;
+
+                if constexpr (std::is_same_v<bool, T>) {
+                    os << (value ? "true" : "false");
+                }
+                else if constexpr (std::is_pointer_v<T> && !std::is_void_v<no_pointer_t> && trait::is_reflectable_v<no_pointer_t>) {
+                    if (value == nullptr) {
+                        os << "nullptr";
+                    }
+                    else {
+                        os << '&';
+                        debug_impl(os, *value, -1);
+                    }
+                }
+                else if constexpr (trait::is_reflectable_v<T>) {
+                    debug_reflectable(os, value, depth);
+                }
+                else if constexpr (detail::is_ostream_printable_v<CharT, T>) {
+                    os << value;
+                }
+                else if constexpr (trait::is_container_v<T>) {
+                    debug_container(os, value, depth);
+                }
+                else {
+                    os << "(not printable)";
+                }
+            }
+        }
+
+        /**
+         * Writes the debug representation of value to the given std::ostream.
+         * Calls the function specified by the debug<F> attribute whenever possible,
+         * before falling back to recursively interating the members and printing them.
+         * Takes an optional arguments specifying whether to print a compact representation.
+         * The compact representation contains no newlines.
+         */
+        template <typename CharT, typename T>
+        void debug(std::basic_ostream<CharT>& os, const T& value, [[maybe_unused]] bool compact)
+        {
+            static_assert(trait::is_reflectable_v<T> || trait::is_container_v<T> || detail::is_ostream_printable_v<CharT, T>,
+                "Type is not reflectable, not a container of reflectable types and does not support operator<<(std::ostream&, T)!");
+
+            detail::debug_impl(os, value, compact ? -1 : 0);
+        }
+
+        /**
+         * Writes the compact debug representation of the provided values to the given std::ostream.
+         */
+        template <typename CharT, typename... Ts>
+        void debug_all(std::basic_ostream<CharT>& os, const Ts&... values)
+        {
+            refl::runtime::debug(os, std::forward_as_tuple(static_cast<const Ts&>(values)...), true);
+        }
+
+        /**
+         * Writes the debug representation of the provided value to an std::string and returns it.
+         * Takes an optional arguments specifying whether to print a compact representation.
+         * The compact representation contains no newlines.
+         */
+        template <typename CharT = char, typename T>
+        std::basic_string<CharT> debug_str(const T& value, bool compact = false)
+        {
+            std::basic_stringstream<CharT> ss;
+            debug(ss, value, compact);
+            return ss.str();
+        }
+
+        /**
+         * Writes the compact debug representation of the provided values to an std::string and returns it.
+         */
+        template <typename CharT = char, typename... Ts>
+        std::basic_string<CharT> debug_all_str(const Ts&... values)
+        {
+            return refl::runtime::debug_str(std::forward_as_tuple(static_cast<const Ts&>(values)...), true);
+        }
+
+        /**
+         * Invokes the specified member with the provided arguments.
+         * When used with a member that is a field, the function gets or sets the value of the field.
+         * The list of members is initially filtered by the type of the arguments provided.
+         * THe filtered list is then searched at runtime by member name for the specified member
+         * and that member is then invoked by operator(). If no match is found,
+         * an std::runtime_error is thrown.
+         */
+        template <typename U, typename T, typename... Args>
+        U invoke(T&& target, const char* name, Args&&... args)
+        {
+            using type = std::remove_reference_t<T>;
+            static_assert(refl::trait::is_reflectable_v<type>, "Unsupported type!");
+            typedef type_descriptor<type> type_descriptor;
+
+            std::conditional_t<std::is_void_v<U>, bool, std::optional<U>> result{};
+
+            for_each(type_descriptor::members, [&](auto member) {
+                using member_t = decltype(member);
+                if (result) return;
+
+                if constexpr (std::is_invocable_r_v<U, decltype(member), T, Args...>) {
+                    if constexpr (trait::is_member_v<member_t>) {
+                        if (std::strcmp(member.name.c_str(), name) == 0) {
+                            if constexpr (std::is_void_v<U>) {
+                                member(target, std::forward<Args>(args)...);
+                                result = true;
+                            }
+                            else {
+                                result.emplace(member(target, std::forward<Args>(args)...));
+                            }
+                        }
+                    }
+                }
+            });
+
+            if (!result) {
+                throw std::runtime_error(std::string("The member ")
+                    + type_descriptor::name.str() + "::" + name
+                    + " is not compatible with the provided parameters or return type, is not reflected or does not exist!");
+            }
+            if constexpr (!std::is_void_v<U>) {
+                return std::move(*result);
+            }
+        }
+
+    } // namespace runtime
+
+} // namespace refl
+
+namespace refl::detail
+{
+    constexpr bool validate_attr_unique(type_list<>) noexcept
+    {
+        return true;
+    }
+
+    /** Statically asserts that all types in Ts... are unique. */
+    template <typename T, typename... Ts>
+    constexpr bool validate_attr_unique(type_list<T, Ts...>) noexcept
+    {
+        constexpr bool cond = (... && (!std::is_same_v<T, Ts> && validate_attr_unique(type_list<Ts>{})));
+        static_assert(cond, "Some of the attributes provided have duplicate types!");
+        return cond;
+    }
+
+    template <typename Req, typename Attr>
+    constexpr bool validate_attr_usage() noexcept
+    {
+        return std::is_base_of_v<Req, Attr>;
+    }
+
+    /**
+     * Statically asserts that all arguments inherit
+     * from the appropriate bases to be used with Req.
+     * Req must be one of the types defined in attr::usage.
+     */
+    template <typename Req, typename... Args>
+    constexpr auto make_attributes(Args&&... args) noexcept
+    {
+        constexpr bool check_unique = validate_attr_unique(type_list<Args...>{});
+        static_assert(check_unique, "Some of the supplied attributes cannot be used on this declaration!");
+
+        constexpr bool check_usage = (... && validate_attr_usage<Req, trait::remove_qualifiers_t<Args>>());
+        static_assert(check_usage, "Some of the supplied attributes cannot be used on this declaration!");
+
+        return std::make_tuple(std::forward<Args>(args)...);
+    }
+
+    template <typename T, typename...>
+    struct head
+    {
+        typedef T type;
+    };
+
+    /**
+     * Accesses the first type T of Ts...
+     * Used to allow for SFIANE to kick in in the implementation of REFL_FUNC.
+     */
+    template <typename T, typename... Ts>
+    using head_t = typename head<T, Ts...>::type;
+
+    template <typename T, typename U>
+    struct transfer_const
+    {
+        using type = std::conditional_t<std::is_const_v<T>, std::add_const_t<U>, U>;
+    };
+
+    template <typename T, typename U>
+    struct transfer_volatile
+    {
+        using type = std::conditional_t<std::is_volatile_v<T>, std::add_volatile_t<U>, U>;
+    };
+
+    template <typename T, typename U>
+    struct transfer_cv : transfer_const<T, typename transfer_volatile<T, U>::type>
+    {
+    };
+
+    template <typename T, typename U>
+    struct transfer_lvalue_ref
+    {
+        using type = std::conditional_t<std::is_lvalue_reference_v<T>, std::add_lvalue_reference_t<U>, U>;
+    };
+
+    template <typename T, typename U>
+    struct transfer_rvalue_ref
+    {
+        using type = std::conditional_t<std::is_rvalue_reference_v<T>, std::add_rvalue_reference_t<U>, U>;
+    };
+
+    template <typename T, typename U>
+    struct transfer_ref : transfer_rvalue_ref<T, typename transfer_lvalue_ref<T, U>::type>
+    {
+    };
+
+    template <typename T, typename U>
+    struct transfer_cvref : transfer_ref<T, typename transfer_cv<std::remove_reference_t<T>, U>::type>
+    {
+    };
+
+    template <typename T, typename U>
+    constexpr auto forward_cast(std::remove_reference_t<T>& t) -> decltype(static_cast<typename transfer_cvref<T, U>::type&&>(t))
+    {
+        return static_cast<typename transfer_cvref<T, U>::type&&>(t);
+    }
+
+    template <typename T, typename U>
+    constexpr auto forward_cast(std::remove_reference_t<T>&& t) -> decltype(static_cast<typename transfer_cvref<T, U>::type&&>(t))
+    {
+        static_assert(!std::is_lvalue_reference_v<T>, "template argument substituting T is an lvalue reference type");
+        return static_cast<typename transfer_cvref<T, U>::type&&>(t);
+    }
+
+    template <typename T>
+    constexpr auto get_type_name()
+    {
+        if constexpr (trait::is_reflectable_v<T>) {
+            return type_descriptor<T>::name;
+        }
+        else {
+            return make_const_string("(unknown)");
+        }
+    }
+
+} // namespace refl::detail
+
+/********************************/
+/*  Metadata-generation macros  */
+/********************************/
+
+#define REFL_DETAIL_STR_IMPL(...) #__VA_ARGS__
+/** Used to stringify input separated by commas (e.g. template specializations with multiple types). */
+#define REFL_DETAIL_STR(...) REFL_DETAIL_STR_IMPL(__VA_ARGS__)
+/** Used to group input containing commas (e.g. template specializations with multiple types). */
+#define REFL_DETAIL_GROUP(...) __VA_ARGS__
+
+/**
+ * Expands to the appropriate attributes static member variable.
+ * DeclType must be the name of one of the constraints defined in attr::usage.
+ * __VA_ARGS__ is the list of attributes.
+ */
+#define REFL_DETAIL_ATTRIBUTES(DeclType, ...) \
+        static constexpr auto attributes{ ::refl::detail::make_attributes<::refl::attr::usage:: DeclType>(__VA_ARGS__) }; \
+
+/**
+ * Expands to the body of a type_info__ specialization.
+ */
+#define REFL_DETAIL_TYPE_BODY(TypeName, ...) \
+        typedef REFL_DETAIL_GROUP TypeName type; \
+        REFL_DETAIL_ATTRIBUTES(type, __VA_ARGS__) \
+        static constexpr auto name{ ::refl::util::make_const_string(REFL_DETAIL_STR(REFL_DETAIL_GROUP TypeName)) }; \
+        static constexpr size_t member_index_offset = __COUNTER__ + 1; \
+        template <size_t, typename = void> \
+        struct member {};
+
+/**
+ * Creates reflection information for a specified type. Takes an optional attribute list.
+ * This macro must only be expanded in the global namespace.
+ *
+ * # Examples:
+ * ```
+ * REFL_TYPE(Point)
+ * ...
+ * REFL_END
+ * ```
+ */
+#define REFL_TYPE(TypeName, ...) \
+    namespace refl_impl::metadata { template<> struct type_info__<TypeName> { \
+        REFL_DETAIL_TYPE_BODY((TypeName), __VA_ARGS__)
+
+/**
+ * Creates reflection information for a specified type template. Takes an optional attribute list.
+ * TemplateDeclaration must be a panenthesis-enclosed list declaring the template parameters. (e.g. (typename A, typename B)).
+ * TypeName must be the fully-specialized type name and should also be enclosed in panenthesis. (e.g. (MyType<A, B>))
+ * This macro must only be expanded in the global namespace.
+ *
+ * # Examples:
+ * ```
+ * REFL_TEMPLATE((typename T), (std::vector<T>))
+ * ...
+ * REFL_END
+ * ```
+ */
+#define REFL_TEMPLATE(TemplateDeclaration, TypeName, ...) \
+    namespace refl_impl::metadata { template <REFL_DETAIL_GROUP TemplateDeclaration> struct type_info__<REFL_DETAIL_GROUP TypeName> { \
+        REFL_DETAIL_TYPE_BODY(TypeName, __VA_ARGS__)
+
+/**
+ * Terminated the declaration of reflection metadata for a particular type.
+ *
+ * # Examples:
+ * ```
+ * REFL_TYPE(Point)
+ * ...
+ * REFL_END
+ */
+#define REFL_END \
+        static constexpr size_t member_count{ __COUNTER__ - member_index_offset }; \
+    }; }
+
+#define REFL_DETAIL_MEMBER_HEADER template<typename Unused__> struct member<__COUNTER__ - member_index_offset, Unused__>
+
+#define REFL_DETAIL_MEMBER_COMMON(MemberType_, MemberName_, ...) \
+        typedef ::refl::member::MemberType_ member_type; \
+        static constexpr auto name{ ::refl::util::make_const_string(REFL_DETAIL_STR(MemberName_)) }; \
+        REFL_DETAIL_ATTRIBUTES(MemberType_, __VA_ARGS__)
+
+/** Creates the support infrastructure needed for the refl::runtime::proxy type. */
+/*
+    There can be a total of 12 differently qualified member functions with the same name.
+    Providing remaps for non-const and const-only strikes a balance between compilation time and usability.
+    And even though there are many other remap implementation possibilities (like virtual, field variants),
+    adding them was considered to not be efficient from a compilation-time point of view.
+*/
+#define REFL_DETAIL_MEMBER_PROXY(MemberName_) \
+        template <typename Proxy> struct remap { \
+            template <typename... Args> decltype(auto) MemberName_(Args&&... args) { \
+                return Proxy::invoke_impl(static_cast<Proxy&>(*this), ::std::forward<Args>(args)...); \
+            } \
+            template <typename... Args> decltype(auto) MemberName_(Args&&... args) const { \
+                return Proxy::invoke_impl(static_cast<const Proxy&>(*this), ::std::forward<Args>(args)...); \
+            } \
+        }
+
+/**
+ * Creates reflection information for a public field. Takes an optional attribute list.
+ */
+#define REFL_FIELD(FieldName_, ...) \
+    REFL_DETAIL_MEMBER_HEADER { \
+        REFL_DETAIL_MEMBER_COMMON(field, FieldName_, __VA_ARGS__) \
+    public: \
+        typedef decltype(type::FieldName_) value_type; \
+        static constexpr auto pointer{ &type::FieldName_ }; \
+        REFL_DETAIL_MEMBER_PROXY(FieldName_); \
+    };
+
+/**
+ * Creates reflection information for a public functions. Takes an optional attribute list.
+ */
+#define REFL_FUNC(FunctionName_, ...) \
+    REFL_DETAIL_MEMBER_HEADER { \
+        REFL_DETAIL_MEMBER_COMMON(function, FunctionName_, __VA_ARGS__) \
+        public: \
+        template<typename Self, typename... Args> static constexpr auto invoke(Self&& self, Args&&... args) -> decltype(::refl::detail::forward_cast<Self, type>(self).FunctionName_(::std::forward<Args>(args)...)) {\
+            return ::refl::detail::forward_cast<Self, type>(self).FunctionName_(::std::forward<Args>(args)...); \
+        } \
+        template<typename... Args> static constexpr auto invoke(Args&&... args) -> decltype(::refl::detail::head_t<type, Args...>::FunctionName_(::std::declval<Args>()...)) { \
+            return ::refl::detail::head_t<type, Args...>::FunctionName_(::std::forward<Args>(args)...); \
+        } \
+        template <typename Dummy = void> \
+        static constexpr auto pointer() -> decltype(&::refl::detail::head_t<type, Dummy>::FunctionName_) { return &::refl::detail::head_t<type, Dummy>::FunctionName_; } \
+        template <typename Pointer> \
+        static constexpr auto resolve() -> ::std::decay_t<decltype(Pointer(&type::FunctionName_))> { return Pointer(&type::FunctionName_); } \
+        REFL_DETAIL_MEMBER_PROXY(FunctionName_); \
+    };
+
+/********************************/
+/*  Default Reflection Metadata */
+/********************************/
+
+#define REFL_DETAIL_PRIMITIVE(TypeName) \
+    REFL_TYPE(TypeName) \
+    REFL_END
+
+    // Char types.
+    REFL_DETAIL_PRIMITIVE(char)
+    REFL_DETAIL_PRIMITIVE(wchar_t)
+    REFL_DETAIL_PRIMITIVE(char16_t)
+    REFL_DETAIL_PRIMITIVE(char32_t)
+#ifdef __cpp_lib_char8_t
+    REFL_DETAIL_PRIMITIVE(char8_t)
+#endif
+
+    // Integral types.
+    REFL_DETAIL_PRIMITIVE(bool)
+    REFL_DETAIL_PRIMITIVE(signed char)
+    REFL_DETAIL_PRIMITIVE(unsigned char)
+    REFL_DETAIL_PRIMITIVE(signed short)
+    REFL_DETAIL_PRIMITIVE(unsigned short)
+    REFL_DETAIL_PRIMITIVE(signed int)
+    REFL_DETAIL_PRIMITIVE(unsigned int)
+    REFL_DETAIL_PRIMITIVE(signed long)
+    REFL_DETAIL_PRIMITIVE(unsigned long)
+    REFL_DETAIL_PRIMITIVE(signed long long)
+    REFL_DETAIL_PRIMITIVE(unsigned long long)
+
+    // Floating point types.
+    REFL_DETAIL_PRIMITIVE(float)
+    REFL_DETAIL_PRIMITIVE(double)
+    REFL_DETAIL_PRIMITIVE(long double)
+
+    // Other types.
+    REFL_DETAIL_PRIMITIVE(decltype(nullptr))
+
+    // Void type.
+    REFL_TYPE(void)
+    REFL_END
+
+#undef REFL_DETAIL_PRIMITIVE
+
+#define REFL_DETAIL_POINTER(Ptr) \
+        template<typename T> \
+        struct type_info__<T Ptr> { \
+            typedef T Ptr type; \
+            template <size_t N> \
+            struct member {}; \
+            static constexpr auto name{ ::refl::detail::get_type_name<T>() + ::refl::util::make_const_string(#Ptr) }; \
+            static constexpr ::std::tuple<> attributes{ }; \
+            static constexpr size_t member_count{ 0 }; \
+        }
+
+    namespace refl_impl
+    {
+        namespace metadata
+        {
+            REFL_DETAIL_POINTER(*);
+            REFL_DETAIL_POINTER(&);
+            REFL_DETAIL_POINTER(&&);
+        }
+    }
+
+#undef REFL_DETAIL_POINTER
+
+namespace refl::detail
+{
+    template <typename CharT>
+    std::basic_string<CharT> convert(const std::string& str)
+    {
+        return std::basic_string<CharT>(str.begin(), str.end());
+    }
+
+#ifdef __cpp_lib_string_view
+    struct write_basic_string_view
+    {
+        template <typename CharT, typename Traits>
+        void operator()(std::basic_ostream<CharT>& os, std::basic_string_view<CharT, Traits> str) const
+        {
+            // some vers of clang dont have std::quoted(string_view) overload
+            if (!str.back()) { // no copy needed when null-terminated
+                os << std::quoted(str.data());
+            }
+            else {
+                os << std::quoted(std::basic_string<CharT, Traits>(str.begin(), str.end()));
+            }
+        }
+    };
+#endif
+
+    struct write_basic_string
+    {
+        template <typename CharT, typename Traits, typename Allocator>
+        void operator()(std::basic_ostream<CharT>& os, const std::basic_string<CharT, Traits, Allocator>& str) const
+        {
+            os << std::quoted(str);
+        }
+    };
+
+    struct write_exception
+    {
+        template <typename CharT>
+        void operator()(std::basic_ostream<CharT>& os, const std::exception& e) const
+        {
+            os << convert<CharT>("Exception");
+    #ifdef REFL_RTTI_ENABLED
+            os << convert<CharT>(" (") << convert<CharT>(typeid(e).name()) << convert<CharT>(")");
+    #endif
+            os << convert<CharT>(": `") << e.what() << convert<CharT>("`");
+        }
+    };
+
+    struct write_tuple
+    {
+        template <typename CharT, typename Tuple, size_t... Idx>
+        void write(std::basic_ostream<CharT>& os, Tuple&& t, std::index_sequence<Idx...>) const
+        {
+            os << CharT('(');
+            for_each(type_list<std::integral_constant<size_t, Idx>...>{}, [&](auto idx_c) {
+                using idx_t = decltype(idx_c);
+                runtime::debug(os, std::get<idx_t::value>(t));
+                if constexpr (sizeof...(Idx) - 1 != idx_t::value) {
+                    os << convert<CharT>(", ");
+                }
+            });
+            os << CharT(')');
+        }
+
+        template <typename CharT, typename... Ts>
+        void operator()(std::basic_ostream<CharT>& os, const std::tuple<Ts...>& t) const
+        {
+            write(os, t, std::make_index_sequence<sizeof...(Ts)>{});
+        }
+    };
+
+    struct write_pair
+    {
+        template <typename CharT, typename K, typename V>
+        void operator()(std::basic_ostream<CharT>& os, const std::pair<K, V>& t) const
+        {
+            os << CharT('(');
+            runtime::debug(os, t.first);
+            os << convert<CharT>(", ");
+            runtime::debug(os, t.second);
+            os << CharT(')');
+        }
+    };
+
+    struct write_unique_ptr
+    {
+        template <typename CharT, typename T, typename D>
+        void operator()(std::basic_ostream<CharT>& os, const std::unique_ptr<T, D>& t) const
+        {
+            runtime::debug(os, t.get(), true);
+        }
+    };
+
+    struct write_shared_ptr
+    {
+        template <typename CharT, typename T>
+        void operator()(std::basic_ostream<CharT>& os, const std::shared_ptr<T>& t) const
+        {
+            runtime::debug(os, t.get(), true);
+        }
+    };
+
+    struct write_weak_ptr
+    {
+        template <typename CharT, typename T>
+        void operator()(std::basic_ostream<CharT>& os, const std::weak_ptr<T>& t) const
+        {
+            runtime::debug(os, t.lock().get(), true);
+        }
+    };
+
+    struct write_complex
+    {
+        template <typename CharT, typename T>
+        void operator()(std::basic_ostream<CharT>& os, const std::complex<T>& t) const
+        {
+            runtime::debug(os, t.real());
+            os << CharT('+');
+            runtime::debug(os, t.imag());
+            os << CharT('i');
+        }
+    };
+} // namespace refl::detail
+
+// Custom reflection information for
+// some common built-in types (std::basic_string, std::tuple, std::pair).
+
+#ifndef REFL_NO_STD_SUPPORT
+
+REFL_TYPE(std::exception, debug{ refl::detail::write_exception() })
+    REFL_FUNC(what, property{ })
+REFL_END
+
+REFL_TEMPLATE(
+    (typename Elem, typename Traits, typename Alloc),
+    (std::basic_string<Elem, Traits, Alloc>),
+    debug{ refl::detail::write_basic_string() })
+    REFL_FUNC(size, property{ })
+    REFL_FUNC(data, property{ })
+REFL_END
+
+#ifdef __cpp_lib_string_view
+
+REFL_TEMPLATE(
+    (typename Elem, typename Traits),
+    (std::basic_string_view<Elem, Traits>),
+    debug{ refl::detail::write_basic_string_view() })
+    REFL_FUNC(size, property{ })
+    REFL_FUNC(data, property{ })
+REFL_END
+
+#endif
+
+REFL_TEMPLATE(
+    (typename... Ts),
+    (std::tuple<Ts...>),
+    debug{ refl::detail::write_tuple() })
+REFL_END
+
+REFL_TEMPLATE(
+    (typename T, typename D),
+    (std::unique_ptr<T, D>),
+    debug{ refl::detail::write_unique_ptr() })
+REFL_END
+
+REFL_TEMPLATE(
+    (typename T),
+    (std::shared_ptr<T>),
+    debug{ refl::detail::write_shared_ptr() })
+REFL_END
+
+REFL_TEMPLATE(
+    (typename K, typename V),
+    (std::pair<K, V>),
+    debug{ refl::detail::write_pair() })
+REFL_END
+
+#ifndef REFL_NO_STD_COMPLEX
+
+REFL_TEMPLATE(
+    (typename T),
+    (std::complex<T>),
+    debug{ refl::detail::write_complex() })
+REFL_END
+
+#endif // !REFL_NO_STD_COMPLEX
+
+#endif // !REFL_NO_STD_SUPPORT
+
+#ifndef REFL_NO_AUTO_MACRO
+
+#define REFL_DETAIL_EXPAND(x) x
+#define REFL_DETAIL_FOR_EACH_0(...)
+#define REFL_DETAIL_FOR_EACH_1(what, x, ...) what(x)
+#define REFL_DETAIL_FOR_EACH_2(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_1(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_3(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_2(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_4(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_3(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_5(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_4(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_6(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_5(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_7(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_6(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_8(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_7(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_9(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_8(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_10(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_9(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_11(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_10(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_12(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_11(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_13(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_12(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_14(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_13(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_15(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_14(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_16(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_15(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_17(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_16(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_18(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_17(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_19(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_18(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_20(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_19(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_21(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_20(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_22(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_21(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_23(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_22(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_24(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_23(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_25(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_24(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_26(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_25(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_27(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_26(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_28(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_27(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_29(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_28(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_30(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_29(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_31(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_30(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_32(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_31(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_33(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_32(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_34(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_33(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_35(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_34(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_36(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_35(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_37(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_36(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_38(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_37(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_39(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_38(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_40(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_39(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_41(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_40(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_42(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_41(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_43(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_42(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_44(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_43(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_45(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_44(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_46(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_45(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_47(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_46(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_48(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_47(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_49(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_48(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_50(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_49(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_51(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_50(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_52(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_51(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_53(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_52(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_54(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_53(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_55(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_54(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_56(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_55(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_57(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_56(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_58(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_57(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_59(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_58(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_60(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_59(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_61(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_60(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_62(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_61(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_63(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_62(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_64(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_63(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_65(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_64(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_66(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_65(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_67(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_66(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_68(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_67(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_69(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_68(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_70(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_69(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_71(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_70(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_72(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_71(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_73(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_72(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_74(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_73(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_75(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_74(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_76(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_75(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_77(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_76(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_78(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_77(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_79(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_78(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_80(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_79(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_81(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_80(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_82(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_81(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_83(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_82(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_84(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_83(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_85(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_84(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_86(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_85(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_87(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_86(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_88(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_87(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_89(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_88(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_90(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_89(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_91(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_90(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_92(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_91(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_93(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_92(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_94(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_93(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_95(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_94(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_96(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_95(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_97(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_96(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_98(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_97(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_99(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_98(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_100(what, x, ...) what(x) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_99(what, __VA_ARGS__))
+
+#define REFL_DETAIL_FOR_EACH_NARG(...) REFL_DETAIL_FOR_EACH_NARG_(__VA_ARGS__, REFL_DETAIL_FOR_EACH_RSEQ_N())
+#define REFL_DETAIL_FOR_EACH_NARG_(...) REFL_DETAIL_EXPAND(REFL_DETAIL_FOR_EACH_ARG_N(__VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH_ARG_N(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63, _64, _65, _66, _67, _68, _69, _70, _71, _72, _73, _74, _75, _76, _77, _78, _79, _80, _81, _82, _83, _84, _85, _86, _87, _88, _89, _90, _91, _92, _93, _94, _95, _96, _97, _98, _99, _100, N, ...) N
+#define REFL_DETAIL_FOR_EACH_RSEQ_N() 100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+#define REFL_DETAIL_CONCATENATE(x, y) x##y
+#define REFL_DETAIL_FOR_EACH_(N, what, ...) REFL_DETAIL_EXPAND(REFL_DETAIL_CONCATENATE(REFL_DETAIL_FOR_EACH_, N)(what, __VA_ARGS__))
+#define REFL_DETAIL_FOR_EACH(what, ...) REFL_DETAIL_FOR_EACH_(REFL_DETAIL_FOR_EACH_NARG(__VA_ARGS__), what, __VA_ARGS__)
+
+// Intellisense does not work nicely with passing variadic parameters (for the attributes)
+// through all of the macro expansions and causes differently named member declarations to be
+// used during code inspection.
+#ifdef __INTELLISENSE__
+
+#define REFL_DETAIL_EX_1_type(X, ...) REFL_TYPE(X)
+#define REFL_DETAIL_EX_1_template(X, Y, ...) REFL_TEMPLATE(X, Y)
+#define REFL_DETAIL_EX_1_field(X, ...) REFL_FIELD(X)
+#define REFL_DETAIL_EX_1_func(X, ...) REFL_FUNC(X)
+
+#else // !defined(__INTELLISENSE__)
+
+#define REFL_DETAIL_EX_1_type(...) REFL_DETAIL_EX_EXPAND(REFL_DETAIL_EX_DEFER(REFL_TYPE)(__VA_ARGS__))
+#define REFL_DETAIL_EX_1_template(...) REFL_DETAIL_EX_EXPAND(REFL_DETAIL_EX_DEFER(REFL_TEMPLATE)(__VA_ARGS__))
+#define REFL_DETAIL_EX_1_field(...) REFL_DETAIL_EX_EXPAND(REFL_DETAIL_EX_DEFER(REFL_FIELD)(__VA_ARGS__))
+#define REFL_DETAIL_EX_1_func(...) REFL_DETAIL_EX_EXPAND(REFL_DETAIL_EX_DEFER(REFL_FUNC)(__VA_ARGS__))
+
+#endif // __INTELLISENSE__
+
+#define REFL_DETAIL_EX_(Specifier, ...) REFL_DETAIL_EX_1_##Specifier __VA_ARGS__
+
+#define REFL_DETAIL_EX_EMPTY()
+#define REFL_DETAIL_EX_DEFER(Id) Id REFL_DETAIL_EX_EMPTY()
+#define REFL_DETAIL_EX_EXPAND(...)  __VA_ARGS__
+
+#define REFL_DETAIL_EX_END() REFL_END
+
+#define REFL_AUTO(...) REFL_DETAIL_FOR_EACH(REFL_DETAIL_EX_, __VA_ARGS__) REFL_DETAIL_EX_EXPAND(REFL_DETAIL_EX_DEFER(REFL_DETAIL_EX_END)())
+
+#endif // !defined(REFL_NO_AUTO_MACRO)
+
+#endif // REFL_INCLUDE_HPP


### PR DESCRIPTION
### Inline header only dependencies to `./third_party/...` directory.

Presently only 'refl-cpp' and 'magic_enum' -- both expected to be replaced by C++26, for details see: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2996r0.html

Compiler warnings for these external dependencies are enabled by default but can be disabled by the `-DDISABLE_EXTERNAL_DEPS_WARNINGS=ON` cmake flag.

Replaced some custom [from, to] string<->enum by magic_enum ... more to follow. 

This PR focuses more on the CI, build mechanics, and coverage/sonar-line disabling for the inlined header-only libraries.