### PR TITLE
Add ConsumableInputRange for inputs instead of pure std::span.

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -175,7 +175,8 @@ public:
 
         std::vector<std::span<const double>> readers;
         for (auto &input_port : _input_ports) {
-            readers.push_back(input_port.streamReader().get(available_samples));
+            gr::ConsumableSpan auto r = input_port.streamReader().get(available_samples);
+            readers.push_back(static_cast<std::span<const double>>(r));
         }
 
         auto &writer = _output_port.streamWriter();

--- a/blocks/testing/include/gnuradio-4.0/testing/FunctionBlocks.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/FunctionBlocks.hpp
@@ -206,7 +206,6 @@ struct FunctionSink : gr::Block<FunctionSink<T>> {
     }
 };
 
-
 /**
  * MessageSender is a convenience struct template to allow easy creation
  * of a block that generates and sends messages on the builtin messaging

--- a/core/benchmarks/bm_Buffer.cpp
+++ b/core/benchmarks/bm_Buffer.cpp
@@ -55,7 +55,7 @@ testNewAPI(Buffer auto &buffer, const std::size_t vector_length, const std::size
 
     constexpr int n_repeat = 8;
 
-    std::barrier  barrier(static_cast<std::ptrdiff_t>(nProducer + nConsumer + 1));
+    std::barrier barrier(static_cast<std::ptrdiff_t>(nProducer + nConsumer + 1));
 
     // init producers
     std::atomic<int>         threadID = 0;
@@ -100,10 +100,10 @@ testNewAPI(Buffer auto &buffer, const std::size_t vector_length, const std::size
                     if (reader.available() < vector_length) {
                         continue;
                     }
-                    const auto &input = reader.get(vector_length);
+                    const ConsumableSpan auto &input = reader.get(vector_length);
                     nSamplesConsumed += input.size();
 
-                    if (!reader.consume(input.size())) {
+                    if (!input.consume(input.size())) {
                         throw std::runtime_error(fmt::format("could not consume {} samples", input.size()));
                     }
                 }

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -284,17 +284,6 @@ concept HasProcessBulkFunction = traits::block::can_processBulk<Derived>;
 template<typename Derived>
 concept HasRequiredProcessFunction = (HasProcessBulkFunction<Derived> or HasProcessOneFunction<Derived>) and(HasProcessOneFunction<Derived> + HasProcessBulkFunction<Derived>) == 1;
 
-template<typename T>
-concept ConsumableSpan = std::ranges::contiguous_range<T> and std::convertible_to<T, std::span<const std::remove_cvref_t<typename T::value_type>>> and requires(T &s) { s.consume(0); };
-
-static_assert(ConsumableSpan<traits::block::detail::dummy_input_span<float>>);
-
-template<typename T>
-concept PublishableSpan = std::ranges::contiguous_range<T> and std::ranges::output_range<T, std::remove_cvref_t<typename T::value_type>>
-                      and std::convertible_to<T, std::span<std::remove_cvref_t<typename T::value_type>>> and requires(T &s) { s.publish(0UZ); };
-
-static_assert(PublishableSpan<traits::block::detail::dummy_output_span<float>>);
-
 /**
  * @brief The 'Block<Derived>' is a base class for blocks that perform specific signal processing operations. It stores
  * references to its input and output 'ports' that can be zero, one, or many, depending on the use case.
@@ -1101,9 +1090,7 @@ protected:
 
         // TODO: these checks can be moved to setting changed
         checkParametersAndThrowIfNeeded();
-
         updatePortsStatus();
-
         if constexpr (kIsSourceBlock) {
             // TODO: available_samples() methods are no longer needed for Source blocks, the are presently still/only needed for merge graph/block.
             // TODO: Review if they can be removed.

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -276,7 +276,10 @@ template<typename TBlock>
 concept can_processOne_with_offset = can_processOne_scalar_with_offset<TBlock> or can_processOne_simd_with_offset<TBlock>;
 
 template<typename TBlock, typename TPort>
-concept can_processMessagesForPort = requires(TBlock &block, TPort &inPort) { block.processMessages(inPort, inPort.streamReader().get(1UZ)); };
+concept can_processMessagesForPortConsumableSpan = requires(TBlock &block, TPort &inPort) { block.processMessages(inPort, inPort.streamReader().get(1UZ)); };
+
+template<typename TBlock, typename TPort>
+concept can_processMessagesForPortStdSpan = requires(TBlock &block, TPort &inPort, std::span<const Message> msgSpan) { block.processMessages(inPort, msgSpan); };
 
 namespace detail {
 template<typename T>

--- a/core/include/gnuradio-4.0/Buffer.hpp
+++ b/core/include/gnuradio-4.0/Buffer.hpp
@@ -45,12 +45,36 @@ static_assert(std::is_same_v<double, value_type_t<std::array<double, 42>>>);
 
 } // namespace util
 
+// TODO: find a better place for these 3 concepts
+template<typename From, typename To>
+concept convertible_from_lvalue_to = std::convertible_to<const std::remove_cvref_t<From> &, To>;
+
+template<typename From, typename To>
+concept convertible_from_rvalue_to = std::convertible_to<std::remove_cvref_t<From> &&, To>;
+
+template<typename From, typename To>
+concept convertible_from_lvalue_only = convertible_from_lvalue_to<From, To> && !convertible_from_rvalue_to<From, To>;
+
+template<typename T>
+concept SpanLike = std::convertible_to<T, std::span<std::remove_cvref_t<typename T::value_type>>>;
+
+template<typename T>
+concept ConstSpanLike = std::convertible_to<T, std::span<const std::remove_cvref_t<typename T::value_type>>>;
+
+template<typename T>
+concept ConstSpanLvalueLike = convertible_from_lvalue_only<T, std::span<const std::remove_cvref_t<typename T::value_type>>>;
+
+template<typename T>
+concept ConsumableSpan = std::ranges::contiguous_range<T> && ConstSpanLvalueLike<T> && requires(T &s) { s.consume(0); };
+
+template<typename T>
+concept PublishableSpan = std::ranges::contiguous_range<T> && std::ranges::output_range<T, std::remove_cvref_t<typename T::value_type>> && SpanLike<T> && requires(T &s) { s.publish(0UZ); };
+
 // clang-format off
 // disable formatting until clang-format (v16) supporting concepts
 template<class T>
 concept BufferReader = requires(T /*const*/ t, const std::size_t n_items) {
-    { t.get(n_items) }     -> std::same_as<std::span<const util::value_type_t<T>>>;
-    { t.consume(n_items) } -> std::same_as<bool>;
+    { t.get(n_items) } ; // TODO: get returns CircularBuffer::buffer_reader::ConsumableInputRange
     { t.position() }       -> std::same_as<std::make_signed_t<std::size_t>>;
     { t.available() }      -> std::same_as<std::size_t>;
     { t.buffer() };
@@ -65,7 +89,7 @@ concept BufferWriter = requires(T t, const std::size_t n_items, std::pair<std::s
     { t.publish([](std::span<util::value_type_t<T>> &/*writable_data*/, std::make_signed_t<std::size_t> /* writePos */, Args ...) { /* */  }, n_items, args...) }   -> std::same_as<void>;
     { t.try_publish([](std::span<util::value_type_t<T>> &/*writable_data*/, Args ...) { /* */ }, n_items, args...) }                             -> std::same_as<bool>;
     { t.try_publish([](std::span<util::value_type_t<T>> &/*writable_data*/, std::make_signed_t<std::size_t> /* writePos */, Args ...) { /* */  }, n_items, args...) }-> std::same_as<bool>;
-    { t.reserve_output_range(n_items) };
+    { t.reserve_output_range(n_items) };// TODO: reserve_output_range returns CircularBuffer::buffer_writer::ReservedOutputRange
     { t.available() }         -> std::same_as<std::size_t>;
     { t.buffer() };
 };

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -980,7 +980,7 @@ inline constexpr TagPredicate auto defaultEOSTagMatcher = [](const Tag &tag, Tag
 
 inline constexpr std::optional<std::size_t>
 nSamplesToNextTagConditional(const PortLike auto &port, detail::TagPredicate auto &predicate, Tag::signed_index_type readOffset) {
-    const std::span<const Tag> tagData = port.tagReader().template get<false>();
+    const gr::ConsumableSpan auto tagData = port.tagReader().template get<false>();
     if (!port.isConnected() || tagData.empty()) [[likely]] {
         return std::nullopt; // default: no tags in sight
     }

--- a/core/include/gnuradio-4.0/Profiler.hpp
+++ b/core/include/gnuradio-4.0/Profiler.hpp
@@ -404,8 +404,8 @@ public:
             while (!seen_finished) {
                 seen_finished = finished;
                 while (reader.available() > 0) {
-                    auto event = reader.get(1);
-                    auto it    = mapped_threads.find(event[0].thread_id);
+                    gr::ConsumableSpan auto event = reader.get(1);
+                    auto                    it    = mapped_threads.find(event[0].thread_id);
                     if (it == mapped_threads.end()) {
                         it = mapped_threads.emplace(event[0].thread_id, static_cast<int>(mapped_threads.size())).first;
                     }
@@ -415,7 +415,7 @@ public:
                         fmt::print(out_stream, "{}", event[0].toJSON(pid, it->second));
                     }
                     is_first    = false;
-                    std::ignore = reader.consume(1);
+                    std::ignore = event.consume(1);
                 }
             }
             fmt::print(out_stream, "\n]\n");

--- a/core/test/qa_port_array.cpp
+++ b/core/test/qa_port_array.cpp
@@ -125,14 +125,14 @@ struct ArrayPortsNode : gr::Block<ArrayPortsNode<T>> {
             auto available = std::min(inputReader->available(), outputWriter->available());
             if (available == 0) return gr::work::Status::DONE;
 
-            auto inputSpan  = inputReader->get(available);
-            auto outputSpan = outputWriter->reserve_output_range(available);
+            gr::ConsumableSpan auto inputSpan  = inputReader->get(available);
+            auto                    outputSpan = outputWriter->reserve_output_range(available);
 
             for (std::size_t valueIndex = 0; valueIndex < available; ++valueIndex) {
                 outputSpan[valueIndex] = inputSpan[valueIndex];
             }
 
-            inputReader->consume(available);
+            inputSpan.consume(available);
             outputSpan.publish(available);
         }
         return gr::work::Status::OK;


### PR DESCRIPTION
In this PR new `ConsumableInputRange` for inputs instead of pure `std::span` is implemented. 

Followup issue https://github.com/fair-acc/graph-prototype/issues/258
