### PR TITLE
Scheduler: add function to test whether a MT scheduler is still running

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -273,6 +273,13 @@ public:
                     const profiling::Options &profiling_options = {})
         : SchedulerBase<TProfiler>(std::move(graph), thread_pool, profiling_options) {}
 
+    bool
+    isProcessing() const
+        requires(executionPolicy == multiThreaded)
+    {
+        return this->_running_threads.load() > 0;
+    }
+
     void
     init() {
         if (!this->canInit()) {
@@ -378,6 +385,13 @@ public:
     explicit BreadthFirst(gr::Graph &&graph, std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("breadth-first-pool", thread_pool::CPU_BOUND),
                           const profiling::Options &profiling_options = {})
         : SchedulerBase<TProfiler>(std::move(graph), thread_pool, profiling_options) {}
+
+    bool
+    isProcessing() const
+        requires(executionPolicy == multiThreaded)
+    {
+        return this->_running_threads.load() > 0;
+    }
 
     void
     init() {


### PR DESCRIPTION
Makes it possible to check whether the scheduler finished, without blocking.