### PR TITLE
Add an API to iterate the graph once

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -26,7 +26,7 @@ namespace gr {
 namespace stdx = vir::stdx;
 using gr::meta::fixed_string;
 
-enum class LifeCycleState : char { IDLE, INITIALISED, RUNNING, REQUESTED_STOP, REQUESTED_PAUSE, STOPPED, PAUSED, ERROR };
+enum class LifeCycleState : char { IDLE, INITIALISED, RUNNING, DONE, REQUESTED_STOP, REQUESTED_PAUSE, STOPPED, PAUSED, ERROR };
 
 template<typename F>
 constexpr void

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -326,11 +326,35 @@ const boost::ut::suite SchedulerTests = [] {
         expect(boost::ut::that % t == TraceVectorType{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
     };
 
+    "SimpleScheduler_linear_iterate"_test = [&threadPool] {
+        using scheduler               = gr::scheduler::Simple<>;
+        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
+        auto                    sched = scheduler{ getGraphLinear(trace), threadPool };
+        while (!sched.isDone()) {
+            sched.iterateAndWait();
+        }
+        auto t = trace->getVector();
+        expect(boost::ut::that % t.size() == 8u);
+        expect(boost::ut::that % t == TraceVectorType{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
+    };
+
     "BreadthFirstScheduler_linear"_test = [&] {
         using scheduler               = gr::scheduler::BreadthFirst<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphLinear(trace), threadPool };
         sched.runAndWait();
+        auto t = trace->getVector();
+        expect(boost::ut::that % t.size() == 8u);
+        expect(boost::ut::that % t == TraceVectorType{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
+    };
+
+    "BreadthFirstScheduler_linear_iterate"_test = [&] {
+        using scheduler               = gr::scheduler::BreadthFirst<>;
+        std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
+        auto                    sched = scheduler{ getGraphLinear(trace), threadPool };
+        while (!sched.isDone()) {
+            sched.iterateAndWait();
+        }
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 8u);
         expect(boost::ut::that % t == TraceVectorType{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });


### PR DESCRIPTION
This PR adds new API to the schedulers to iterate the graph and return the control to the caller, without waiting for it to finish. This is needed by opendigitizer to continuously update when drawin the UI. (https://github.com/fair-acc/opendigitizer/pull/141)