### PR TITLE
Implementation of FunctionGenerator class

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
@@ -1,0 +1,327 @@
+#ifndef GNURADIO_FUNCTION_GENERATOR_HPP
+#define GNURADIO_FUNCTION_GENERATOR_HPP
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/Tag.hpp>
+#include <magic_enum.hpp>
+#include <magic_enum_utility.hpp>
+#include <numbers>
+
+namespace gr::basic {
+
+using namespace gr;
+
+namespace function_generator {
+enum class SignalType : int { Const, LinearRamp, ParabolicRamp, CubicSpline, ImpulseResponse };
+// TODO: Enum values should be capitalized CamelStyle, for the moment they are the same as FunctionGenerator class members
+enum class ParameterType : int { signal_type, start_value, final_value, duration, round_off_time, impulse_time0, impulse_time1 };
+
+using enum SignalType;
+using enum ParameterType;
+constexpr auto SignalTypeList = magic_enum::enum_values<SignalType>();
+
+template<typename T>
+    requires std::is_same_v<T, SignalType> || std::is_same_v<T, ParameterType>
+constexpr std::string
+toString(T type) {
+    return std::string(magic_enum::enum_name(type));
+}
+
+template<typename EnumType, typename T>
+    requires std::is_same_v<EnumType, SignalType> || std::is_same_v<EnumType, ParameterType>
+[[nodiscard]] std::pair<std::string, pmtv::pmt>
+createPropertyMapEntry(EnumType enumType, T value) {
+    if constexpr (std::is_same_v<T, SignalType>) {
+        return { toString(enumType), static_cast<pmtv::pmt>(toString(value)) };
+    } else {
+        return { toString(enumType), static_cast<pmtv::pmt>(value) };
+    }
+}
+
+template<typename T>
+    requires std::is_same_v<T, SignalType> || std::is_same_v<T, ParameterType>
+constexpr T
+parse(std::string_view name) {
+    auto type = magic_enum::enum_cast<T>(name, magic_enum::case_insensitive);
+    if (!type.has_value()) {
+        throw std::invalid_argument(fmt::format("parser error, unknown function_generator::{} - '{}'", meta::type_name<T>(), name));
+    }
+    return type.value();
+}
+
+template<typename T>
+[[nodiscard]] property_map
+createConstPropertyMap(T startValue) {
+    return { createPropertyMapEntry(signal_type, Const), createPropertyMapEntry(start_value, startValue) };
+}
+
+template<typename T>
+[[nodiscard]] property_map
+createLinearRampPropertyMap(T startValue, T finalValue, T durationValue) {
+    return { createPropertyMapEntry(signal_type, LinearRamp), createPropertyMapEntry(start_value, startValue), createPropertyMapEntry(final_value, finalValue),
+             createPropertyMapEntry(duration, durationValue) };
+}
+
+template<typename T>
+[[nodiscard]] property_map
+createParabolicRampPropertyMap(T startValue, T finalValue, T durationValue, T roundOffTime) {
+    return { createPropertyMapEntry(signal_type, ParabolicRamp), createPropertyMapEntry(start_value, startValue), createPropertyMapEntry(final_value, finalValue),
+             createPropertyMapEntry(duration, durationValue), createPropertyMapEntry(round_off_time, roundOffTime) };
+}
+
+template<typename T>
+[[nodiscard]] property_map
+createCubicSplinePropertyMap(T startValue, T finalValue, T durationValue) {
+    return { createPropertyMapEntry(signal_type, CubicSpline), createPropertyMapEntry(start_value, startValue), createPropertyMapEntry(final_value, finalValue),
+             createPropertyMapEntry(duration, durationValue) };
+}
+
+template<typename T>
+[[nodiscard]] property_map
+createImpulseResponsePropertyMap(T startValue, T finalValue, T time0, T time1) {
+    return { createPropertyMapEntry(signal_type, ImpulseResponse), createPropertyMapEntry(start_value, startValue), createPropertyMapEntry(final_value, finalValue),
+             createPropertyMapEntry(impulse_time0, time0), createPropertyMapEntry(impulse_time1, time1) };
+}
+
+} // namespace function_generator
+
+using FunctionGeneratorDoc = Doc<R""(
+@brief The `FunctionGenerator` class generates a variety of functions and their combinations.
+It supports multiple function types, including Constant, Linear Ramp, Parabolic Ramp, Cubic Spline, and Impulse Response.
+Each function type is configurable with specific parameters, enabling precise tailoring to meet the user's requirements.
+Users can create sequences of various functions using tags.
+These tags are generated through dedicated helper methods, named `create{FunctionName}Tag(...)`.
+This method enables the flexible assembly of diverse function chains, offering significant versatility in signal generation.
+
+Supported function types and their configurable parameters:
+
+* Const
+  - Constantly returns the same value, specified by 'startValue'.
+  To create a `property_map` use `createConstPropertyMap(tagIndex, startValue)`.
+
+* LinearRamp
+  - Interpolates linearly between a start and a final value over a set duration.
+  To create a `property_map` use `createLinearRampPropertyMap(tagIndex, startValue, finalValue, duration)`.
+
+* ParabolicRamp
+  - Produces a function with three sections: parabolic-linear-parabolic. The 'roundOffTime' parameter determines the length of the parabolic sections.
+  To create a `property_map` use `createParabolicRampPropertyMap(tagIndex, startValue, finalValue, duration, roundOffTime)`.
+
+* CubicSpline
+  - Implements smooth cubic spline interpolation between start and final values over a specified duration.
+  To create a `property_map` use `createCubicSplinePropertyMap(tagIndex, startValue, finalValue, duration)`.
+
+* ImpulseResponse
+  - Creates a function that spikes from 'time0' for a duration of 'time1'.
+  To create a `property_map` use `createImpulseResponsePropertyMap(tagIndex, startValue, finalValue, time0, time1)`.
+
+To create a chain of functions one can use `ClockSource`. There are 2 ways to do it:
+1) Using times + property_map
+Firstly, add time Tag entries, with time and command string:
+@code
+auto &clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({ gr::tag::SAMPLE_RATE(100.f), { "n_samples_max", 100 }, { "name", "ClockSource" } });
+clockSrc.addTimeTagEntry(1'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1");
+clockSrc.addTimeTagEntry(10'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2");
+clockSrc.addTimeTagEntry(30'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3");
+@endcode
+
+Secondly, create table to match command and functions:
+@code
+funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1" } }, createConstPropertyMap(5.f));
+funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2" } }, createLinearRampPropertyMap(5.f, 30.f, .2f));
+funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3" } }, createConstPropertyMap(30.f));
+@endcode
+
+Lastly create a matching predicate with the following signature:
+@code
+std::function<std::optional<bool>(const property_map &, const property_map &, std::size_t)>;
+@endcode
+
+
+2) Using user defined ready-to-use Tags.
+@code
+auto &clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({ gr::tag::SAMPLE_RATE(100.f), { "n_samples_max", 100 }, { "name", "ClockSource" } });
+clockSrc.tags = { Tag(0, createConstPropertyMap(5.f)),
+                  Tag(100, createLinearRampPropertyMap(5.f, 30.f, .2f)),
+                  Tag(300, createConstPropertyMap(30.f)),
+                  Tag(350, createParabolicRampPropertyMap(30.f, 20.f, .1f, 0.02f)),
+                  Tag(550, createConstPropertyMap(20.f)),
+                  Tag(650, createCubicSplinePropertyMap(20.f, 10.f, .1f)),
+                  Tag(800, createConstPropertyMap(10.f)),
+                  Tag(850, createImpulseResponsePropertyMap(10.f, 20.f, .02f, .06f)) };
+@endcode
+
+)"">;
+
+template<typename T>
+    requires(std::floating_point<T>)
+struct FunctionGenerator : public gr::Block<FunctionGenerator<T>, BlockingIO<true>, FunctionGeneratorDoc> {
+    /**
+     * TODO: Taken from CtxSettings
+     * A predicate for matching two contexts
+     * The third "attempt" parameter indicates the current round of matching being done.
+     * This is useful for hierarchical matching schemes,
+     * e.g. in the first round the predicate could look for almost exact matches only,
+     * then in a a second round (attempt=1) it could be more forgiving, given that there are no exact matches available.
+     *
+     * The predicate will be called until it returns "true" (a match is found), or until it returns std::nullopt,
+     * which indicates that no matches were found and there is no chance of matching anything in a further round.
+     */
+    using MatchPredicate = std::function<std::optional<bool>(const property_map &, const property_map &, std::size_t)>;
+
+    PortIn<T>  in; // ClockSource input
+    PortOut<T> out;
+
+    // TODO: Example of type aliases for sample_rate, make global and for all default Tags
+    using SampleRate       = Annotated<float, "sample_rate", Visible, Doc<"stream sampling rate in [Hz]">>;
+    SampleRate sample_rate = 1000.f;
+
+    Annotated<std::string, "signal_type", Visible, Doc<"see function_generator::SignalType">> signal_type = function_generator::toString(function_generator::Const);
+
+    // Parameters for different functions, not all parameters are used for all functions
+    Annotated<T, "start_value">                                               start_value    = T(0.);
+    Annotated<T, "final_value">                                               final_value    = T(0.);
+    Annotated<T, "duration", Doc<"in sec">>                                   duration       = T(0.);
+    Annotated<T, "round_off_time", Doc<"Specific to ParabolicRamp, in sec">>  round_off_time = T(0.);
+    Annotated<T, "impulse_time0", Doc<"Specific to ImpulseResponse, in sec">> impulse_time0  = T(0.);
+    Annotated<T, "impulse_time1", Doc<"Specific to ImpulseResponse, in sec">> impulse_time1  = T(0.);
+
+    Annotated<property_map, "trigger_meta_info"> trigger_meta_info{};
+    // TODO; need to use 2 std::vectors, can not use property_map as std::map key.
+    std::vector<property_map> function_keys{};   // matches the trigger tag map to the prestored settings
+    std::vector<property_map> function_values{}; // matches the trigger tag map to the prestored settings
+
+    MatchPredicate match_pred = [](auto, auto, auto) { return std::nullopt; };
+
+    T   _currentTime  = T(0.);
+    int sampleCounter = 0;
+
+private:
+    function_generator::SignalType _signalType = function_generator::parse<function_generator::SignalType>(signal_type);
+    T                              _timeTick   = T(1.) / static_cast<T>(sample_rate);
+
+public:
+    void
+    settingsChanged(const property_map & /*old_settings*/, const property_map &new_settings) {
+        if (new_settings.contains(gr::tag::TRIGGER_META_INFO.shortKey())) {
+            const auto funcSettings = bestMatch(trigger_meta_info);
+            if (funcSettings.has_value()) {
+                applyFunctionSettings(funcSettings.value());
+                _currentTime = T(0.);
+                _signalType  = function_generator::parse<function_generator::SignalType>(signal_type);
+            }
+        }
+        if (new_settings.contains(function_generator::toString(function_generator::signal_type))) {
+            _currentTime = T(0.);
+            _signalType  = function_generator::parse<function_generator::SignalType>(signal_type);
+        }
+        _timeTick = T(1.) / static_cast<T>(sample_rate);
+    }
+
+    [[nodiscard]] constexpr T
+    processOne(T /*input*/) noexcept {
+        sampleCounter++;
+        using enum function_generator::SignalType;
+        T value{};
+
+        switch (_signalType) {
+        case Const: value = start_value; break;
+        case LinearRamp: value = _currentTime > duration.value ? final_value.value : start_value + (final_value - start_value) * (_currentTime / duration); break;
+        case ParabolicRamp: value = calculateParabolicRamp(); break;
+        case CubicSpline: {
+            const T normalizedTime  = _currentTime / duration;
+            const T normalizedTime2 = T(3.) * std::pow(normalizedTime, T(2.));
+            const T normalizedTime3 = T(2.) * std::pow(normalizedTime, T(3.));
+            const T tmpValue        = (normalizedTime3 - normalizedTime2 + 1) * start_value + (-normalizedTime3 + normalizedTime2) * final_value;
+            value                   = _currentTime > duration ? final_value.value : tmpValue;
+            break;
+        }
+        case ImpulseResponse: value = (_currentTime < impulse_time0 || _currentTime > impulse_time0 + impulse_time1) ? start_value.value : final_value.value; break;
+        default: value = T(0.);
+        }
+        _currentTime += _timeTick;
+        return value;
+    }
+
+    constexpr void
+    addFunctionTableEntry(const property_map &key, const property_map &value) {
+        function_keys.push_back(key);
+        function_values.push_back(value);
+    }
+
+private:
+    void
+    applyFunctionSettings(const property_map &properties) {
+        auto getProperty = [&properties]<typename U>(const property_map &m, function_generator::ParameterType paramType, U &&) -> std::optional<U> {
+            const auto it = m.find(function_generator::toString(paramType));
+            if (it == m.end()) {
+                return std::nullopt;
+            }
+            try {
+                return std::get<U>(it->second);
+            } catch (const std::bad_variant_access &) {
+                return std::nullopt;
+            }
+        };
+
+        signal_type    = getProperty(properties, function_generator::signal_type, std::string("")).value_or(function_generator::toString(function_generator::Const));
+        start_value    = getProperty(properties, function_generator::start_value, T{}).value_or(T(0.));
+        final_value    = getProperty(properties, function_generator::final_value, T{}).value_or(T(0.));
+        duration       = getProperty(properties, function_generator::duration, T{}).value_or(T(0.));
+        round_off_time = getProperty(properties, function_generator::round_off_time, T{}).value_or(T(0.));
+        impulse_time0  = getProperty(properties, function_generator::impulse_time0, T{}).value_or(T(0.));
+        impulse_time1  = getProperty(properties, function_generator::impulse_time1, T{}).value_or(T(0.));
+    }
+
+    [[nodiscard]] constexpr T
+    calculateParabolicRamp() {
+        const T roundOnTime  = round_off_time; // assume that round ON and OFF times are equal
+        const T linearLength = duration - (roundOnTime + round_off_time);
+        const T a            = (final_value - start_value) / (T(2.) * roundOnTime * (linearLength + round_off_time));
+        const T ar2          = a * std::pow(round_off_time, T(2.));
+        const T slope        = (final_value - start_value - T(2.) * ar2) / linearLength;
+
+        if (_currentTime > duration) {
+            return final_value;
+        }
+        if (_currentTime < roundOnTime) {
+            return start_value + a * std::pow(_currentTime, T(2.)); // first parabolic section
+        }
+        if (_currentTime < duration - round_off_time) {
+            const T transitPoint1 = start_value + ar2;
+            return transitPoint1 + slope * (_currentTime - round_off_time); // linear section
+        }
+        // second parabolic section
+        const T shiftedTime   = _currentTime - (duration - round_off_time);
+        const T transitPoint2 = final_value - ar2;
+        return transitPoint2 + slope * shiftedTime - a * std::pow(shiftedTime, T(2.));
+    }
+
+    std::optional<property_map>
+    bestMatch(const property_map &context) const {
+        if (function_keys.size() != function_values.size()) {
+            throw std::invalid_argument(fmt::format("function_keys size ({}) and function_values size ({}) must be equal", function_keys.size(), function_values.size()));
+        }
+        if (function_keys.empty() || function_values.empty()) {
+            return std::nullopt;
+        }
+        // retry until we either get a match or std::nullopt
+        for (std::size_t attempt = 0;; attempt++) {
+            for (std::size_t i = 0; i < function_values.size(); i++) {
+                const auto isMatched = match_pred(function_keys[i], context, attempt);
+                if (!isMatched) {
+                    return std::nullopt;
+                } else if (*isMatched) {
+                    return function_values[i];
+                }
+            }
+        }
+    }
+};
+
+} // namespace gr::basic
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (gr::basic::FunctionGenerator<T>), in, out, sample_rate, signal_type, start_value, final_value, duration, round_off_time, impulse_time0,
+                                    impulse_time1, trigger_meta_info);
+
+#endif // GNURADIO_FUNCTION_GENERATOR_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/SignalGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/SignalGenerator.hpp
@@ -1,5 +1,5 @@
-#ifndef GNURADIO_SIGNAL_SOURCE_HPP
-#define GNURADIO_SIGNAL_SOURCE_HPP
+#ifndef GNURADIO_SIGNAL_GENERATOR_HPP
+#define GNURADIO_SIGNAL_GENERATOR_HPP
 
 #include <gnuradio-4.0/Block.hpp>
 #include <numbers>
@@ -8,7 +8,7 @@ namespace gr::basic {
 
 using namespace gr;
 
-namespace signal_source {
+namespace signal_generator {
 enum class Type : int { Const, Sin, Cos, Square, Saw, Triangle };
 using enum Type;
 constexpr auto                                 TypeList  = magic_enum::enum_values<Type>();
@@ -18,12 +18,12 @@ constexpr Type
 parse(std::string_view name) {
     auto signalType = magic_enum::enum_cast<Type>(name, magic_enum::case_insensitive);
     if (!signalType.has_value()) {
-        throw std::invalid_argument(fmt::format("unknown signal source type '{}'", name));
+        throw std::invalid_argument(fmt::format("unknown signal generator type '{}'", name));
     }
     return signalType.value();
 }
 
-} // namespace signal_source
+} // namespace signal_generator
 
 using SignalGeneratorDoc = Doc<R""(
 @brief The SignalGenerator class generates various types of signal waveforms, including sine, cosine, square, constant, saw, and triangle signals.
@@ -64,29 +64,29 @@ struct SignalGenerator : public gr::Block<SignalGenerator<T>, BlockingIO<true>, 
     PortIn<T>  in; // ClockSource input
     PortOut<T> out;
 
-    Annotated<float, "sample_rate", Visible, Doc<"sample rate">>                   sample_rate = 1000.f;
-    Annotated<std::string, "signal_type", Visible, Doc<"see signal_source::Type">> signal_type = "Sin";
-    Annotated<T, "frequency", Visible>                                             frequency   = T(1.);
-    Annotated<T, "amplitude", Visible>                                             amplitude   = T(1.);
-    Annotated<T, "offset", Visible>                                                offset      = T(0.);
-    Annotated<T, "phase", Visible, Doc<"in rad">>                                  phase       = T(0.);
+    Annotated<float, "sample_rate", Visible, Doc<"sample rate">>                      sample_rate = 1000.f;
+    Annotated<std::string, "signal_type", Visible, Doc<"see signal_generator::Type">> signal_type = "Sin";
+    Annotated<T, "frequency", Visible>                                                frequency   = T(1.);
+    Annotated<T, "amplitude", Visible>                                                amplitude   = T(1.);
+    Annotated<T, "offset", Visible>                                                   offset      = T(0.);
+    Annotated<T, "phase", Visible, Doc<"in rad">>                                     phase       = T(0.);
 
     T _currentTime = T(0.);
 
 private:
-    signal_source::Type _signalType = signal_source::parse(signal_type);
-    T                   _timeTick   = T(1.) / T(sample_rate);
+    signal_generator::Type _signalType = signal_generator::parse(signal_type);
+    T                      _timeTick   = T(1.) / T(sample_rate);
 
 public:
     void
     settingsChanged(const property_map & /*old_settings*/, const property_map & /*new_settings*/) {
-        _signalType = signal_source::parse(signal_type);
+        _signalType = signal_generator::parse(signal_type);
         _timeTick   = T(1.) / T(sample_rate);
     }
 
     [[nodiscard]] constexpr T
     processOne(T /*input*/) noexcept {
-        using enum signal_source::Type;
+        using enum signal_generator::Type;
 
         constexpr T pi2 = T(2.) * std::numbers::pi_v<T>;
         T           value{};
@@ -121,4 +121,4 @@ public:
 
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (gr::basic::SignalGenerator<T>), in, out, sample_rate, signal_type, frequency, amplitude, offset, phase);
 
-#endif // GNURADIO_SIGNAL_SOURCE_HPP
+#endif // GNURADIO_SIGNAL_GENERATOR_HPP

--- a/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/clock_source.hpp
@@ -10,6 +10,7 @@
 #include <thread>
 #include <queue>
 
+#include <fmt/chrono.h>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
@@ -26,16 +27,27 @@ template<typename T, gr::meta::fixed_string description = "", typename... Argume
 using A = gr::Annotated<T, description, Arguments...>;
 using namespace gr;
 
-template<typename T, bool useIoThread = true, typename ClockSourceType = std::chrono::system_clock, bool basicPeriodAlgorithm = true>
-struct ClockSource : public gr::Block<ClockSource<T, useIoThread, ClockSourceType>, BlockingIO<useIoThread>, Doc<R""(
+using ClockSourceDoc = Doc<R""(
 ClockSource Documentation -- add here
-)"">> {
+)"">;
+
+template<typename T, bool useIoThread = true, typename ClockSourceType = std::chrono::system_clock, bool basicPeriodAlgorithm = true>
+struct ClockSource : public gr::Block<ClockSource<T, useIoThread, ClockSourceType>, BlockingIO<useIoThread>, ClockSourceDoc> {
     std::chrono::time_point<ClockSourceType> nextTimePoint = ClockSourceType::now();
-    //
-    PortOut<T>       out;
+
+    PortOut<T> out;
+
+    // Ready-to-use tags set by user
     std::vector<Tag> tags{};
     std::size_t      next_tag{ 0 };
-    //
+
+    // Time-string tags
+    std::vector<std::uint64_t> tag_times; // time in nanoseconds
+    std::vector<std::string>   tag_values;
+    std::size_t                next_time_tag{ 0 };
+    std::uint64_t              repeat_period{ 0 };          // if repeat_period > last tag_time -> restart tags, in nanoseconds
+    bool                       do_zero_order_hold{ false }; // if more tag_times than values: true=publish last tag, false=publish empty
+
     A<std::uint32_t, "n_samples_max", Visible, Doc<"0: unlimited">>              n_samples_max = 1024;
     std::uint32_t                                                                n_samples_produced{ 0 };
     A<float, "avg. sample rate", Visible>                                        sample_rate = 1000.f;
@@ -43,6 +55,11 @@ ClockSource Documentation -- add here
     std::shared_ptr<std::thread>                                                 userProvidedThread;
     bool                                                                         verbose_console = true;
 
+private:
+    std::chrono::time_point<ClockSourceType> _beginSequenceTimePoint = ClockSourceType::now();
+    bool                                     _beginSequenceTimePointInitialized{ false };
+
+public:
     void
     start() {
         if (verbose_console) {
@@ -76,6 +93,12 @@ ClockSource Documentation -- add here
 
     work::Status
     processBulk(PublishableSpan auto &output) noexcept {
+        // TODO: does one need to check every processBulk call
+        bool isAscending = std::ranges::adjacent_find(tag_times, std::greater_equal()) == tag_times.end();
+        if (!isAscending) {
+            throw std::invalid_argument("The input tag_times vector should be ascending.");
+        }
+
         if (n_samples_max > 0 && n_samples_produced >= n_samples_max) {
             output.publish(0UZ);
             return work::Status::DONE;
@@ -85,39 +108,71 @@ ClockSource Documentation -- add here
             // sleep until next update period -- the following call blocks
             std::this_thread::sleep_until(nextTimePoint);
         }
-        const auto writableSamples = static_cast<std::uint32_t>(output.size());
-        if (writableSamples < chunk_size) {
+
+        const std::uint32_t remainingSamples = n_samples_max - n_samples_produced;
+        std::uint32_t       samplesToProduce = std::min(remainingSamples, chunk_size.value);
+
+        std::uint32_t samplesToNextTimeTag = std::numeric_limits<uint32_t>::max();
+        if (!tag_times.empty()) {
+            if (next_time_tag == 0 && !_beginSequenceTimePointInitialized) {
+                _beginSequenceTimePoint            = nextTimePoint;
+                _beginSequenceTimePointInitialized = true;
+            }
+            if (next_time_tag >= tag_times.size() && repeat_period >= tag_times.back()) {
+                _beginSequenceTimePoint += std::chrono::microseconds(repeat_period / 1000); // ns -> μs
+                _beginSequenceTimePointInitialized = true;
+                next_time_tag                      = 0;
+            }
+            if (next_time_tag < tag_times.size()) {
+                const auto currentTagTime = std::chrono::microseconds(tag_times[next_time_tag] / 1000); // ns -> μs
+                const auto timeToNextTag  = std::chrono::duration_cast<std::chrono::microseconds>((_beginSequenceTimePoint + currentTagTime - nextTimePoint));
+                samplesToNextTimeTag      = static_cast<std::uint32_t>((static_cast<double>(timeToNextTag.count()) / 1.e6) * static_cast<double>(sample_rate));
+            }
+        }
+
+        auto samplesToNextTag = tags.empty() || next_tag >= tags.size() ? std::numeric_limits<uint32_t>::max() : static_cast<std::uint32_t>(tags[next_tag].index) - n_samples_produced;
+
+        if (samplesToNextTag < samplesToNextTimeTag) {
+            if (next_tag < tags.size() && samplesToNextTag <= samplesToProduce) {
+                const auto tagDeltaIndex = tags[next_tag].index - static_cast<Tag::signed_index_type>(n_samples_produced); // position w.r.t. start of this chunk
+                if (verbose_console) {
+                    gr::testing::print_tag(tags[next_tag], fmt::format("{}::processBulk(...)\t publish tag at  {:6}", this->name, n_samples_produced + tagDeltaIndex));
+                }
+                out.publishTag(tags[next_tag].map, tagDeltaIndex);
+                samplesToProduce = samplesToNextTag;
+                next_tag++;
+            }
+        } else {
+            if (!tag_times.empty() && next_time_tag < tag_times.size() && samplesToNextTimeTag <= samplesToProduce) {
+                std::string  value    = next_time_tag < tag_values.size() ? tag_values[next_time_tag] : do_zero_order_hold ? tag_values.back() : "";
+                property_map context  = { { "context", value } };
+                property_map metaInfo = { { "trigger_meta_info", context } };
+                if (verbose_console) {
+                    fmt::println("{}::processBulk(...)\t publish tag-time at  {:6}, time:{}ns", this->name, samplesToNextTimeTag, tag_times[next_time_tag]);
+                }
+                out.publishTag(metaInfo, samplesToNextTimeTag);
+                samplesToProduce = samplesToNextTimeTag;
+                next_time_tag++;
+            }
+        }
+        samplesToProduce = std::min(samplesToProduce, n_samples_max.value);
+
+        if (static_cast<std::uint32_t>(output.size()) < samplesToProduce) {
             output.publish(0UZ);
             return work::Status::INSUFFICIENT_OUTPUT_ITEMS;
         }
 
-        const std::uint32_t remaining_samples = n_samples_max - n_samples_produced;
-        const std::uint32_t limit             = std::min(writableSamples, remaining_samples);
-        const std::uint32_t n_available       = std::min(limit, chunk_size.value);
-
-        std::uint32_t samples_to_produce = n_available;
-        while (next_tag < tags.size() && tags[next_tag].index <= static_cast<std::make_signed_t<std::size_t>>(n_samples_produced + n_available)) {
-            const auto tagDeltaIndex = tags[next_tag].index - static_cast<Tag::signed_index_type>(n_samples_produced); // position w.r.t. start of this chunk
-            if (verbose_console) {
-                gr::testing::print_tag(tags[next_tag], fmt::format("{}::processBulk(...)\t publish tag at  {:6}", this->name, n_samples_produced + tagDeltaIndex));
-            }
-            out.publishTag(tags[next_tag].map, tagDeltaIndex);
-            samples_to_produce = static_cast<std::uint32_t>(tags[next_tag].index) - n_samples_produced;
-            next_tag++;
-        }
-        samples_to_produce = std::min(samples_to_produce, n_samples_max.value);
-
-        output.publish(static_cast<std::size_t>(samples_to_produce));
-        n_samples_produced += samples_to_produce;
+        output.publish(static_cast<std::size_t>(samplesToProduce));
+        n_samples_produced += samplesToProduce;
 
         if constexpr (basicPeriodAlgorithm) {
-            const auto updatePeriod = std::chrono::microseconds(static_cast<long>(1e6f * static_cast<float>(chunk_size) / sample_rate));
+            const auto updatePeriod = std::chrono::microseconds(static_cast<long>(1e6f * static_cast<float>(samplesToProduce) / sample_rate));
             nextTimePoint += updatePeriod;
         } else {
-            const auto updatePeriod = std::chrono::microseconds(static_cast<long>(1e6f * static_cast<float>(chunk_size) / sample_rate));
+            const auto updatePeriod = std::chrono::microseconds(static_cast<long>(1e6f * static_cast<float>(samplesToProduce) / sample_rate));
             // verify the actual rate
             const auto actual_elapsed_time   = std::chrono::duration_cast<std::chrono::microseconds>(ClockSourceType::now() - nextTimePoint + updatePeriod).count();
-            const auto expected_elapsed_time = 1e6f * static_cast<float>(chunk_size) / sample_rate;
+            const auto expected_elapsed_time = 1e6f * static_cast<float>(samplesToProduce) / sample_rate;
 
             // adjust the next update period
             const float ratio = static_cast<float>(actual_elapsed_time) / expected_elapsed_time;

--- a/blocks/basic/test/qa_sources.cpp
+++ b/blocks/basic/test/qa_sources.cpp
@@ -7,6 +7,7 @@
 
 #include <gnuradio-4.0/algorithm/ImChart.hpp>
 #include <gnuradio-4.0/basic/clock_source.hpp>
+#include <gnuradio-4.0/basic/FunctionGenerator.hpp>
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
@@ -15,6 +16,13 @@
 template<>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
 #endif
+
+template<typename T>
+constexpr void
+addTimeTagEntry(gr::basic::ClockSource<T> &clockSource, std::uint64_t timeInNanoseconds, const std::string &value) {
+    clockSource.tag_times.push_back(timeInNanoseconds);
+    clockSource.tag_values.push_back(value);
+}
 
 const boost::ut::suite TagTests = [] {
     using namespace boost::ut;
@@ -163,6 +171,144 @@ const boost::ut::suite TagTests = [] {
         sched.runAndWait();
 
         expect(eq(n_samples, static_cast<std::uint32_t>(sink.n_samples_produced))) << "Number of samples does not match";
+    };
+
+    "FunctionGenerator ImChart test"_test = [] {
+        using namespace function_generator;
+        const std::size_t       N          = 128; // test points
+        double                  startValue = 10.;
+        double                  finalValue = 20.;
+        std::vector<SignalType> signals{ Const, LinearRamp, ParabolicRamp, CubicSpline, ImpulseResponse };
+        for (const auto &sig : signals) {
+            FunctionGenerator<double> funcGen{};
+            std::ignore = funcGen.settings().set({ createPropertyMapEntry(signal_type, sig),
+                                                   { "n_samples_max", static_cast<std::uint32_t>(N) },
+                                                   { "sample_rate", 128.f },
+                                                   createPropertyMapEntry(start_value, startValue),
+                                                   createPropertyMapEntry(final_value, finalValue),
+                                                   createPropertyMapEntry(duration, 1.),
+                                                   createPropertyMapEntry(round_off_time, .15),
+                                                   createPropertyMapEntry(impulse_time0, .2),
+                                                   createPropertyMapEntry(impulse_time1, .15) });
+            std::ignore = funcGen.settings().applyStagedParameters();
+
+            std::vector<double> xValues(N), yValues(N);
+            std::iota(xValues.begin(), xValues.end(), 0);
+            std::ranges::generate(yValues, [&funcGen]() { return funcGen.processOne(0.); });
+            fmt::println("Chart {}\n\n", toString(sig));
+            auto chart = gr::graphs::ImChart<128, 32>({ { 0., static_cast<double>(N) }, { 7., 22. } });
+            chart.draw(xValues, yValues, toString(sig));
+            chart.draw();
+        }
+    };
+
+    "FunctionGenerator + ClockSource test"_test = [] {
+        using namespace function_generator;
+        constexpr std::uint32_t N           = 1000;
+        constexpr float         sample_rate = 1000.f;
+        Graph                   testGraph;
+        auto                   &clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({ { "sample_rate", sample_rate }, { "n_samples_max", N }, { "name", "ClockSource" } });
+
+        clockSrc.tags = { Tag(0, createConstPropertyMap(5.f)),                              //
+                          Tag(100, createLinearRampPropertyMap(5.f, 30.f, .2f)),            //
+                          Tag(300, createConstPropertyMap(30.f)),                           //
+                          Tag(350, createParabolicRampPropertyMap(30.f, 20.f, .1f, 0.02f)), //
+                          Tag(550, createConstPropertyMap(20.f)),                           //
+                          Tag(650, createCubicSplinePropertyMap(20.f, 10.f, .1f)),          //
+                          Tag(800, createConstPropertyMap(10.f)),
+                          Tag(850, createImpulseResponsePropertyMap(10.f, 20.f, .02f, .06f)) };
+
+        auto &funcGen = testGraph.emplaceBlock<FunctionGenerator<float>>({ { "sample_rate", sample_rate }, { "name", "FunctionGenerator" } });
+        auto &sink    = testGraph.emplaceBlock<gr::testing::TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagSink" } });
+
+        expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(clockSrc).to<"in">(funcGen)));
+        expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(sink)));
+
+        scheduler::Simple sched{ std::move(testGraph) };
+        sched.runAndWait();
+        expect(eq(N, static_cast<std::uint32_t>(sink.samples.size()))) << "Number of samples does not match";
+
+        std::vector<double> xValues(N);
+        std::vector<double> yValues(sink.samples.begin(), sink.samples.end());
+        std::iota(xValues.begin(), xValues.end(), 0);
+        auto chart = gr::graphs::ImChart<128, 32>({ { 0., static_cast<double>(N) }, { 0., 35. } });
+        chart.draw(xValues, yValues, "Signal");
+        chart.draw();
+    };
+
+    "FunctionGenerator + ClockSource FAIR test"_test = [] {
+        using namespace function_generator;
+        constexpr std::uint32_t N           = 1000;
+        constexpr float         sample_rate = 10000.f;
+        Graph                   testGraph;
+        auto                   &clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({ { "sample_rate", sample_rate }, { "n_samples_max", N }, { "name", "ClockSource" } });
+
+        // all times are in nanoseconds
+        addTimeTagEntry(clockSrc, 1'000'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1");
+        addTimeTagEntry(clockSrc, 10'000'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2");
+        addTimeTagEntry(clockSrc, 30'000'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3");
+        addTimeTagEntry(clockSrc, 35'000'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=4");
+        addTimeTagEntry(clockSrc, 55'000'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=5");
+        addTimeTagEntry(clockSrc, 65'000'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=6");
+        addTimeTagEntry(clockSrc, 80'000'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=7");
+        addTimeTagEntry(clockSrc, 85'000'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=8");
+        clockSrc.repeat_period      = 5'000'000;
+        clockSrc.do_zero_order_hold = true;
+        auto &funcGen               = testGraph.emplaceBlock<FunctionGenerator<float>>({ { "sample_rate", sample_rate }, { "name", "FunctionGenerator" } });
+        funcGen.match_pred          = [](const auto &tableEntry, const auto &searchEntry, const auto attempt) -> std::optional<bool> {
+            if (searchEntry.find("context") == searchEntry.end()) {
+                return std::nullopt;
+            }
+            if (tableEntry.find("context") == tableEntry.end()) {
+                return false;
+            }
+
+            const pmtv::pmt searchEntryContext = searchEntry.at("context");
+            const pmtv::pmt tableEntryContext  = tableEntry.at("context");
+            if (std::holds_alternative<std::string>(searchEntryContext) && std::holds_alternative<std::string>(tableEntryContext)) {
+                const auto searchString = std::get<std::string>(searchEntryContext);
+                const auto tableString  = std::get<std::string>(tableEntryContext);
+
+                if (!searchString.starts_with("CMD_BP_START:")) {
+                    return std::nullopt;
+                }
+
+                if (attempt >= searchString.length()) {
+                    return std::nullopt;
+                }
+                auto [it1, it2] = std::ranges::mismatch(searchString, tableString);
+                if (std::distance(searchString.begin(), it1) == static_cast<std::ptrdiff_t>(searchString.length() - attempt)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        // Time duration is in seconds
+        funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1" } }, createConstPropertyMap(5.f));
+        funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2" } }, createLinearRampPropertyMap(5.f, 30.f, 0.02f));
+        funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3" } }, createConstPropertyMap(30.f));
+        funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=4" } }, createParabolicRampPropertyMap(30.f, 20.f, .01f, 0.002f));
+        funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=5" } }, createConstPropertyMap(20.f));
+        funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=6" } }, createCubicSplinePropertyMap(20.f, 10.f, 0.01f));
+        funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=7" } }, createConstPropertyMap(10.f));
+        funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=8" } }, createImpulseResponsePropertyMap(10.f, 20.f, 0.002f, 0.006f));
+
+        auto &sink = testGraph.emplaceBlock<gr::testing::TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagSink" } });
+
+        expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(clockSrc).to<"in">(funcGen)));
+        expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(sink)));
+
+        scheduler::Simple sched{ std::move(testGraph) };
+        sched.runAndWait();
+        expect(eq(N, static_cast<std::uint32_t>(sink.samples.size()))) << "Number of samples does not match";
+
+        std::vector<double> xValues(N);
+        std::vector<double> yValues(sink.samples.begin(), sink.samples.end());
+        std::iota(xValues.begin(), xValues.end(), 0);
+        auto chart = gr::graphs::ImChart<128, 32>({ { 0., static_cast<double>(N) }, { 0., 35. } });
+        chart.draw(xValues, yValues, "Signal");
+        chart.draw();
     };
 };
 

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -227,13 +227,14 @@ inline EM_CONSTEXPR_STATIC DefaultTag<"signal_max", float, "a.u.", "signal physi
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_name", std::string> TRIGGER_NAME;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_time", uint64_t, "ns", "UTC-based time-stamp"> TRIGGER_TIME;
 inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_offset", float, "s", "sample delay w.r.t. the trigger (e.g.compensating analog group delays)"> TRIGGER_OFFSET;
+inline EM_CONSTEXPR_STATIC DefaultTag<"trigger_meta_info", property_map, "", "maps containing additional trigger information"> TRIGGER_META_INFO;
 inline EM_CONSTEXPR_STATIC DefaultTag<"context", std::string, "", "multiplexing key to orchestrate node settings/behavioural changes"> CONTEXT;
 inline EM_CONSTEXPR_STATIC DefaultTag<"reset_default", bool, "", "reset block state to stored default"> RESET_DEFAULTS;
 inline EM_CONSTEXPR_STATIC DefaultTag<"store_default", bool, "", "store block settings as default"> STORE_DEFAULTS;
 inline EM_CONSTEXPR_STATIC DefaultTag<"end_of_stream", bool, "", "end of stream, receiver should change to DONE state"> END_OF_STREAM;
 
-inline constexpr std::tuple DEFAULT_TAGS = { SAMPLE_RATE,  SIGNAL_NAME,    SIGNAL_UNIT, SIGNAL_MIN,     SIGNAL_MAX,     TRIGGER_NAME,
-                                             TRIGGER_TIME, TRIGGER_OFFSET, CONTEXT,     RESET_DEFAULTS, STORE_DEFAULTS, END_OF_STREAM };
+inline constexpr std::tuple DEFAULT_TAGS = { SAMPLE_RATE,    SIGNAL_NAME,       SIGNAL_UNIT, SIGNAL_MIN,     SIGNAL_MAX,     TRIGGER_NAME, TRIGGER_TIME,
+                                             TRIGGER_OFFSET, TRIGGER_META_INFO, CONTEXT,     RESET_DEFAULTS, STORE_DEFAULTS, END_OF_STREAM };
 } // namespace tag
 
 } // namespace gr


### PR DESCRIPTION
The `FunctionGenerator` class generates a variety of functions and their combinations.
It supports multiple function types, including Constant, Linear Ramp, Parabolic Ramp, Cubic Spline, and Impulse Response.
Each function type is configurable with specific parameters, enabling precise tailoring to meet the user's requirements.
Users can create sequences of various functions using tags.
Some helper methods to create tags or property maps are provided: 1) `create{FunctionName}Tag(...)`, 2) `create{FunctionName}PropertyMap(...)`

Supported function types and their configurable parameters:

* Const
  - Constantly returns the same value, specified by 'startValue'.
  To generate a tag use `createConstTag(tagIndex, startValue)`.

* LinearRamp
  - Interpolates linearly between a start and a final value over a set duration.
  To generate a tag use `createLinearRampTag(tagIndex, startValue, finalValue, duration)`.

* ParabolicRamp
  - Produces a function with three sections: parabolic-linear-parabolic. The 'roundOffTime' parameter determines the length of the parabolic sections.
  To generate a tag use `createParabolicRampTag(tagIndex, startValue, finalValue, duration, roundOffTime)`.

* CubicSpline
  - Implements smooth cubic spline interpolation between start and final values over a specified duration.
  To generate a tag use `createCubicSplineTag(tagIndex, startValue, finalValue, duration)`.

* ImpulseResponse
  - Creates a function that spikes from 'time0' for a duration of 'time1'.
  To generate a tag use `createImpulseResponseTag(tagIndex, startValue, finalValue, time0, time1)`.


### 2 ways to create a chain of functions using `ClockSource`. 

1) Using times + property_map
Firstly, add time Tag entries, with time and command string:
```cpp
auto &clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({gr::tag::SAMPLE_RATE(sample_rate), { "n_samples_max", 100 }, { "name", "ClockSource" } });
clockSrc.addTimeTagEntry(1'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1");
clockSrc.addTimeTagEntry(10'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2");
clockSrc.addTimeTagEntry(30'000, "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3");
```

Secondly, create table to match command and functions:
```cpp
funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=1" } }, createConstPropertyMap(5.f));
funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=2" } }, createLinearRampPropertyMap(5.f, 30.f, .2f));
funcGen.addFunctionTableEntry({ { "context", "CMD_BP_START:FAIR.SELECTOR.C=1:S=1:P=3" } }, createConstPropertyMap(30.f));
```

Lastly create a matching predicate with the following signature:
```cpp
std::function<std::optional<bool>(const property_map &, const property_map &, std::size_t)>;
```


2) Using user defined ready-to-use Tags.
```cpp
auto &clockSrc = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({ gr::tag::SAMPLE_RATE(sample_rate), { "n_samples_max", 100 }, { "name", "ClockSource" } });
clockSrc.tags = { Tag(0, createConstPropertyMap(5.f)),
                  Tag(100, createLinearRampPropertyMap(5.f, 30.f, .2f)),
                  Tag(300, createConstPropertyMap(30.f)),
                  Tag(350, createParabolicRampPropertyMap(30.f, 20.f, .1f, 0.02f)),
                  Tag(550, createConstPropertyMap(20.f)),
                  Tag(650, createCubicSplinePropertyMap(20.f, 10.f, .1f)),
                  Tag(800, createConstPropertyMap(10.f)),
                  Tag(850, createImpulseResponsePropertyMap(10.f, 20.f, .02f, .06f)) };
```


This code generates the following output:


<img width="895" alt="func" src="https://github.com/fair-acc/graph-prototype/assets/25366186/69c3dafb-5ce2-47b2-a455-129f5d45fe65">



