### PR TITLE
re-enable POSIX buffer benchmarks

### DIFF
--- a/core/benchmarks/bm_Buffer.cpp
+++ b/core/benchmarks/bm_Buffer.cpp
@@ -129,7 +129,7 @@ inline const boost::ut::suite _buffer_tests = [] {
     enum class BufferStrategy { posix, portable };
 
     for (WriteApi writerAPI : { WriteApi::via_lambda, WriteApi::via_split_request_publish_RAII }) {
-        for (BufferStrategy strategy : { /*BufferStrategy::posix,*/ BufferStrategy::portable }) {
+        for (BufferStrategy strategy : { BufferStrategy::posix, BufferStrategy::portable }) {
             for (std::size_t veclen : { 1UL, 1024UL }) {
                 if (not(strategy == BufferStrategy::posix and veclen == 1UL)) {
                     benchmark::results::add_separator();


### PR DESCRIPTION
Benchmarks on AMD Ryzen 9 5900X:

**GCC 13.2.1**
```text
all micro-benchmarks passed:
┌─────────────────────────benchmark:─────────────────────────┬──────┬─#N─┬─CTX-SW─┬───CPU cache misses────┬───CPU branch misses───┬─<CPU-I>─┬──min───┬──mean──┬─stddev─┬─median─┬──max───┬─total time─┬─ops/s─┐
│    POSIX: 1 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 9.08k / 19.8k = 45.8% │ 5.48k / 37.3k = 14.7% │    1.9m │ 158 ms │ 160 ms │   1 ms │ 160 ms │ 162 ms │       1  s │ 62.5M │
│    POSIX: 1 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 3.18k / 13.9k = 23.0% │ 5.04k / 36.6k = 13.8% │    1.9m │ 253 ms │ 274 ms │  13 ms │ 282 ms │ 287 ms │       2  s │ 36.6M │
│    POSIX: 1 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 3.13k / 13.6k = 23.1% │ 5.14k / 37.5k = 13.7% │    1.9m │ 374 ms │ 424 ms │  34 ms │ 447 ms │ 471 ms │       3  s │ 23.6M │
│    POSIX: 2 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 5.04k / 17.3k = 29.1% │ 5.31k / 37.1k = 14.3% │    1.9m │ 664 ms │ 670 ms │   5 ms │ 668 ms │ 679 ms │       5  s │ 14.9M │
│    POSIX: 2 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 4.07k / 15.9k = 25.6% │ 5.47k / 38.2k = 14.3% │    2.0m │ 913 ms │ 920 ms │   4 ms │ 920 ms │ 926 ms │       7  s │ 10.9M │
│    POSIX: 2 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 4.55k / 17.0k = 26.8% │ 5.84k / 40.4k = 14.5% │    2.1m │   1  s │   1  s │   2 ms │   1  s │   1  s │      10  s │  7.9M │
│    POSIX: 4 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 4.74k / 16.8k = 28.2% │ 5.91k / 39.0k = 15.2% │    2.0m │ 848 ms │ 851 ms │   2 ms │ 851 ms │ 855 ms │       7  s │ 11.8M │
│    POSIX: 4 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 5.01k / 15.8k = 31.7% │ 6.20k / 40.1k = 15.5% │    2.1m │   1  s │   1  s │   3 ms │   1  s │   1  s │       8  s │  9.6M │
│    POSIX: 4 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 5.23k / 18.1k = 28.9% │ 6.34k / 42.4k = 15.0% │    2.2m │   2  s │   2  s │   2 ms │   2  s │   2  s │      17  s │  4.7M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│    POSIX: 1 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 1.98k / 11.1k = 17.8% │ 4.64k / 36.0k = 12.9% │    1.9m │ 164 us │ 167 us │   2 us │ 167 us │ 171 us │       1 ms │ 59.9G │
│    POSIX: 1 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 1.13k / 10.6k = 10.7% │ 4.64k / 36.8k = 12.6% │    1.9m │ 270 us │ 283 us │  14 us │ 280 us │ 318 us │       2 ms │ 35.3G │
│    POSIX: 1 producers -<1024>-> 4 consumers                │ PASS │ 8  │    12  │ 1.43k / 12.4k = 11.5% │ 6.32k / 48.6k = 13.0% │    2.5m │ 414 us │ 447 us │  25 us │ 458 us │ 483 us │       4 ms │ 22.4G │
│    POSIX: 2 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 1.31k / 10.6k = 12.4% │ 4.62k / 36.6k = 12.6% │    1.9m │ 661 us │ 708 us │  56 us │ 691 us │ 805 us │       6 ms │ 14.1G │
│    POSIX: 2 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 1.41k / 11.3k = 12.5% │ 4.85k / 38.2k = 12.7% │    2.0m │ 907 us │ 920 us │  13 us │ 918 us │ 950 us │       7 ms │ 10.9G │
│    POSIX: 2 producers -<1024>-> 4 consumers                │ PASS │ 8  │    10  │ 1.45k / 11.2k = 12.9% │ 5.70k / 44.5k = 12.8% │    2.3m │   1 ms │   1 ms │  70 us │   1 ms │   1 ms │      10 ms │  7.9G │
│    POSIX: 4 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 1.53k / 9.16k = 16.7% │ 4.92k / 38.9k = 12.7% │    2.0m │ 877 us │ 893 us │  14 us │ 889 us │ 920 us │       7 ms │ 11.2G │
│    POSIX: 4 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 1.77k / 10.7k = 16.6% │ 5.04k / 39.8k = 12.6% │    2.0m │ 986 us │   1 ms │  20 us │   1 ms │   1 ms │       8 ms │  9.7G │
│    POSIX: 4 producers -<1024>-> 4 consumers                │ PASS │ 8  │    12  │ 1.62k / 12.0k = 13.5% │ 6.70k / 51.6k = 13.0% │    2.7m │   2 ms │   2 ms │  21 us │   2 ms │   2 ms │      17 ms │  4.6G │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ portable: 1 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 13.2k / 24.8k = 53.3% │ 6.02k / 35.7k = 16.8% │    1.8m │ 176 ms │ 177 ms │ 690 us │ 177 ms │ 178 ms │       1  s │ 56.3M │
│ portable: 1 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 2.68k / 12.6k = 21.3% │ 5.10k / 37.0k = 13.8% │    1.9m │ 221 ms │ 226 ms │  11 ms │ 222 ms │ 254 ms │       2  s │ 44.3M │
│ portable: 1 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 3.02k / 13.4k = 22.5% │ 5.17k / 37.5k = 13.8% │    1.9m │ 351 ms │ 410 ms │  29 ms │ 424 ms │ 445 ms │       3  s │ 24.4M │
│ portable: 2 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 4.06k / 15.8k = 25.7% │ 5.18k / 37.0k = 14.0% │    1.9m │ 606 ms │ 617 ms │   6 ms │ 619 ms │ 627 ms │       5  s │ 16.2M │
│ portable: 2 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 4.14k / 16.1k = 25.7% │ 5.22k / 38.2k = 13.7% │    2.0m │ 877 ms │ 883 ms │   3 ms │ 884 ms │ 886 ms │       7  s │ 11.3M │
│ portable: 2 producers -< 1  >-> 4 consumers                │ PASS │ 8  │    13  │ 3.36k / 16.8k = 20.1% │ 7.18k / 52.1k = 13.8% │    2.7m │   1  s │   1  s │   4 ms │   1  s │   1  s │       9  s │  8.5M │
│ portable: 4 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 4.80k / 16.1k = 29.9% │ 6.16k / 40.0k = 15.4% │    2.1m │ 898 ms │ 904 ms │   5 ms │ 902 ms │ 911 ms │       7  s │ 11.1M │
│ portable: 4 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 4.86k / 16.0k = 30.4% │ 6.07k / 39.7k = 15.3% │    2.0m │   1  s │   1  s │   3 ms │   1  s │   1  s │       9  s │  9.2M │
│ portable: 4 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 4.78k / 15.9k = 30.0% │ 6.36k / 41.8k = 15.2% │    2.1m │   2  s │   2  s │   2 ms │   2  s │   2  s │      17  s │  4.7M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ portable: 1 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 6.38k / 16.7k = 38.2% │ 5.28k / 35.9k = 14.7% │    1.8m │ 924 us │   2 ms │ 240 us │   2 ms │   2 ms │      12 ms │  6.6G │
│ portable: 1 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 1.25k / 10.8k = 11.5% │ 4.69k / 37.1k = 12.6% │    1.9m │   1 ms │   1 ms │  86 us │   1 ms │   1 ms │       9 ms │  9.4G │
│ portable: 1 producers -<1024>-> 4 consumers                │ PASS │ 8  │    10  │ 1.37k / 11.0k = 12.5% │ 5.62k / 43.3k = 13.0% │    2.2m │   1 ms │   1 ms │ 169 us │   1 ms │   2 ms │       9 ms │  8.9G │
│ portable: 2 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 1.37k / 10.9k = 12.6% │ 4.65k / 36.8k = 12.6% │    1.9m │   1 ms │   1 ms │  76 us │   1 ms │   1 ms │      10 ms │  8.3G │
│ portable: 2 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 1.50k / 11.3k = 13.2% │ 4.80k / 37.9k = 12.6% │    2.0m │   1 ms │   1 ms │  43 us │   1 ms │   1 ms │      11 ms │  7.6G │
│ portable: 2 producers -<1024>-> 4 consumers                │ PASS │ 8  │     9  │ 1.49k / 11.1k = 13.4% │ 5.28k / 41.2k = 12.8% │    2.1m │   1 ms │   2 ms │  56 us │   1 ms │   2 ms │      12 ms │  6.6G │
│ portable: 4 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 3.22k / 14.4k = 22.3% │ 4.89k / 38.9k = 12.6% │    2.0m │ 809 us │ 822 us │  13 us │ 818 us │ 853 us │       7 ms │ 12.2G │
│ portable: 4 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 3.41k / 13.6k = 25.0% │ 5.04k / 40.2k = 12.5% │    2.1m │ 914 us │ 947 us │  72 us │ 922 us │   1 ms │       8 ms │ 10.6G │
│ portable: 4 producers -<1024>-> 4 consumers                │ PASS │ 8  │    10  │ 2.88k / 11.6k = 24.8% │ 5.75k / 44.9k = 12.8% │    2.3m │   2 ms │   2 ms │  24 us │   2 ms │   2 ms │      14 ms │  5.9G │
│ POSIX - RAII writer: 1 producers -< 1  >-> 1 consumers     │ PASS │ 8  │     8  │ 13.6k / 26.3k = 51.6% │ 6.03k / 37.4k = 16.1% │    1.8m │ 157 ms │ 168 ms │   5 ms │ 171 ms │ 172 ms │       1  s │ 59.6M │
│ POSIX - RAII writer: 1 producers -< 1  >-> 2 consumers     │ PASS │ 8  │     8  │ 2.71k / 13.2k = 20.5% │ 5.04k / 37.0k = 13.6% │    1.9m │ 314 ms │ 319 ms │   3 ms │ 320 ms │ 323 ms │       3  s │ 31.3M │
│ POSIX - RAII writer: 1 producers -< 1  >-> 4 consumers     │ PASS │ 8  │     8  │ 2.94k / 13.7k = 21.5% │ 5.19k / 37.8k = 13.7% │    1.9m │ 380 ms │ 442 ms │  25 ms │ 452 ms │ 465 ms │       4  s │ 22.6M │
│ POSIX - RAII writer: 2 producers -< 1  >-> 1 consumers     │ PASS │ 8  │     8  │ 3.80k / 15.6k = 24.4% │ 5.11k / 37.1k = 13.8% │    1.9m │ 638 ms │ 640 ms │   2 ms │ 640 ms │ 644 ms │       5  s │ 15.6M │
│ POSIX - RAII writer: 2 producers -< 1  >-> 2 consumers     │ PASS │ 8  │    10  │ 3.90k / 16.7k = 23.4% │ 6.02k / 43.6k = 13.8% │    2.2m │ 870 ms │ 874 ms │   3 ms │ 874 ms │ 878 ms │       7  s │ 11.4M │
│ POSIX - RAII writer: 2 producers -< 1  >-> 4 consumers     │ PASS │ 8  │     8  │ 4.25k / 16.8k = 25.3% │ 5.64k / 40.4k = 14.0% │    2.1m │   1  s │   1  s │  19 ms │   1  s │   1  s │      10  s │  8.2M │
│ POSIX - RAII writer: 4 producers -< 1  >-> 1 consumers     │ PASS │ 8  │     8  │ 4.16k / 15.4k = 27.0% │ 5.91k / 38.7k = 15.3% │    2.0m │ 868 ms │ 870 ms │ 890 us │ 870 ms │ 871 ms │       7  s │ 11.5M │
│ POSIX - RAII writer: 4 producers -< 1  >-> 2 consumers     │ PASS │ 8  │     8  │ 4.86k / 16.7k = 29.1% │ 6.14k / 39.8k = 15.4% │    2.0m │   1  s │   1  s │   1 ms │   1  s │   1  s │       8  s │  9.6M │
│ POSIX - RAII writer: 4 producers -< 1  >-> 4 consumers     │ PASS │ 8  │     8  │ 5.33k / 17.4k = 30.6% │ 6.36k / 41.7k = 15.2% │    2.1m │   2  s │   2  s │ 815 us │   2  s │   2  s │      16  s │  5.0M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ POSIX - RAII writer: 1 producers -<1024>-> 1 consumers     │ PASS │ 8  │     8  │ 2.67k / 12.2k = 22.0% │ 4.75k / 35.9k = 13.2% │    1.8m │ 175 us │ 178 us │   2 us │ 178 us │ 181 us │       1 ms │ 56.3G │
│ POSIX - RAII writer: 1 producers -<1024>-> 2 consumers     │ PASS │ 8  │     8  │ 1.15k / 10.8k = 10.6% │ 4.69k / 37.0k = 12.7% │    1.9m │ 252 us │ 345 us │  39 us │ 356 us │ 385 us │       3 ms │ 29.0G │
│ POSIX - RAII writer: 1 producers -<1024>-> 4 consumers     │ PASS │ 8  │    11  │ 1.35k / 11.6k = 11.6% │ 5.93k / 46.1k = 12.9% │    2.4m │ 381 us │ 439 us │  49 us │ 431 us │ 525 us │       4 ms │ 22.8G │
│ POSIX - RAII writer: 2 producers -<1024>-> 1 consumers     │ PASS │ 8  │     8  │ 1.10k / 10.2k = 10.8% │ 4.57k / 36.7k = 12.4% │    1.9m │ 641 us │ 654 us │  10 us │ 654 us │ 677 us │       5 ms │ 15.3G │
│ POSIX - RAII writer: 2 producers -<1024>-> 2 consumers     │ PASS │ 8  │     8  │ 1.40k / 11.5k = 12.1% │ 4.81k / 38.1k = 12.6% │    2.0m │ 849 us │ 855 us │   8 us │ 853 us │ 875 us │       7 ms │ 11.7G │
│ POSIX - RAII writer: 2 producers -<1024>-> 4 consumers     │ PASS │ 8  │     8  │ 1.55k / 10.8k = 14.4% │ 4.99k / 39.4k = 12.7% │    2.0m │   1 ms │   1 ms │  10 us │   1 ms │   1 ms │       9 ms │  8.6G │
│ POSIX - RAII writer: 4 producers -<1024>-> 1 consumers     │ PASS │ 8  │     8  │ 1.51k / 9.85k = 15.3% │ 4.90k / 38.8k = 12.6% │    2.0m │ 877 us │ 893 us │  11 us │ 895 us │ 916 us │       7 ms │ 11.2G │
│ POSIX - RAII writer: 4 producers -<1024>-> 2 consumers     │ PASS │ 8  │     8  │ 1.53k / 10.6k = 14.5% │ 4.99k / 39.8k = 12.5% │    2.0m │   1 ms │   1 ms │  15 us │   1 ms │   1 ms │       8 ms │  9.5G │
│ POSIX - RAII writer: 4 producers -<1024>-> 4 consumers     │ PASS │ 8  │     9  │ 1.66k / 12.7k = 13.1% │ 5.66k / 44.1k = 12.8% │    2.3m │   2 ms │   2 ms │  17 us │   2 ms │   2 ms │      17 ms │  4.7G │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ portable - RAII writer: 1 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 13.3k / 25.0k = 53.1% │ 6.03k / 35.7k = 16.9% │    1.8m │ 184 ms │ 184 ms │ 507 us │ 185 ms │ 185 ms │       1  s │ 54.2M │
│ portable - RAII writer: 1 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 5.59k / 16.8k = 33.3% │ 5.31k / 37.1k = 14.3% │    1.9m │ 264 ms │ 272 ms │   6 ms │ 275 ms │ 282 ms │       2  s │ 36.7M │
│ portable - RAII writer: 1 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 3.34k / 13.4k = 24.9% │ 5.25k / 37.8k = 13.9% │    1.9m │ 324 ms │ 378 ms │  36 ms │ 388 ms │ 437 ms │       3  s │ 26.5M │
│ portable - RAII writer: 2 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     9  │ 12.8k / 25.4k = 50.4% │ 6.41k / 38.1k = 16.8% │    2.0m │ 608 ms │ 619 ms │   8 ms │ 619 ms │ 637 ms │       5  s │ 16.1M │
│ portable - RAII writer: 2 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 4.24k / 16.5k = 25.7% │ 5.34k / 38.3k = 14.0% │    2.0m │ 892 ms │ 930 ms │  22 ms │ 940 ms │ 965 ms │       7  s │ 10.8M │
│ portable - RAII writer: 2 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 4.20k / 15.7k = 26.8% │ 5.61k / 40.1k = 14.0% │    2.1m │   1  s │   1  s │   6 ms │   1  s │   1  s │      10  s │  8.2M │
│ portable - RAII writer: 4 producers -< 1  >-> 1 consumers  │ PASS │ 8  │    14  │ 4.76k / 19.2k = 24.8% │ 8.11k / 59.9k = 13.5% │    3.1m │ 867 ms │ 884 ms │   8 ms │ 883 ms │ 895 ms │       7  s │ 11.3M │
│ portable - RAII writer: 4 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     9  │ 3.58k / 14.6k = 24.5% │ 6.11k / 44.0k = 13.9% │    2.2m │   1  s │   1  s │  13 ms │   1  s │   1  s │       8  s │  9.6M │
│ portable - RAII writer: 4 producers -< 1  >-> 4 consumers  │ PASS │ 8  │    10  │ 3.41k / 14.4k = 23.7% │ 6.51k / 46.8k = 13.9% │    2.4m │   2  s │   2  s │   6 ms │   2  s │   2  s │      16  s │  5.0M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ portable - RAII writer: 1 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 1.76k / 11.4k = 15.4% │ 4.61k / 36.0k = 12.8% │    1.9m │ 887 us │ 904 us │  23 us │ 895 us │ 955 us │       7 ms │ 11.1G │
│ portable - RAII writer: 1 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.19k / 11.7k = 18.7% │ 4.68k / 37.0k = 12.6% │    1.9m │ 946 us │ 990 us │ 100 us │ 953 us │   1 ms │       8 ms │ 10.1G │
│ portable - RAII writer: 1 producers -<1024>-> 4 consumers  │ PASS │ 8  │     9  │ 1.35k / 9.95k = 13.6% │ 5.38k / 41.8k = 12.9% │    2.1m │   1 ms │   1 ms │ 153 us │   1 ms │   1 ms │       9 ms │  9.3G │
│ portable - RAII writer: 2 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 2.10k / 11.4k = 18.4% │ 4.59k / 36.7k = 12.5% │    1.9m │   1 ms │   1 ms │  11 us │   1 ms │   1 ms │       9 ms │  8.5G │
│ portable - RAII writer: 2 producers -<1024>-> 2 consumers  │ PASS │ 8  │     9  │ 2.08k / 12.5k = 16.6% │ 5.28k / 40.7k = 13.0% │    2.1m │   1 ms │   2 ms │ 441 us │   1 ms │   3 ms │      12 ms │  6.7G │
│ portable - RAII writer: 2 producers -<1024>-> 4 consumers  │ PASS │ 8  │    10  │ 1.53k / 12.3k = 12.4% │ 5.70k / 44.8k = 12.7% │    2.3m │   1 ms │   2 ms │  68 us │   2 ms │   2 ms │      12 ms │  6.6G │
│ portable - RAII writer: 4 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 3.09k / 15.0k = 20.6% │ 4.91k / 38.9k = 12.6% │    2.0m │ 820 us │ 828 us │   7 us │ 827 us │ 846 us │       7 ms │ 12.1G │
│ portable - RAII writer: 4 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 3.10k / 12.6k = 24.6% │ 5.03k / 40.2k = 12.5% │    2.1m │ 918 us │ 961 us │  66 us │ 929 us │   1 ms │       8 ms │ 10.4G │
│ portable - RAII writer: 4 producers -<1024>-> 4 consumers  │ PASS │ 8  │    10  │ 3.22k / 14.4k = 22.4% │ 5.98k / 46.5k = 12.9% │    2.4m │   2 ms │   2 ms │  60 us │   2 ms │   2 ms │      14 ms │  5.5G │
└────────────────────────────────────────────────────────────┴──────┴────┴────────┴───────────────────────┴───────────────────────┴─────────┴────────┴────────┴────────┴────────┴────────┴────────────┴───────┘
```

Clang 17.0.6
```text
all micro-benchmarks passed:
┌─────────────────────────benchmark:─────────────────────────┬──────┬─#N─┬─CTX-SW─┬───CPU cache misses────┬───CPU branch misses───┬─<CPU-I>─┬──min───┬──mean──┬─stddev─┬─median─┬──max───┬─total time─┬─ops/s─┐
│    POSIX: 1 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 12.6k / 25.1k = 50.4% │ 6.04k / 37.4k = 16.2% │    1.9m │ 170 ms │ 173 ms │   1 ms │ 174 ms │ 175 ms │       1  s │ 57.7M │
│    POSIX: 1 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 11.6k / 23.2k = 50.2% │ 5.85k / 36.7k = 16.0% │    1.9m │ 289 ms │ 298 ms │   6 ms │ 299 ms │ 305 ms │       2  s │ 33.6M │
│    POSIX: 1 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 9.77k / 20.5k = 47.6% │ 5.61k / 38.4k = 14.6% │    2.0m │ 310 ms │ 355 ms │  34 ms │ 350 ms │ 401 ms │       3  s │ 28.2M │
│    POSIX: 2 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 12.8k / 25.0k = 51.4% │ 5.99k / 36.5k = 16.4% │    1.9m │ 639 ms │ 654 ms │  11 ms │ 654 ms │ 681 ms │       5  s │ 15.3M │
│    POSIX: 2 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 14.4k / 28.4k = 50.7% │ 6.30k / 39.9k = 15.8% │    2.0m │ 849 ms │ 864 ms │   8 ms │ 866 ms │ 875 ms │       7  s │ 11.6M │
│    POSIX: 2 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 11.2k / 23.3k = 48.1% │ 6.28k / 39.9k = 15.7% │    2.1m │   1  s │   1  s │  21 ms │   1  s │   1  s │       9  s │  8.6M │
│    POSIX: 4 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     9  │ 10.6k / 23.2k = 45.5% │ 6.36k / 41.2k = 15.4% │    2.1m │ 803 ms │ 809 ms │   4 ms │ 808 ms │ 814 ms │       6  s │ 12.4M │
│    POSIX: 4 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 13.7k / 26.8k = 51.2% │ 6.60k / 40.2k = 16.4% │    2.1m │   1  s │   1  s │   3 ms │   1  s │   1  s │       8  s │  9.8M │
│    POSIX: 4 producers -< 1  >-> 4 consumers                │ PASS │ 8  │    10  │ 3.74k / 15.3k = 24.5% │ 6.37k / 45.2k = 14.1% │    2.3m │   2  s │   2  s │   2 ms │   2  s │   2  s │      16  s │  5.0M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│    POSIX: 1 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 1.82k / 11.4k = 16.0% │ 4.61k / 36.0k = 12.8% │    1.9m │ 178 us │ 182 us │   3 us │ 183 us │ 188 us │       1 ms │ 54.8G │
│    POSIX: 1 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 1.88k / 11.7k = 16.0% │ 4.67k / 36.9k = 12.7% │    1.9m │ 270 us │ 314 us │  23 us │ 319 us │ 340 us │       3 ms │ 31.9G │
│    POSIX: 1 producers -<1024>-> 4 consumers                │ PASS │ 8  │     8  │ 2.18k / 12.8k = 17.1% │ 4.67k / 37.0k = 12.6% │    1.9m │ 384 us │ 428 us │  31 us │ 449 us │ 471 us │       3 ms │ 23.3G │
│    POSIX: 2 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.00k / 12.7k = 15.7% │ 4.61k / 36.9k = 12.5% │    1.9m │ 656 us │ 697 us │  28 us │ 696 us │ 740 us │       6 ms │ 14.3G │
│    POSIX: 2 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.07k / 11.8k = 17.5% │ 4.75k / 37.9k = 12.5% │    2.0m │ 847 us │ 876 us │  27 us │ 875 us │ 936 us │       7 ms │ 11.4G │
│    POSIX: 2 producers -<1024>-> 4 consumers                │ PASS │ 8  │     8  │ 2.94k / 13.7k = 21.5% │ 5.04k / 39.6k = 12.7% │    2.0m │   1 ms │   1 ms │  24 us │   1 ms │   1 ms │      10 ms │  8.0G │
│    POSIX: 4 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.66k / 12.8k = 20.7% │ 4.98k / 39.0k = 12.8% │    2.0m │ 823 us │ 834 us │   9 us │ 829 us │ 851 us │       7 ms │ 12.0G │
│    POSIX: 4 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.29k / 13.4k = 17.2% │ 5.20k / 40.2k = 12.9% │    2.1m │ 987 us │   1 ms │  17 us │   1 ms │   1 ms │       8 ms │  9.9G │
│    POSIX: 4 producers -<1024>-> 4 consumers                │ PASS │ 8  │     8  │ 2.72k / 11.8k = 23.1% │ 5.64k / 42.6k = 13.2% │    2.2m │   2 ms │   2 ms │  69 us │   2 ms │   2 ms │      15 ms │  5.2G │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ portable: 1 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 13.3k / 25.5k = 52.3% │ 5.98k / 35.6k = 16.8% │    1.8m │ 194 ms │ 196 ms │   1 ms │ 197 ms │ 198 ms │       2  s │ 51.0M │
│ portable: 1 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 13.4k / 26.0k = 51.5% │ 6.24k / 36.9k = 16.9% │    1.9m │ 272 ms │ 281 ms │   6 ms │ 282 ms │ 289 ms │       2  s │ 35.6M │
│ portable: 1 producers -< 1  >-> 4 consumers                │ PASS │ 8  │     8  │ 10.4k / 21.9k = 47.4% │ 5.99k / 39.2k = 15.3% │    2.0m │ 287 ms │ 349 ms │  69 ms │ 334 ms │ 501 ms │       3  s │ 28.6M │
│ portable: 2 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     8  │ 12.2k / 24.2k = 50.5% │ 5.93k / 36.6k = 16.2% │    1.9m │ 613 ms │ 623 ms │   6 ms │ 628 ms │ 630 ms │       5  s │ 16.1M │
│ portable: 2 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 12.0k / 24.0k = 50.0% │ 6.09k / 37.6k = 16.2% │    1.9m │ 919 ms │ 943 ms │  23 ms │ 940 ms │ 983 ms │       8  s │ 10.6M │
│ portable: 2 producers -< 1  >-> 4 consumers                │ PASS │ 8  │    10  │ 3.77k / 15.3k = 24.6% │ 6.21k / 43.4k = 14.3% │    2.2m │   1  s │   1  s │   4 ms │   1  s │   1  s │       9  s │  8.5M │
│ portable: 4 producers -< 1  >-> 1 consumers                │ PASS │ 8  │     9  │ 9.62k / 21.6k = 44.4% │ 6.75k / 44.1k = 15.3% │    2.3m │ 896 ms │ 902 ms │   3 ms │ 902 ms │ 908 ms │       7  s │ 11.1M │
│ portable: 4 producers -< 1  >-> 2 consumers                │ PASS │ 8  │     8  │ 4.42k / 17.1k = 25.8% │ 5.62k / 40.3k = 14.0% │    2.1m │   1  s │   1  s │   5 ms │   1  s │   1  s │       9  s │  9.2M │
│ portable: 4 producers -< 1  >-> 4 consumers                │ PASS │ 8  │    11  │ 3.59k / 15.8k = 22.6% │ 7.16k / 51.1k = 14.0% │    2.6m │   2  s │   2  s │   2 ms │   2  s │   2  s │      17  s │  4.8M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ portable: 1 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 1.76k / 11.4k = 15.5% │ 4.55k / 35.8k = 12.7% │    1.9m │   2 ms │   2 ms │  17 us │   2 ms │   2 ms │      14 ms │  5.7G │
│ portable: 1 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.63k / 13.6k = 19.3% │ 4.98k / 38.6k = 12.9% │    2.0m │   1 ms │   1 ms │ 133 us │   1 ms │   1 ms │       9 ms │  9.4G │
│ portable: 1 producers -<1024>-> 4 consumers                │ PASS │ 8  │     8  │ 2.64k / 12.4k = 21.4% │ 4.83k / 38.3k = 12.6% │    2.0m │   1 ms │   1 ms │ 102 us │   1 ms │   1 ms │       9 ms │  9.2G │
│ portable: 2 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.11k / 11.4k = 18.5% │ 4.56k / 36.6k = 12.5% │    1.9m │   1 ms │   1 ms │  12 us │   1 ms │   1 ms │       9 ms │  8.8G │
│ portable: 2 producers -<1024>-> 2 consumers                │ PASS │ 8  │     8  │ 2.19k / 11.9k = 18.5% │ 4.82k / 38.3k = 12.6% │    2.0m │   1 ms │   1 ms │  51 us │   1 ms │   1 ms │      10 ms │  7.7G │
│ portable: 2 producers -<1024>-> 4 consumers                │ PASS │ 8  │     8  │ 1.84k / 12.2k = 15.1% │ 5.12k / 40.2k = 12.7% │    2.1m │   1 ms │   1 ms │  72 us │   1 ms │   2 ms │      12 ms │  6.7G │
│ portable: 4 producers -<1024>-> 1 consumers                │ PASS │ 8  │     8  │ 2.41k / 13.4k = 18.1% │ 5.22k / 40.8k = 12.8% │    2.1m │ 792 us │ 803 us │   9 us │ 803 us │ 824 us │       6 ms │ 12.5G │
│ portable: 4 producers -<1024>-> 2 consumers                │ PASS │ 8  │     9  │ 5.25k / 17.2k = 30.5% │ 5.84k / 42.5k = 13.8% │    2.2m │ 880 us │ 931 us │  83 us │ 896 us │   1 ms │       7 ms │ 10.7G │
│ portable: 4 producers -<1024>-> 4 consumers                │ PASS │ 8  │    11  │ 3.08k / 14.1k = 21.9% │ 6.40k / 48.2k = 13.3% │    2.5m │   2 ms │   2 ms │  66 us │   2 ms │   2 ms │      14 ms │  5.8G │
│ POSIX - RAII writer: 1 producers -< 1  >-> 1 consumers     │ PASS │ 8  │     8  │ 10.9k / 21.7k = 50.3% │ 5.53k / 35.6k = 15.5% │    1.8m │ 214 ms │ 314 ms │  71 ms │ 339 ms │ 460 ms │       3  s │ 31.8M │
│ POSIX - RAII writer: 1 producers -< 1  >-> 2 consumers     │ PASS │ 8  │     8  │ 14.1k / 26.3k = 53.4% │ 6.14k / 36.5k = 16.8% │    1.9m │ 286 ms │ 352 ms │  64 ms │ 359 ms │ 444 ms │       3  s │ 28.4M │
│ POSIX - RAII writer: 1 producers -< 1  >-> 4 consumers     │ PASS │ 8  │     8  │ 14.3k / 27.1k = 52.6% │ 6.45k / 38.7k = 16.7% │    2.0m │ 345 ms │ 375 ms │  34 ms │ 376 ms │ 454 ms │       3  s │ 26.7M │
│ POSIX - RAII writer: 2 producers -< 1  >-> 1 consumers     │ PASS │ 8  │     8  │ 12.2k / 24.5k = 49.6% │ 6.19k / 37.4k = 16.6% │    1.9m │ 630 ms │ 636 ms │   2 ms │ 636 ms │ 639 ms │       5  s │ 15.7M │
│ POSIX - RAII writer: 2 producers -< 1  >-> 2 consumers     │ PASS │ 8  │     8  │ 13.7k / 26.0k = 52.6% │ 6.24k / 37.6k = 16.6% │    1.9m │ 873 ms │ 877 ms │   3 ms │ 878 ms │ 881 ms │       7  s │ 11.4M │
│ POSIX - RAII writer: 2 producers -< 1  >-> 4 consumers     │ PASS │ 8  │     8  │ 10.3k / 21.6k = 47.4% │ 6.01k / 38.6k = 15.6% │    2.0m │   1  s │   1  s │   8 ms │   1  s │   1  s │      10  s │  8.4M │
│ POSIX - RAII writer: 4 producers -< 1  >-> 1 consumers     │ PASS │ 8  │    10  │ 9.97k / 23.3k = 42.7% │ 6.60k / 43.5k = 15.2% │    2.2m │ 796 ms │ 807 ms │   6 ms │ 807 ms │ 815 ms │       6  s │ 12.4M │
│ POSIX - RAII writer: 4 producers -< 1  >-> 2 consumers     │ PASS │ 8  │    10  │ 9.48k / 22.2k = 42.8% │ 7.09k / 47.1k = 15.1% │    2.4m │   1  s │   1  s │   6 ms │   1  s │   1  s │       8  s │  9.7M │
│ POSIX - RAII writer: 4 producers -< 1  >-> 4 consumers     │ PASS │ 8  │     8  │ 13.9k / 26.9k = 51.7% │ 6.84k / 42.0k = 16.3% │    2.2m │   2  s │   2  s │   9 ms │   2  s │   2  s │      16  s │  4.9M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ POSIX - RAII writer: 1 producers -<1024>-> 1 consumers     │ PASS │ 8  │     8  │ 2.74k / 12.3k = 22.2% │ 4.74k / 35.7k = 13.3% │    1.8m │ 185 us │ 187 us │   2 us │ 187 us │ 191 us │       1 ms │ 53.4G │
│ POSIX - RAII writer: 1 producers -<1024>-> 2 consumers     │ PASS │ 8  │     8  │ 2.60k / 11.6k = 22.4% │ 4.69k / 36.8k = 12.8% │    1.9m │ 285 us │ 305 us │  14 us │ 303 us │ 336 us │       2 ms │ 32.8G │
│ POSIX - RAII writer: 1 producers -<1024>-> 4 consumers     │ PASS │ 8  │     8  │ 2.24k / 11.7k = 19.1% │ 4.88k / 38.3k = 12.7% │    2.0m │ 402 us │ 455 us │  35 us │ 461 us │ 523 us │       4 ms │ 22.0G │
│ POSIX - RAII writer: 2 producers -<1024>-> 1 consumers     │ PASS │ 8  │     8  │ 2.09k / 11.5k = 18.3% │ 4.64k / 36.8k = 12.6% │    1.9m │ 630 us │ 646 us │  17 us │ 643 us │ 686 us │       5 ms │ 15.5G │
│ POSIX - RAII writer: 2 producers -<1024>-> 2 consumers     │ PASS │ 8  │     8  │ 3.06k / 12.5k = 24.5% │ 4.80k / 37.9k = 12.7% │    2.0m │ 865 us │ 880 us │  16 us │ 876 us │ 918 us │       7 ms │ 11.4G │
│ POSIX - RAII writer: 2 producers -<1024>-> 4 consumers     │ PASS │ 8  │     8  │ 2.53k / 13.5k = 18.7% │ 5.03k / 39.6k = 12.7% │    2.0m │   1 ms │   1 ms │  19 us │   1 ms │   1 ms │      10 ms │  8.4G │
│ POSIX - RAII writer: 4 producers -<1024>-> 1 consumers     │ PASS │ 8  │     8  │ 2.80k / 12.4k = 22.7% │ 4.88k / 38.9k = 12.5% │    2.0m │ 837 us │ 855 us │  15 us │ 853 us │ 889 us │       7 ms │ 11.7G │
│ POSIX - RAII writer: 4 producers -<1024>-> 2 consumers     │ PASS │ 8  │     8  │ 3.79k / 13.6k = 27.9% │ 5.11k / 40.1k = 12.7% │    2.1m │   1 ms │   1 ms │  16 us │   1 ms │   1 ms │       8 ms │  9.6G │
│ POSIX - RAII writer: 4 producers -<1024>-> 4 consumers     │ PASS │ 8  │     8  │ 2.96k / 11.7k = 25.3% │ 5.10k / 39.7k = 12.9% │    2.0m │   2 ms │   2 ms │  23 us │   2 ms │   2 ms │      16 ms │  5.0G │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ portable - RAII writer: 1 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 12.0k / 23.6k = 50.8% │ 5.78k / 35.7k = 16.2% │    1.9m │ 201 ms │ 203 ms │   1 ms │ 202 ms │ 205 ms │       2  s │ 49.3M │
│ portable - RAII writer: 1 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 9.30k / 20.0k = 46.4% │ 5.42k / 36.4k = 14.9% │    1.9m │ 253 ms │ 276 ms │  19 ms │ 277 ms │ 298 ms │       2  s │ 36.3M │
│ portable - RAII writer: 1 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 10.2k / 21.3k = 47.9% │ 5.55k / 36.8k = 15.1% │    1.9m │ 336 ms │ 387 ms │  30 ms │ 404 ms │ 425 ms │       3  s │ 25.8M │
│ portable - RAII writer: 2 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 12.9k / 25.0k = 51.7% │ 5.96k / 36.4k = 16.4% │    1.9m │ 636 ms │ 646 ms │   8 ms │ 645 ms │ 660 ms │       5  s │ 15.5M │
│ portable - RAII writer: 2 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 14.4k / 27.0k = 53.4% │ 6.29k / 37.6k = 16.7% │    1.9m │ 892 ms │ 916 ms │  19 ms │ 912 ms │ 959 ms │       7  s │ 10.9M │
│ portable - RAII writer: 2 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 14.6k / 27.5k = 53.0% │ 6.53k / 39.4k = 16.6% │    2.0m │   1  s │   1  s │  14 ms │   1  s │   1  s │      10  s │  8.3M │
│ portable - RAII writer: 4 producers -< 1  >-> 1 consumers  │ PASS │ 8  │     8  │ 14.7k / 27.5k = 53.4% │ 6.39k / 38.3k = 16.7% │    2.0m │ 848 ms │ 855 ms │   6 ms │ 854 ms │ 865 ms │       7  s │ 11.7M │
│ portable - RAII writer: 4 producers -< 1  >-> 2 consumers  │ PASS │ 8  │     8  │ 14.6k / 28.3k = 51.6% │ 6.79k / 40.6k = 16.7% │    2.1m │   1  s │   1  s │   8 ms │   1  s │   1  s │       9  s │  9.3M │
│ portable - RAII writer: 4 producers -< 1  >-> 4 consumers  │ PASS │ 8  │     8  │ 14.6k / 28.3k = 51.7% │ 6.97k / 42.4k = 16.4% │    2.2m │   2  s │   2  s │   2 ms │   2  s │   2  s │      17  s │  4.8M │
├────────────────────────────────────────────────────────────┼──────┼────┼────────┼───────────────────────┼───────────────────────┼─────────┼────────┼────────┼────────┼────────┼────────┼────────────┼───────┤
│ portable - RAII writer: 1 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 2.31k / 11.8k = 19.6% │ 4.62k / 35.8k = 12.9% │    1.9m │   2 ms │   2 ms │  16 us │   2 ms │   2 ms │      14 ms │  5.7G │
│ portable - RAII writer: 1 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 1.97k / 11.2k = 17.7% │ 4.62k / 36.7k = 12.6% │    1.9m │ 988 us │   1 ms │  89 us │ 994 us │   1 ms │       8 ms │  9.7G │
│ portable - RAII writer: 1 producers -<1024>-> 4 consumers  │ PASS │ 8  │     8  │ 8.71k / 18.3k = 47.6% │ 5.70k / 39.0k = 14.6% │    2.0m │   1 ms │   1 ms │ 107 us │   1 ms │   1 ms │       9 ms │  9.2G │
│ portable - RAII writer: 2 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 2.67k / 12.2k = 21.8% │ 4.73k / 36.4k = 13.0% │    1.9m │   1 ms │   1 ms │  26 us │   1 ms │   1 ms │       9 ms │  8.5G │
│ portable - RAII writer: 2 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.46k / 12.1k = 20.3% │ 4.81k / 38.1k = 12.6% │    2.0m │   1 ms │   1 ms │  54 us │   1 ms │   1 ms │      10 ms │  7.7G │
│ portable - RAII writer: 2 producers -<1024>-> 4 consumers  │ PASS │ 8  │     8  │ 2.64k / 12.8k = 20.7% │ 5.02k / 39.6k = 12.7% │    2.0m │   1 ms │   1 ms │  72 us │   1 ms │   2 ms │      12 ms │  6.7G │
│ portable - RAII writer: 4 producers -<1024>-> 1 consumers  │ PASS │ 8  │     8  │ 2.11k / 11.6k = 18.3% │ 4.83k / 38.6k = 12.5% │    2.0m │ 793 us │ 809 us │  22 us │ 802 us │ 866 us │       6 ms │ 12.4G │
│ portable - RAII writer: 4 producers -<1024>-> 2 consumers  │ PASS │ 8  │     8  │ 2.61k / 12.5k = 21.0% │ 5.03k / 39.9k = 12.6% │    2.1m │ 882 us │ 917 us │  63 us │ 895 us │   1 ms │       7 ms │ 10.9G │
│ portable - RAII writer: 4 producers -<1024>-> 4 consumers  │ PASS │ 8  │    11  │ 2.71k / 14.9k = 18.1% │ 6.10k / 47.3k = 12.9% │    2.4m │   2 ms │   2 ms │  53 us │   2 ms │   2 ms │      14 ms │  5.9G │
└────────────────────────────────────────────────────────────┴──────┴────┴────────┴───────────────────────┴───────────────────────┴─────────┴────────┴────────┴────────┴────────┴────────┴────────────┴───────┘
```