### PR TITLE
Integrate UncertainValue to IIR and FIR filter

### DIFF
--- a/meta/include/gnuradio-4.0/meta/UncertainValue.hpp
+++ b/meta/include/gnuradio-4.0/meta/UncertainValue.hpp
@@ -70,6 +70,28 @@ UncertainValue(T, T) -> UncertainValue<T>;
 template<typename T>
 concept UncertainValueLike = gr::meta::is_instantiation_of<T, UncertainValue>;
 
+template<typename T>
+    requires arithmetic_or_complex_like<meta::fundamental_base_value_type_t<T>>
+[[nodiscard]] inline constexpr auto
+value(const T &val) noexcept {
+    if constexpr (UncertainValueLike<T>) {
+        return val.value;
+    } else {
+        val;
+    }
+}
+
+template<typename T>
+    requires arithmetic_or_complex_like<meta::fundamental_base_value_type_t<T>>
+[[nodiscard]] inline constexpr auto
+uncertainty(const T &val) noexcept {
+    if constexpr (UncertainValueLike<T>) {
+        return val.uncertainty;
+    } else {
+        return T();
+    }
+}
+
 namespace detail {
 template<typename T>
 struct UncertainValueValueType {

--- a/meta/test/qa_UncertainValue.cpp
+++ b/meta/test/qa_UncertainValue.cpp
@@ -653,6 +653,18 @@ const boost::ut::suite uncertainValue = [] {
         expect(approx(value.uncertainty / sqrt(16), sum2.uncertainty, 1e-9));
     };
 
+    "basic IIR low-pass filter examples"_test = [] {
+        UncertainValue   ref{ 4.0, 1.0 };
+        constexpr double alpha = 0.05;
+
+        UncertainValue value{ 0.0, 1.0 };
+        for (std::size_t i = 0UZ; i < 1000UZ; i++) {
+            value = (1.0 - alpha) * value + alpha * ref;
+        }
+        expect(approx(4.0, value.value, 1e-6));
+        expect(approx(0.160, value.uncertainty, 1e-3));
+    };
+
     tag("visual") / "visual examples"_test = [] {
         // uncorrelated values
         UncertainValue uValueA{ 4.0, 2.0 };


### PR DESCRIPTION
### Infinite-Impulse-Response (IIR) as well as Finite-Impulse-Response (FIR) filter based on a single or set of biquad filter coefficients.

This includes the computation of the propagation of uncertainty according to:

$$ \sigma_y^2[0] = \sum_{i=0}^{M} b^2[i]·σ_x^2[i] + \sum_{j=1}^{N} \sum_{k=1}^{N} a[j]·a[k]·R_{yy}[|j-k|]·σ_y[j]·σ_y[k] $$

with $R_{yy}[distance]$ being the auto-correlation function of the impulse response as an estimate of the covariance matrix.

#### Usage example:
```cpp
Filter<UncertainValue<double>> myFilter(filterSections);
UncertainValue<double> outputSample = myFilter.processOne({inputSample, noise});
double mean   = gr::value(outputSample);
double stddev = gr::uncertainty(outputSample);
 ```
 
 #### Visual step-responses examples for IIR and FIR filter for 1, 2, and 4 Hz low-pass bandwidth:
 
![image](https://github.com/fair-acc/graph-prototype/assets/46007894/1d39fbd4-b419-42b2-8b5a-e50ca1b50be0)
![image](https://github.com/fair-acc/graph-prototype/assets/46007894/ee95e411-b395-4373-8f42-94a1e5efcaf0)

The more pronounced linear group-delay for the FIR is normal due to the usually larger filter kernel. N.B. the IIR filter has about a 50% poorer noise/uncertainty suppression which is also linked to the FIR filter kernel size rather than the low-pass cut-off frequency.

#### Preliminary Benchmark Performance:
![image](https://github.com/fair-acc/graph-prototype/assets/46007894/197ff892-f01e-4895-85a6-de310d9d6ee5)


Neither the regular nor `UncertainValue<T>`-enabled IIR/FIR filter implementation have been optimised for `std::simd` use. Hope to get some help/support/guidance by @mattkretz .