### PR TITLE
Fix relocating Port instances

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -69,9 +69,7 @@ public:
 
 protected:
     using TPortIn = gr::PortIn<T>;
-    // std::list because ports don't like to change in-memory address
-    // after connection is established, and vector might reallocate
-    std::list<TPortIn> _input_ports;
+    std::vector<TPortIn> _input_ports;
     gr::PortOut<T>     _output_port;
 
 protected:

--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -184,7 +184,9 @@ public:
                 available_samples);
 
         for (auto &input_port [[maybe_unused]] : _input_ports) {
-            assert(available_samples == input_port.streamReader().consume(available_samples));
+            auto consumed = input_port.streamReader().consume(available_samples);
+            assert(available_samples == consumed);
+            std::ignore = consumed;
         }
         return { requested_work, available_samples, gr::work::Status::OK };
     }

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -309,7 +309,7 @@ public:
         static_assert(portName.empty(), "port name must be exclusively declared via NTTP or constructor parameter");
     }
 
-    constexpr Port(Port &&other) noexcept : name(std::move(other.name)), priority{ other.priority }, min_samples(other.min_samples), max_samples(other.max_samples) {}
+    constexpr Port(Port &&other) noexcept : name(std::move(other.name)), priority{ other.priority }, min_samples(other.min_samples), max_samples(other.max_samples), _connected(other._connected), _ioHandler(std::move(other._ioHandler)), _tagIoHandler(std::move(other._tagIoHandler)) {}
 
     constexpr Port &
     operator=(Port &&other) noexcept {

--- a/core/test/qa_DynamicBlock.cpp
+++ b/core/test/qa_DynamicBlock.cpp
@@ -1,8 +1,9 @@
 #include <list>
 
-#include <gnuradio-4.0/Graph.hpp>
+#include <boost/ut.hpp>
 
 #include <gnuradio-4.0/basic/common_blocks.hpp>
+#include <gnuradio-4.0/Graph.hpp>
 
 template<typename T>
 std::atomic_size_t multi_adder<T>::_unique_id_counter = 0;
@@ -29,54 +30,61 @@ static_assert(gr::traits::block::input_ports<fixed_source<int>>::size() == 0);
 static_assert(gr::traits::block::output_ports<fixed_source<int>>::size() == 1);
 
 template<typename T>
-struct cout_sink : public gr::Block<cout_sink<T>, gr::PortInNamed<T, "in">> {
-    std::size_t remaining = 0;
+struct DebugSink : public gr::Block<DebugSink<T>> {
+    T lastValue = {};
+    gr::PortIn<T> in;
 
     void
     processOne(T value) {
-        remaining--;
-        if (remaining == 0) {
-            std::cerr << "last value was: " << value << "\n";
-        }
+        lastValue = value;
     }
 };
 
-static_assert(gr::BlockLike<cout_sink<int>>);
+static_assert(gr::BlockLike<DebugSink<int>>);
 
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (cout_sink<T>), remaining);
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (DebugSink<T>), lastValue, in);
+
+const boost::ut::suite DynamicBlocktests = [] {
+    using namespace boost::ut;
+    "Change number of ports dynamically"_test = [] {
+        constexpr const std::size_t sources_count = 10;
+        constexpr const std::size_t events_count  = 5;
+
+        gr::Graph                   testGraph;
+
+        // Adder has sources_count inputs in total, but let's create
+        // sources_count / 2 inputs on construction, and change the number
+        // via settings
+        auto &adder = testGraph.addBlock(std::make_unique<multi_adder<double>>(sources_count / 2));
+        auto &sink  = testGraph.emplaceBlock<DebugSink<double>>({});
+
+        // Function that adds a new source node to the graph, and connects
+        // it to one of adder's ports
+        std::ignore = adder.settings().set({ { "input_port_count", 10 } });
+        std::ignore = adder.settings().applyStagedParameters();
+
+        std::vector<fixed_source<double> *> sources;
+        for (std::size_t i = 0; i < sources_count; ++i) {
+            auto &source = testGraph.emplaceBlock<fixed_source<double>>();
+            sources.push_back(&source);
+            testGraph.connect(source, 0, adder, sources.size() - 1);
+        }
+
+        testGraph.connect(adder, 0, sink, 0);
+
+        for (std::size_t i = 0; i < events_count; ++i) {
+            for (auto *source : sources) {
+                source->work(std::numeric_limits<std::size_t>::max());
+            }
+            std::ignore     = adder.work(std::numeric_limits<std::size_t>::max());
+            const auto work = sink.work(std::numeric_limits<std::size_t>::max());
+            expect(eq(work.performed_work, 1UZ));
+
+            expect(eq(sink.lastValue, static_cast<double>((i + 1) * sources.size())));
+        }
+    };
+};
 
 int
-main() {
-    constexpr const std::size_t sources_count = 10;
-    constexpr const std::size_t events_count  = 5;
-
-    gr::Graph testGraph;
-
-    // Adder has sources_count inputs in total, but let's create
-    // sources_count / 2 inputs on construction, and change the number
-    // via settings
-    auto &adder = testGraph.addBlock(std::make_unique<multi_adder<double>>(sources_count / 2));
-    auto &sink  = testGraph.emplaceBlock<cout_sink<double>>({ { "remaining", events_count } });
-
-    // Function that adds a new source node to the graph, and connects
-    // it to one of adder's ports
-    std::ignore = adder.settings().set({ { "input_port_count", 10 } });
-    std::ignore = adder.settings().applyStagedParameters();
-
-    std::vector<fixed_source<double> *> sources;
-    for (std::size_t i = 0; i < sources_count; ++i) {
-        auto &source = testGraph.emplaceBlock<fixed_source<double>>();
-        sources.push_back(&source);
-        testGraph.connect(source, 0, adder, sources.size() - 1);
-    }
-
-    testGraph.connect(adder, 0, sink, 0);
-
-    for (std::size_t i = 0; i < events_count; ++i) {
-        for (auto *source : sources) {
-            source->work(std::numeric_limits<std::size_t>::max());
-        }
-        std::ignore = adder.work(std::numeric_limits<std::size_t>::max());
-        std::ignore = sink.work(std::numeric_limits<std::size_t>::max());
-    }
+main() { /* tests are statically executed */
 }


### PR DESCRIPTION
This PR is split into three semantically distinct commits:

- Convert qa_DynamicBlock to a real boost ut test
- Add a test for dynamically reallocating the ports collection
- Fix reallocating Port instances

The final commit is the patch with the actual fix, the move constructor of `Port` was missing some fields, which caused connections to break as soon as a Port was relocated.

This already fixes https://github.com/fair-acc/opendigitizer/issues/90.

However, there is more to the relationship between `DynamicPort` and its `Port` counterpart. Since they are so tightly coupled together, moving a Port needs to modify the accessor in `DynamicPort`. This is not needed in the above unit test, because the `DynamicPort`s [are always recreated](https://github.com/fair-acc/graph-prototype/blob/427aea104b912c02c13063110c8780f9847d8682/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp#L94), when the `Port` moves so this is actually an unrelated issue, but it might be worthwhile to fix this in the future as well.

One possible (and naive) way to fix this problem is to add an reallocation callback to `Port`, that can be setup by `DynamicPort` to update its reference on `std::move`. More specifically this diff should do it:

```diff
diff --git a/core/include/gnuradio-4.0/Port.hpp b/core/include/gnuradio-4.0/Port.hpp
index e9a988d..227eb50 100644
--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -242,6 +242,7 @@ private:
     bool      _connected    = false;
     IoType    _ioHandler    = newIoHandler();
     TagIoType _tagIoHandler = newTagIoHandler();
+    std::function<void(Port<T, portName, portType, portDirection, Attributes...>&)> _moveCallback;
 
 public:
     [[nodiscard]] constexpr bool
@@ -298,6 +299,10 @@ public:
         return true;
     }
 
+    void setMoveCallback(decltype(_moveCallback) callback) {
+        this->_moveCallback = callback;
+    }
+
     constexpr Port()   = default;
     Port(const Port &) = delete;
     auto
@@ -309,7 +314,11 @@ public:
         static_assert(portName.empty(), "port name must be exclusively declared via NTTP or constructor parameter");
     }
 
-    constexpr Port(Port &&other) noexcept : name(std::move(other.name)), priority{ other.priority }, min_samples(other.min_samples), max_samples(other.max_samples) {}
+    constexpr Port(Port &&other) noexcept : name(std::move(other.name)), priority{ other.priority }, min_samples(other.min_samples), max_samples(other.max_samples), _connected(other._connected), _ioHandler(std::move(other._ioHandler)), _tagIoHandler(std::move(other._tagIoHandler)) {
+        if (_moveCallback) {
+            _moveCallback(*this);
+        }
+    }
 
     constexpr Port &
     operator=(Port &&other) noexcept {
@@ -783,7 +792,11 @@ public:
     // can not be reallocated
     template<PortLike T>
     explicit constexpr DynamicPort(T &arg, non_owned_reference_tag) noexcept
-        : name(arg.name), priority(arg.priority), min_samples(arg.min_samples), max_samples(arg.max_samples), _accessor{ std::make_unique<wrapper<T, false>>(arg) } {}
+        : name(arg.name), priority(arg.priority), min_samples(arg.min_samples), max_samples(arg.max_samples), _accessor{ std::make_unique<wrapper<T, false>>(arg) } {
+            arg.setMoveCallback([&](auto &newArg){
+                    this->_accessor = std::make_unique<wrapper<T, false>>(newArg);
+                });
+        }
 
     template<PortLike T>
     explicit constexpr DynamicPort(T &&arg, owned_value_tag) noexcept
```

However I have to admit I don't really like this solution, as it feels a lot like "hotpatching it in". A change in the architecture how we integrate `DynamicPort` and `Port` might be better.
In any case this is probably out of scope of this PR.
