### PR TITLE
CI: adopt singleheader CI to updated filenames

### DIFF
--- a/.github/workflows/single-header.yml
+++ b/.github/workflows/single-header.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         wget https://raw.githubusercontent.com/edlund/amalgamate/c91f07eea1133aa184f652b8f1398eaf03586208/amalgamate.py
         mkdir -p singleheader
-        python3 amalgamate.py -c devtools/singleheader-config-graph.json -s include/ -v yes
+        python3 amalgamate.py -c devtools/singleheader-config-graph.json -s . -v yes
         python3 amalgamate.py -c devtools/singleheader-config-bench.json -s bench/ -v yes
 
     - name: upload to branch # keeping history of single-header branch

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ A [single header version](https://raw.githubusercontent.com/fair-acc/graph-proto
 is provided in the `singleheader/`subdirectory of the single-header branch.
 If you want to locally regenerate the single header file, just follow
 the [CI step](https://github.com/fair-acc/graph-prototype/blob/main/.github/workflows/single-header.yml#L38-L41).
-It can be used on [compiler-explorer](https://compiler-explorer.com/z/zcx49YP53) with `-sdt=c++20 -O3` compiler options.
+It can be used on [compiler-explorer](https://compiler-explorer.com/z/EG7Eb9K83) with `-std=c++23 -O3` compiler options.
 
 ## Copyright & License
-Copyright (C) 2018-2022 FAIR -- Facility for Antiproton & Ion Research, Darmstadt, Germany<br/>
+Copyright (C) 2018-2024 FAIR -- Facility for Antiproton & Ion Research, Darmstadt, Germany<br/>
 Unless otherwise noted: [SPDX-License-Identifier: LGPL-3.0-or-later](https://spdx.org/licenses/LGPL-3.0-or-later.html)
 
 ### Contributors

--- a/devtools/singleheader-config-graph.json
+++ b/devtools/singleheader-config-graph.json
@@ -2,10 +2,19 @@
 	"project": "Graph.hpp",
 	"target": "singleheader/Graph.hpp",
 	"sources": [
-		"Graph.hpp"
+		"./core/include/gnuradio-4.0/Graph.hpp"
 	],
 	"include_paths": [
-		".",
-		"../build/_deps/refl-cpp-src/include"
+		"./core/include/",
+		"./blocks/basic/include/",
+		"./blocks/filter/include/",
+		"./blocks/fourier/include/",
+		"./blocks/testing/include/",
+		"./algorithm/include/",
+		"./meta/include/",
+		"./build/_deps/vir-simd-src/",
+		"./build/_deps/pmt-src/include/",
+		"./third_party/magic_enum/",
+		"./third_party/refl-cpp/"
 	]
 }


### PR DESCRIPTION
This PR updates the single header generator configuration to adapt to the updated Header filenames and changed dependencies.
Also updates the readme with a new compiler explorer sample.

For this to be useful with compiler-explorer we'll have to look into compile times, the "sample" I added now is barely doing anything and still only compiles without timeout on `-O2`.