### PR TITLE
Add `property_map` as supported type to Settings and Transactions.

### DIFF
--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -13,6 +13,7 @@
 #include "BlockTraits.hpp"
 #include "reflection.hpp"
 #include "Tag.hpp"
+#include <gnuradio-4.0/meta/formatter.hpp>
 
 namespace gr {
 
@@ -237,7 +238,7 @@ struct SettingsBase {
 namespace detail {
 template<typename T>
 concept HasBaseType = requires { typename std::remove_cvref_t<T>::base_t; };
-};
+}; // namespace detail
 
 template<typename TBlock>
 class BasicSettings : public SettingsBase {
@@ -625,7 +626,7 @@ private:
     template<typename T>
     inline constexpr static bool
     isSupportedType() {
-        return std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || gr::meta::vector_type<T>;
+        return std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || gr::meta::vector_type<T> || std::is_same_v<T, property_map>;
     }
 
     template<typename T, typename Func>

--- a/core/test/grc/test.grc.expected
+++ b/core/test/grc/test.grc.expected
@@ -4,6 +4,7 @@ blocks:
     parameters:
       denominator: 1
       event_count: 100
+      meta_information: ""
       name: main_source
       numerator: 1
       stride: 0
@@ -34,6 +35,7 @@ blocks:
     id: good::multiply
     parameters:
       denominator: 1
+      meta_information: ""
       name: multiplier
       numerator: 1
       stride: 0
@@ -63,6 +65,7 @@ blocks:
     id: builtin_counter
     parameters:
       denominator: 1
+      meta_information: ""
       name: counter
       numerator: 1
       stride: 0
@@ -92,6 +95,7 @@ blocks:
     id: good::cout_sink
     parameters:
       denominator: 1
+      meta_information: ""
       name: sink
       numerator: 1
       stride: 0

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -252,17 +252,17 @@ const boost::ut::suite SettingsTests = [] {
         // define basic Sink->TestBlock->Sink flow graph
         auto &src = testGraph.emplaceBlock<Source<float>>({ { "sample_rate", 42.f }, { "n_samples_max", n_samples } });
         expect(eq(src.n_samples_max, n_samples)) << "check map constructor";
-        expect(eq(src.settings().autoUpdateParameters().size(), 3UL));
+        expect(eq(src.settings().autoUpdateParameters().size(), 4UL));
         expect(eq(src.settings().autoForwardParameters().size(), 1UL)); // sample_rate
         auto &block1 = testGraph.emplaceBlock<TestBlock<float>>({ { "name", "TestBlock#1" } });
         auto &block2 = testGraph.emplaceBlock<TestBlock<float>>({ { "name", "TestBlock#2" } });
         auto &sink   = testGraph.emplaceBlock<Sink<float>>();
-        expect(eq(sink.settings().autoUpdateParameters().size(), 5UL));
+        expect(eq(sink.settings().autoUpdateParameters().size(), 6UL));
         expect(eq(sink.settings().autoForwardParameters().size(), 1UL)); // sample_rate
 
         block1.context = "Test Context";
         block1.settings().updateActiveParameters();
-        expect(eq(block1.settings().autoUpdateParameters().size(), 6UL));
+        expect(eq(block1.settings().autoUpdateParameters().size(), 7UL));
         expect(eq(block1.settings().autoForwardParameters().size(), 2UL));
         // need to add 'n_samples_max' to forwarding list for the block to automatically forward it
         // as the 'n_samples_max' tag is not part of the canonical 'gr::tag::DEFAULT_TAGS' list
@@ -284,7 +284,7 @@ const boost::ut::suite SettingsTests = [] {
         expect(block1.settings().get(keys1).empty());
         expect(block1.settings().get(keys2).empty());
         expect(block1.settings().get(keys3).empty());
-        expect(eq(block1.settings().get().size(), 11UL));
+        expect(eq(block1.settings().get().size(), 12UL));
 
         // set non-existent setting
         expect(not block1.settings().changed()) << "settings not changed";
@@ -359,7 +359,7 @@ const boost::ut::suite SettingsTests = [] {
         "empty"_test = [] {
             auto block = TestBlock<float>();
             block.init(block.progress, block.ioThreadPool); // N.B. self-assign existing progress and thread-pool (just for unit-tests)
-            expect(eq(block.settings().get().size(), 11UL));
+            expect(eq(block.settings().get().size(), 12UL));
             expect(eq(std::get<float>(*block.settings().get("scaling_factor")), 1.f));
         };
 
@@ -370,7 +370,7 @@ const boost::ut::suite SettingsTests = [] {
             block.init(block.progress, block.ioThreadPool); // N.B. self-assign existing progress and thread-pool (just for unit-tests)
             expect(eq(block.settings().stagedParameters().size(), 0u));
             block.settings().updateActiveParameters();
-            expect(eq(block.settings().get().size(), 11UL));
+            expect(eq(block.settings().get().size(), 12UL));
             expect(eq(block.scaling_factor, 2.f));
             expect(eq(std::get<float>(*block.settings().get("scaling_factor")), 2.f));
         };
@@ -379,7 +379,7 @@ const boost::ut::suite SettingsTests = [] {
         "empty via graph"_test = [] {
             Graph testGraph;
             auto &block = testGraph.emplaceBlock<TestBlock<float>>();
-            expect(eq(block.settings().get().size(), 11UL));
+            expect(eq(block.settings().get().size(), 12UL));
             expect(eq(block.scaling_factor, 1.f));
             expect(eq(std::get<float>(*block.settings().get("scaling_factor")), 1.f));
         };
@@ -387,7 +387,7 @@ const boost::ut::suite SettingsTests = [] {
         "with init parameter via graph"_test = [] {
             Graph testGraph;
             auto &block = testGraph.emplaceBlock<TestBlock<float>>({ { "scaling_factor", 2.f } });
-            expect(eq(block.settings().get().size(), 11UL));
+            expect(eq(block.settings().get().size(), 12UL));
             expect(eq(block.scaling_factor, 2.f));
             expect(eq(std::get<float>(*block.settings().get("scaling_factor")), 2.f));
         };
@@ -397,7 +397,7 @@ const boost::ut::suite SettingsTests = [] {
         Graph testGraph;
         auto &block = testGraph.emplaceBlock<TestBlock<float>>();
         block.settings().updateActiveParameters();
-        expect(eq(block.settings().get().size(), 11UL));
+        expect(eq(block.settings().get().size(), 12UL));
 
         block.debug    = true;
         const auto val = block.settings().set({ { "vector_setting", std::vector{ 42.f, 2.f, 3.f } }, { "string_vector_setting", std::vector<std::string>{ "A", "B", "C" } } });

--- a/meta/include/gnuradio-4.0/meta/formatter.hpp
+++ b/meta/include/gnuradio-4.0/meta/formatter.hpp
@@ -1,10 +1,10 @@
 #ifndef GNURADIO_FORMATTER_HPP
 #define GNURADIO_FORMATTER_HPP
 
+#include "UncertainValue.hpp"
 #include <complex>
 #include <fmt/format.h>
-
-#include "UncertainValue.hpp"
+#include <gnuradio-4.0/Tag.hpp>
 
 template<typename T>
 struct fmt::formatter<std::complex<T>> {
@@ -68,16 +68,34 @@ struct fmt::formatter<std::complex<T>> {
 template<gr::arithmetic_or_complex_like T>
 struct fmt::formatter<gr::UncertainValue<T>> {
     template<typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
+    constexpr auto
+    parse(ParseContext &ctx) {
+        return ctx.begin();
+    }
 
     template<typename FormatContext>
     constexpr auto
-    format(const gr::UncertainValue<T>&  value, FormatContext &ctx) const {
+    format(const gr::UncertainValue<T> &value, FormatContext &ctx) const {
         if constexpr (gr::meta::complex_like<T>) {
             return fmt::format_to(ctx.out(), "({} ± {})", value.value, value.uncertainty);
         } else {
             return fmt::format_to(ctx.out(), "({:G} ± {:G})", value.value, value.uncertainty);
         }
+    }
+};
+
+template<>
+struct fmt::formatter<gr::property_map> {
+    template<typename ParseContext>
+    constexpr auto
+    parse(ParseContext &ctx) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    constexpr auto
+    format(const gr::property_map &value, FormatContext &ctx) const {
+        return fmt::format_to(ctx.out(), "{{ {} }}", fmt::join(value, ", "));
     }
 };
 

--- a/meta/test/qa_UncertainValue.cpp
+++ b/meta/test/qa_UncertainValue.cpp
@@ -665,7 +665,7 @@ const boost::ut::suite uncertainValue = [] {
         expect(approx(0.160, value.uncertainty, 1e-3));
     };
 
-    tag("visual") / "visual examples"_test = [] {
+    boost::ut::tag("visual") / "visual examples"_test = [] {
         // uncorrelated values
         UncertainValue uValueA{ 4.0, 2.0 };
         UncertainValue uValueB{ 2.0, 1.0 };

--- a/meta/test/qa_formatter.cpp
+++ b/meta/test/qa_formatter.cpp
@@ -11,7 +11,7 @@ namespace gr::meta::test {
 const boost::ut::suite complexFormatter = [] {
     using namespace boost::ut;
     using namespace std::literals::complex_literals;
-    using C                = std::complex<double>;
+    using C                                = std::complex<double>;
     "fmt::formatter<std::complex<T>>"_test = [] {
         expect("(1+1i)" == fmt::format("{}", C(1., +1.)));
         expect("(1-1i)" == fmt::format("{}", C(1., -1.)));
@@ -46,23 +46,35 @@ const boost::ut::suite complexFormatter = [] {
 const boost::ut::suite uncertainValueFormatter = [] {
     using namespace boost::ut;
     using namespace std::literals::complex_literals;
-    using UncertainDouble = gr::UncertainValue<double>;
+    using UncertainDouble  = gr::UncertainValue<double>;
     using UncertainComplex = gr::UncertainValue<std::complex<double>>;
 
     "fmt::formatter<gr::meta::UncertainValue<T>>"_test = [] {
         // Test with UncertainValue<double>
-        expect("(1.23 ± 0.45)" == fmt::format("{}", UncertainDouble{1.23, 0.45}));
-        expect("(3.14 ± 0.01)" == fmt::format("{}", UncertainDouble{3.14, 0.01}));
-        expect("(0 ± 0)" == fmt::format("{}", UncertainDouble{0, 0}));
+        expect("(1.23 ± 0.45)" == fmt::format("{}", UncertainDouble{ 1.23, 0.45 }));
+        expect("(3.14 ± 0.01)" == fmt::format("{}", UncertainDouble{ 3.14, 0.01 }));
+        expect("(0 ± 0)" == fmt::format("{}", UncertainDouble{ 0, 0 }));
 
         // Test with UncertainValue<std::complex<double>>
-        expect("((1+2i) ± (0.1+0.2i))" == fmt::format("{}", UncertainComplex{{1, 2}, {0.1, 0.2}}));
-        expect("((3.14+1.59i) ± (0.01+0.02i))" == fmt::format("{}", UncertainComplex{{3.14, 1.59}, {0.01, 0.02}}));
-        expect("(0 ± 0)" == fmt::format("{}", UncertainComplex{{0, 0}, {0, 0}}));
+        expect("((1+2i) ± (0.1+0.2i))" == fmt::format("{}", UncertainComplex{ { 1, 2 }, { 0.1, 0.2 } }));
+        expect("((3.14+1.59i) ± (0.01+0.02i))" == fmt::format("{}", UncertainComplex{ { 3.14, 1.59 }, { 0.01, 0.02 } }));
+        expect("(0 ± 0)" == fmt::format("{}", UncertainComplex{ { 0, 0 }, { 0, 0 } }));
     };
 };
 
-}
+const boost::ut::suite propertyMapFormatter = [] {
+    using namespace boost::ut;
+
+    "fmt::formatter<gr::property_map>"_test = [] {
+        gr::property_map pmInt{ { "key0", 0 }, { "key1", 1 }, { "key2", 2 } };
+        expect("{ key0: 0, key1: 1, key2: 2 }" == fmt::format("{}", pmInt));
+
+        gr::property_map pmFloat{ { "key0", 0.01f }, { "key1", 1.01f }, { "key2", 2.01f } };
+        expect("{ key0: 0.01, key1: 1.01, key2: 2.01 }" == fmt::format("{}", pmFloat));
+    };
+};
+
+} // namespace gr::meta::test
 
 int
 main() { /* tests are statically executed */


### PR DESCRIPTION
This PR includes the following changes:
- Add `property_map` as supported type to Settings and Transactions.
- Add `fmt::formatter` for `property_map`