### PR TITLE
pmtv:map_t std::less<> follow-up update

### DIFF
--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -270,13 +270,7 @@ public:
                             using RawType = std::remove_cvref_t<decltype(member(*_block))>;
                             using Type    = unwrap_if_wrapped_t<RawType>;
                             if constexpr (!traits::block::detail::is_port_or_collection<Type>() && !std::is_const_v<Type> && is_writable(member) && isSupportedType<Type>()) {
-                                auto matchesIgnoringPrefix = [](std::string_view str, std::string_view prefix, std::string_view target) {
-                                    if (str.starts_with(prefix)) {
-                                        str.remove_prefix(prefix.size());
-                                    }
-                                    return str == target;
-                                };
-                                if (matchesIgnoringPrefix(default_tag.shortKey(), std::string_view(GR_TAG_PREFIX), get_display_name(member))) {
+                                if (default_tag == get_display_name(member)) {
                                     _auto_forward.emplace(get_display_name(member));
                                 }
                                 _auto_update.emplace(get_display_name(member));

--- a/core/include/gnuradio-4.0/Tag.hpp
+++ b/core/include/gnuradio-4.0/Tag.hpp
@@ -181,6 +181,38 @@ public:
     }
 };
 
+template<fixed_string Key, typename PMT_TYPE, fixed_string Unit, fixed_string Description, gr::meta::string_like TOtherString>
+inline constexpr std::strong_ordering
+operator<=>(const DefaultTag<Key, PMT_TYPE, Unit, Description> &dt, const TOtherString &str) noexcept {
+    if ((dt.shortKey() <=> str) == 0) {
+        return std::strong_ordering::equal; // shortKeys are equal
+    } else {
+        return dt.key() <=> str; // compare key()
+    }
+}
+
+template<fixed_string Key, typename PMT_TYPE, fixed_string Unit, fixed_string Description, gr::meta::string_like TOtherString>
+inline constexpr std::strong_ordering
+operator<=>(const TOtherString &str, const DefaultTag<Key, PMT_TYPE, Unit, Description> &dt) noexcept {
+    if ((str <=> dt.shortKey()) == std::strong_ordering::equal) {
+        return std::strong_ordering::equal; // shortKeys are equal
+    } else {
+        return str <=> dt.key(); // compare key()
+    }
+}
+
+template<fixed_string Key, typename PMT_TYPE, fixed_string Unit, fixed_string Description, gr::meta::string_like TOtherString>
+inline constexpr bool
+operator==(const DefaultTag<Key, PMT_TYPE, Unit, Description> &dt, const TOtherString &str) noexcept {
+    return (dt <=> std::string_view(str)) == 0;
+}
+
+template<fixed_string Key, typename PMT_TYPE, fixed_string Unit, fixed_string Description, gr::meta::string_like TOtherString>
+inline constexpr bool
+operator==(const TOtherString &str, const DefaultTag<Key, PMT_TYPE, Unit, Description> &dt) noexcept {
+    return (std::string_view(str) <=> dt) == 0;
+}
+
 namespace tag { // definition of default tags and names
 inline EM_CONSTEXPR_STATIC DefaultTag<"sample_rate", float, "Hz", "signal sample rate"> SAMPLE_RATE;
 inline EM_CONSTEXPR_STATIC DefaultTag<"sample_rate", float, "Hz", "signal sample rate"> SIGNAL_RATE;

--- a/core/include/gnuradio-4.0/reflection.hpp
+++ b/core/include/gnuradio-4.0/reflection.hpp
@@ -4,6 +4,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
 #include <refl.hpp>
 
 /**

--- a/core/test/qa_DynamicPort.cpp
+++ b/core/test/qa_DynamicPort.cpp
@@ -1,7 +1,5 @@
 #include <fmt/ranges.h>
 
-#include <refl.hpp>
-
 #include <boost/ut.hpp>
 
 #include <gnuradio-4.0/Buffer.hpp>

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -51,6 +51,30 @@ const boost::ut::suite TagTests = [] {
         static_assert(tag::TRIGGER_NAME.shortKey() == "trigger_name");
         static_assert(tag::TRIGGER_TIME.shortKey() == "trigger_time");
         static_assert(tag::TRIGGER_OFFSET.shortKey() == "trigger_offset");
+
+        // test other tag on key definition only
+        static_assert(tag::SIGNAL_UNIT.key() == "gr:signal_unit");
+        static_assert(tag::SIGNAL_MIN.key() == "gr:signal_min");
+        static_assert(tag::SIGNAL_MAX.key() == "gr:signal_max");
+        static_assert(tag::TRIGGER_NAME.key() == "gr:trigger_name");
+        static_assert(tag::TRIGGER_TIME.key() == "gr:trigger_time");
+        static_assert(tag::TRIGGER_OFFSET.key() == "gr:trigger_offset");
+
+        using namespace std::string_literals;
+        using namespace std::string_view_literals;
+        static_assert(tag::SIGNAL_UNIT == "signal_unit"s);
+        static_assert("signal_unit"s == tag::SIGNAL_UNIT);
+
+        static_assert("signal_unit"sv == tag::SIGNAL_UNIT);
+        static_assert(tag::SIGNAL_UNIT == "signal_unit"sv);
+
+        static_assert(tag::SIGNAL_UNIT == "signal_unit");
+        static_assert("signal_unit" == tag::SIGNAL_UNIT);
+
+        // alt definition -> eventually needed for SigMF compatibility
+        using namespace gr::tag;
+        static_assert(SIGNAL_UNIT == "gr:signal_unit"sv);
+        static_assert("gr:signal_unit" == tag::SIGNAL_UNIT);
     };
 };
 

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -36,8 +36,8 @@ struct print_types;
 
 template<typename CharT, std::size_t SIZE>
 struct fixed_string {
-    constexpr static std::size_t N            = SIZE;
-    CharT                        _data[N + 1] = {};
+    constexpr static std::size_t N              = SIZE;
+    CharT                        _data[N + 1UZ] = {};
 
     constexpr fixed_string() = default;
 
@@ -77,6 +77,20 @@ struct fixed_string {
     [[nodiscard]] friend constexpr bool
     operator==(const fixed_string &, const fixed_string<CharT, N2> &) {
         return false;
+    }
+
+    constexpr auto
+    operator<=>(const fixed_string &other) const noexcept
+            = default;
+
+    friend constexpr auto
+    operator<=>(const fixed_string &fs, std::string_view sv) noexcept {
+        return std::string_view(fs) <=> sv;
+    }
+
+    friend constexpr auto
+    operator<=>(const fixed_string &fs, const std::string &str) noexcept {
+        return std::string(fs) <=> str;
     }
 };
 
@@ -503,6 +517,9 @@ using fundamental_base_value_type_t = typename detail::fundamental_base_value_ty
 static_assert(std::is_same_v<fundamental_base_value_type_t<int>, int>);
 static_assert(std::is_same_v<fundamental_base_value_type_t<std::vector<float>>, float>);
 static_assert(std::is_same_v<fundamental_base_value_type_t<std::vector<std::complex<double>>>, double>);
+
+template<typename T>
+concept string_like = std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view> || std::is_convertible_v<T, std::string_view>;
 
 } // namespace gr::meta
 


### PR DESCRIPTION
`pmtv::map_t` got a transparent comparator that `std::map<std::string, pmt_t, std::less<>>` required:
 * explicit comparators for fixed_string
 * DefaultTag

added corresponding unit-tests, removed now obsolete code, and added implicit equivalency for DefaultTag names such as `"XXX"` "and `"gr:XXX"`. N.B. the later is required for compatibility with SigMF.