### PR TITLE
Implement HttpBlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,7 @@ jobs:
           export SYSTEM_NODE=`which node` # use system node instead of old version distributed with emsdk for threading support
           source ~/emsdk/emsdk_env.sh
           emcmake cmake -S . -B ../build -DDISABLE_EXTERNAL_DEPS_WARNINGS=ON -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DENABLE_COVERAGE=OFF -DCMAKE_CROSSCOMPILING_EMULATOR=${SYSTEM_NODE}
+          npm install -g xhr2 # needed for emscripten fetch
 
       - name: Build
         if: matrix.configurations.compiler != 'gcc13' || matrix.cmake-build-type != 'Debug'
@@ -123,6 +124,8 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: ctest --output-on-failure
+        env:
+          NODE_PATH: /usr/local/lib/node_modules
 
       - name: execute tests with coverage
         if: matrix.configurations.compiler == 'gcc13' && matrix.cmake-build-type == 'Debug'

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ CMakeLists.txt.user
 virtualenv/
 
 emscripten-toolchain.ini
+
+# node/npm files for emscripten fetch support
+node_modules/
+package.json
+package-lock.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ if (EMSCRIPTEN)
             -fwasm-exceptions
             -pthread
             "SHELL:-s PTHREAD_POOL_SIZE=30"
+            "SHELL:-s FETCH=1"
+            "SHELL:-s ASSERTIONS=1"
     )
 endif ()
 
@@ -136,7 +138,13 @@ FetchContent_Declare(
         GIT_TAG v0.2.0
 )
 
-FetchContent_MakeAvailable(fmt pmt ut yaml-cpp vir-simd)
+FetchContent_Declare(
+    httplib
+    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+    GIT_TAG v0.15.1
+)
+
+FetchContent_MakeAvailable(fmt pmt ut yaml-cpp vir-simd httplib)
 
 add_library(pmtv INTERFACE)
 target_include_directories(pmtv INTERFACE ${pmt_SOURCE_DIR}/include/)

--- a/blocks/CMakeLists.txt
+++ b/blocks/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(basic)
 add_subdirectory(filter)
 add_subdirectory(fourier)
+add_subdirectory(http)
 add_subdirectory(testing)

--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -10,22 +10,6 @@
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/reflection.hpp>
 
-// A convenience class to make writing unit tests easier.
-// This sink allows to inspect the input port values as a class member.
-template<typename T>
-class InspectSink : public gr::Block<InspectSink<T>> {
-public:
-    T             value{};
-    gr::PortIn<T> in;
-
-    constexpr void
-    processOne(T val) {
-        value = val;
-    }
-};
-
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (InspectSink<T>), value, in);
-
 template<typename T>
 class builtin_multiply : public gr::Block<builtin_multiply<T>> {
 public:

--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -10,6 +10,22 @@
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/reflection.hpp>
 
+// A convenience class to make writing unit tests easier.
+// This sink allows to inspect the input port values as a class member.
+template<typename T>
+class InspectSink : public gr::Block<InspectSink<T>> {
+public:
+    T             value{};
+    gr::PortIn<T> in;
+
+    constexpr void
+    processOne(T val) {
+        value = val;
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (InspectSink<T>), value, in);
+
 template<typename T>
 class builtin_multiply : public gr::Block<builtin_multiply<T>> {
 public:

--- a/blocks/http/CMakeLists.txt
+++ b/blocks/http/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(gr-http INTERFACE)
+target_link_libraries(gr-http INTERFACE gnuradio-core gnuradio-algorithm httplib::httplib)
+target_include_directories(gr-http INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/> $<INSTALL_INTERFACE:include/>)
+
+if (ENABLE_TESTING)
+    add_subdirectory(test)
+endif ()

--- a/blocks/http/include/gnuradio-4.0/http/HttpBlock.hpp
+++ b/blocks/http/include/gnuradio-4.0/http/HttpBlock.hpp
@@ -1,0 +1,287 @@
+#ifndef GNURADIO_HTTP_BLOCK_HPP
+#define GNURADIO_HTTP_BLOCK_HPP
+
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/reflection.hpp>
+#include <pmtv/pmt.hpp>
+#include <semaphore>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#include <emscripten/fetch.h>
+#include <emscripten/threading.h>
+#else
+#include <httplib.h>
+#endif
+
+using namespace gr;
+using namespace std::chrono_literals;
+
+namespace gr::http {
+
+enum class RequestType {
+    GET,
+    SUBSCRIBE,
+    POST,
+};
+
+using HttpBlockDoc = Doc<R""(
+The HttpBlock allows to use the responses from HTTP APIs (e.g. REST APIs) as the value for this block's output port.
+The block can be used either on-demand to do single requests, or can use long polling to subscribe to an event stream.
+The result is provided on a single output port as a map with the following keys:
+- status: The HTTP status code, usually 200 on success
+- raw-data: The data of the response
+- mime-type: The mime-type of the response
+)"">;
+
+template<typename T>
+class HttpBlock : public gr::Block<HttpBlock<T>, BlockingIO<false>, HttpBlockDoc> {
+private:
+    // used for queuing GET responses for the consumer
+    std::queue<pmtv::map_t> _backlog;
+    std::mutex              _backlog_mutex;
+
+    std::shared_ptr<std::thread> _thread;
+    std::atomic_size_t           _pendingRequests = 0;
+    std::atomic_bool             _shutdownThread  = false;
+    std::binary_semaphore        _ready{ 0 };
+
+#ifndef __EMSCRIPTEN__
+    std::unique_ptr<httplib::Client> _client;
+#endif
+
+#ifdef __EMSCRIPTEN__
+    void
+    queueWorkEmscripten(emscripten_fetch_t *fetch) {
+        pmtv::map_t result;
+        result["mime-type"] = "text/plain";
+        result["status"]    = static_cast<int>(fetch->status);
+        result["raw-data"]  = std::string(fetch->data, static_cast<std::size_t>(fetch->numBytes));
+
+        queueWork(result);
+    }
+
+    void
+    onSuccess(emscripten_fetch_t *fetch) {
+        queueWorkEmscripten(fetch);
+        emscripten_fetch_close(fetch);
+    }
+
+    void
+    onError(emscripten_fetch_t *fetch) {
+        // we still want to queue the response, the statusCode will just not be 200
+        queueWorkEmscripten(fetch);
+        emscripten_fetch_close(fetch);
+    }
+
+    void
+    doRequestEmscripten() {
+        emscripten_fetch_attr_t attr;
+        emscripten_fetch_attr_init(&attr);
+        if (type == RequestType::POST) {
+            strcpy(attr.requestMethod, "POST");
+            if (!parameters.empty()) {
+                attr.requestData     = parameters.c_str();
+                attr.requestDataSize = parameters.size();
+            }
+        } else {
+            strcpy(attr.requestMethod, "GET");
+        }
+
+        // this is needed so that we can call into member functions again, when we receive the Fetch callback
+        attr.userData = this;
+
+        attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
+        attr.onsuccess  = [](emscripten_fetch_t *fetch) {
+            auto src = static_cast<HttpBlock<T> *>(fetch->userData);
+            src->onSuccess(fetch);
+        };
+        attr.onerror = [](emscripten_fetch_t *fetch) {
+            auto src = static_cast<HttpBlock<T> *>(fetch->userData);
+            src->onError(fetch);
+        };
+        const auto target = url + endpoint;
+        std::ignore       = emscripten_fetch(&attr, target.c_str());
+    }
+
+    void
+    runThreadEmscripten() {
+        if (type == RequestType::SUBSCRIBE) {
+            while (!_shutdownThread) {
+                // long polling, just keep doing requests
+                std::thread thread{ &HttpBlock::doRequestEmscripten, this };
+                thread.join();
+            }
+        } else {
+            while (!_shutdownThread) {
+                while (_pendingRequests > 0) {
+                    _pendingRequests--;
+                    std::thread thread{ &HttpBlock::doRequestEmscripten, this };
+                    thread.join();
+                }
+                _ready.acquire();
+            }
+        }
+    }
+#else
+    void
+    runThreadNative() {
+        _client = std::make_unique<httplib::Client>(url);
+        _client->set_follow_location(true);
+        if (type == RequestType::SUBSCRIBE) {
+            // it's long polling, be generous with timeouts
+            _client->set_read_timeout(1h);
+            _client->Get(endpoint, [&](const char *data, size_t len) {
+                pmtv::map_t result;
+                result["mime-type"] = "text/plain";
+                result["status"]    = 200;
+                result["raw-data"]  = std::string(data, len);
+
+                queueWork(result);
+
+                return !_shutdownThread;
+            });
+        } else {
+            while (!_shutdownThread) {
+                while (_pendingRequests > 0) {
+                    _pendingRequests--;
+                    httplib::Result resp;
+                    if (type == RequestType::POST) {
+                        resp = parameters.empty() ? _client->Post(endpoint) : _client->Post(endpoint, parameters, "application/x-www-form-urlencoded");
+                    } else {
+                        resp = _client->Get(endpoint);
+                    }
+                    pmtv::map_t result;
+                    if (resp) {
+                        result["mime-type"] = "text/plain";
+                        result["status"]    = resp->status;
+                        result["raw-data"]  = resp->body;
+                        queueWork(result);
+                    }
+                }
+
+                _ready.acquire();
+            }
+        }
+    }
+#endif
+
+    void
+    queueWork(const pmtv::map_t &item) {
+        {
+            std::lock_guard lg{ _backlog_mutex };
+            _backlog.push(item);
+        }
+        const auto work = this->invokeWork();
+        if (work == work::Status::DONE) {
+            this->requestStop();
+        }
+        this->ioLastWorkStatus.exchange(work, std::memory_order_relaxed);
+    }
+
+    void
+    runThread() {
+#ifdef __EMSCRIPTEN__
+        runThreadEmscripten();
+#else
+        runThreadNative();
+#endif
+    }
+
+    void
+    startThread() {
+        _thread = std::shared_ptr<std::thread>(new std::thread([this]() { runThread(); }), [this](std::thread *t) {
+            _shutdownThread = true;
+            _ready.release();
+#ifndef __EMSCRIPTEN__
+            _client->stop();
+#endif
+            if (t->joinable()) {
+                t->join();
+            }
+            _shutdownThread = false;
+            delete t;
+
+            std::ignore = this->changeStateTo(gr::lifecycle::State::STOPPED);
+        });
+    }
+
+    void
+    stopThread() {
+        _thread.reset();
+    }
+
+public:
+    PortIn<T>            in;
+    PortOut<pmtv::map_t> out;
+
+    std::string           url;
+    std::string           endpoint;
+    gr::http::RequestType type = gr::http::RequestType::GET;
+    std::string           parameters; // x-www-form-urlencoded encoded POST parameters
+
+    explicit HttpBlock(const std::string &_url, const std::string &_endpoint = "/", const RequestType _type = RequestType::GET, const std::string &_parameters = "")
+        : url(_url), endpoint(_endpoint), type(_type), parameters(_parameters) {}
+
+    ~HttpBlock() { stopThread(); }
+
+    void
+    settingsChanged(const property_map & /*oldSettings*/, property_map &newSettings) noexcept {
+        if (newSettings.contains("url") || newSettings.contains("type")) {
+            // other setting changes are hot-swappble without restarting the Client
+            startThread();
+        }
+    }
+
+    void
+    start() {
+        startThread();
+    }
+
+    void
+    stop() {
+        stopThread();
+    }
+
+    [[nodiscard]] constexpr auto
+    processOne(T value) noexcept {
+        if (type == RequestType::SUBSCRIBE) {
+            // for long polling, the subscription should stay active, if and only if the value on the input port is 1
+            if (value) {
+                if (!_thread) {
+                    startThread();
+                }
+            } else {
+                stopThread();
+            }
+        }
+
+        pmtv::map_t     result;
+        std::lock_guard lg{ _backlog_mutex };
+        if (!_backlog.empty()) {
+            result = _backlog.front();
+            _backlog.pop();
+        }
+        return result;
+    }
+
+    void
+    trigger() {
+        _pendingRequests++;
+        _ready.release();
+    }
+
+    void
+    processMessages(gr::MsgPortInNamed<"__Builtin"> &, std::span<const gr::Message> message) {
+        std::ranges::for_each(message, [this](auto) { trigger(); });
+    }
+};
+
+static_assert(gr::BlockLike<http::HttpBlock<uint8_t>>);
+
+} // namespace gr::http
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (gr::http::HttpBlock<T>), in, out, url, endpoint);
+
+#endif // GNURADIO_HTTP_BLOCK_HPP

--- a/blocks/http/test/CMakeLists.txt
+++ b/blocks/http/test/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_ut_test(qa_HttpBlock)
+target_link_libraries(qa_HttpBlock PRIVATE gr-http)
+
+if (EMSCRIPTEN)
+    target_link_options(qa_HttpBlock PRIVATE --pre-js=${CMAKE_CURRENT_SOURCE_DIR}/pre.js --emrun)
+endif ()

--- a/blocks/http/test/pre.js
+++ b/blocks/http/test/pre.js
@@ -1,0 +1,54 @@
+// this is a little HTTP server intended for unit test purposes.
+// for interactive CLI usage, you can start the server by passing "start" as the last argument, e.g.:
+// node pre.js start
+//
+// for automated usage in unit tests, please call startServer() yourself after embedding this into the JS runtime with --pre-js
+// see: https://emscripten.org/docs/tools_reference/emcc.html#emcc-pre-js
+
+var http = require("http");
+// this requires xhr2 to be installed, please run: npm install xhr2
+// see: https://github.com/emscripten-core/emscripten/issues/21158
+/*global XMLHttpRequest:writable*/
+XMLHttpRequest = require('xhr2');
+
+const server = http.createServer((req, res) => {
+    console.log(req.url);
+    if (req.url == "/echo") {
+        res.writeHead(200, {"Content-Type": "text/plain"});
+        res.write("Hello world!");
+        res.end();
+    } else if (req.url == "/notify") {
+        // wait a bit before responding (we are testing long polling here)
+        return setTimeout(() => {
+            res.writeHead(200, {"Content-Type": "text/plain"});
+            res.write("event");
+            res.end();
+        }, 10);
+    } else if (req.url == "/number") {
+        res.writeHead(200, {"Content-Type": "text/plain"});
+        res.write("OK");
+        res.end();
+    } else {
+        res.writeHead(404, {"Content-Type": "text/plain"});
+        res.write("Unknown route");
+        res.end();
+    }
+});
+
+var startServer = () => {
+    server.once("error", (err) => { console.log(err); });
+    server.listen(8080);
+    console.log("Started the server");
+};
+
+var stopServer = () => {
+    server.close();
+    server.closeAllConnections();
+    console.log("Stopped the server");
+};
+
+if (process.argv.at(-1) == "start") {
+    startServer();
+} else if (process.argv.at(-1) == "stop") {
+    stopServer();
+}

--- a/blocks/http/test/qa_HttpBlock.cpp
+++ b/blocks/http/test/qa_HttpBlock.cpp
@@ -1,0 +1,228 @@
+#include <future>
+
+#include <boost/ut.hpp>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <gnuradio-4.0/testing/FunctionBlocks.hpp>
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/Buffer.hpp>
+#include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/reflection.hpp>
+#include <gnuradio-4.0/Scheduler.hpp>
+
+#include <gnuradio-4.0/http/HttpBlock.hpp>
+
+template<typename T>
+class FixedSource : public gr::Block<FixedSource<T>> {
+    using super_t = gr::Block<FixedSource<T>>;
+public:
+    gr::PortOut<T> out;
+    T value       = 1;
+
+    [[nodiscard]] constexpr auto
+    processOne() noexcept {
+        return value;
+    }
+
+    void
+    trigger() {
+        gr::Message message;
+        message[gr::message::key::Kind] = "custom_kind";
+        super_t::emitMessage(super_t::msgOut, message);
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (FixedSource<T>), out);
+
+template<typename T>
+class HttpTestSink : public gr::Block<HttpTestSink<T>> {
+public:
+    gr::PortIn<T>         in;
+    T                     value{};
+    std::function<void()> stopFunc;
+
+    constexpr void
+    processOne(T val) {
+        value = val;
+        if (!value.empty()) {
+            stopFunc();
+        }
+    }
+
+    void reset() {
+        value = {};
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (HttpTestSink<T>), in);
+
+const boost::ut::suite HttpBlocktests = [] {
+    using namespace boost::ut;
+    using namespace gr;
+    using namespace std::literals;
+    using namespace std::chrono_literals;
+    using namespace gr::testing;
+
+#ifdef __EMSCRIPTEN__
+    std::thread emscriptenThread{ [&]() {
+        // see ./pre.js for the emscripten server implementation
+        emscripten_run_script("startServer();");
+    } };
+#endif
+
+    "http GET"_test = [&] {
+#ifndef __EMSCRIPTEN__
+        httplib::Server server;
+        server.Get("/echo", [](const httplib::Request, httplib::Response &res) {
+            std::this_thread::sleep_for(10ms);
+            res.set_content("Hello world!", "text/plain");
+        });
+
+        auto thread = std::thread{ [&server] { server.listen("localhost", 8080); } };
+        server.wait_until_ready();
+#endif
+
+        gr::Graph graph;
+        auto     &source    = graph.emplaceBlock<FixedSource<uint8_t>>();
+        auto     &httpBlock = graph.emplaceBlock<http::HttpBlock<uint8_t>>("http://localhost:8080", "/echo");
+        auto     &sink      = graph.emplaceBlock<HttpTestSink<pmtv::map_t>>();
+
+        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(source).template to<"in">(httpBlock)));
+        expect(eq(ConnectionResult::SUCCESS, source.msgOut.connect(httpBlock.msgIn)));
+        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
+
+        auto sched    = gr::scheduler::Simple<>(std::move(graph));
+        sink.stopFunc = [&]() { sched.stop(); };
+        // make a request
+        source.trigger();
+        httpBlock.processScheduledMessages();
+        sched.runAndWait();
+        expect(eq(std::get<std::string>(sink.value.at("raw-data")), "Hello world!"sv));
+
+#ifndef __EMSCRIPTEN__
+        server.stop();
+        thread.join();
+#endif
+    };
+
+    "http GET 404"_test = [&] {
+#ifndef __EMSCRIPTEN__
+        httplib::Server server;
+        server.Get("/does-not-exist", [](const httplib::Request, httplib::Response &res) {
+            std::this_thread::sleep_for(10ms);
+            res.status = httplib::StatusCode::NotFound_404;
+        });
+
+        auto thread = std::thread{ [&server] { server.listen("localhost", 8080); } };
+        server.wait_until_ready();
+#endif
+
+        gr::Graph graph;
+        auto     &source    = graph.emplaceBlock<FixedSource<uint8_t>>();
+        auto     &httpBlock = graph.emplaceBlock<http::HttpBlock<uint8_t>>("http://localhost:8080", "/does-not-exist");
+        auto     &sink      = graph.emplaceBlock<HttpTestSink<pmtv::map_t>>();
+
+        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(source).template to<"in">(httpBlock)));
+        expect(eq(ConnectionResult::SUCCESS, source.msgOut.connect(httpBlock.msgIn)));
+        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
+
+        auto sched    = gr::scheduler::Simple<>(std::move(graph));
+        sink.stopFunc = [&]() { sched.stop(); };
+        httpBlock.trigger();
+        sched.runAndWait();
+        expect(eq(std::get<int>(sink.value.at("status")), 404));
+
+#ifndef __EMSCRIPTEN__
+        server.stop();
+        thread.join();
+#endif
+    };
+
+    "http POST"_test = [] {
+#ifndef __EMSCRIPTEN__
+        httplib::Server server;
+        server.Post("/number", [](const httplib::Request &, httplib::Response &res) {
+            std::this_thread::sleep_for(10ms);
+            res.set_content("OK", "text/plain");
+        });
+
+        auto thread = std::thread{ [&server] { server.listen("localhost", 8080); } };
+        server.wait_until_ready();
+#endif
+
+        gr::Graph graph;
+        auto     &source    = graph.emplaceBlock<FixedSource<uint8_t>>();
+        auto     &httpBlock = graph.emplaceBlock<http::HttpBlock<uint8_t>>("http://localhost:8080", "/number", http::RequestType::POST, "param=42");
+        auto     &sink      = graph.emplaceBlock<HttpTestSink<pmtv::map_t>>();
+
+        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(source).template to<"in">(httpBlock)));
+        expect(eq(ConnectionResult::SUCCESS, source.msgOut.connect(httpBlock.msgIn)));
+        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
+
+        auto sched    = gr::scheduler::Simple<>(std::move(graph));
+        sink.stopFunc = [&]() { sched.stop(); };
+        httpBlock.trigger();
+        sched.runAndWait();
+        expect(eq(std::get<std::string>(sink.value.at("raw-data")), "OK"sv));
+
+#ifndef __EMSCRIPTEN__
+        server.stop();
+        thread.join();
+#endif
+    };
+
+    "http SUBSCRIBE"_test = [] {
+#ifndef __EMSCRIPTEN__
+        std::atomic_bool shutdown = false;
+        httplib::Server  server;
+        server.Get("/notify", [&](const httplib::Request, httplib::Response &res) {
+            res.set_chunked_content_provider("text/plain", [&](size_t, httplib::DataSink &sink) {
+                if (shutdown) {
+                    return false;
+                }
+                // delay the reply a bit, we are long polling
+                std::this_thread::sleep_for(10ms);
+                if (sink.is_writable()) {
+                    sink.os << "event";
+                }
+                return true;
+            });
+        });
+
+        auto thread = std::thread{ [&server] { server.listen("localhost", 8080); } };
+        server.wait_until_ready();
+#endif
+
+        gr::Graph graph;
+        auto     &source    = graph.emplaceBlock<FixedSource<uint8_t>>();
+        auto     &httpBlock = graph.emplaceBlock<http::HttpBlock<uint8_t>>("http://localhost:8080", "/notify", http::RequestType::SUBSCRIBE);
+        auto     &sink      = graph.emplaceBlock<HttpTestSink<pmtv::map_t>>();
+
+        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(source).template to<"in">(httpBlock)));
+        expect(eq(ConnectionResult::SUCCESS, source.msgOut.connect(httpBlock.msgIn)));
+        expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
+
+        auto sched    = gr::scheduler::Simple<>(std::move(graph));
+        sink.stopFunc = [&]() { sched.stop(); };
+        httpBlock.trigger();
+        sched.runAndWait();
+        expect(eq(std::get<std::string>(sink.value.at("raw-data")), "event"sv));
+
+#ifndef __EMSCRIPTEN__
+        shutdown = true;
+        server.stop();
+        thread.join();
+#endif
+    };
+
+#ifdef __EMSCRIPTEN__
+    emscripten_run_script("stopServer();");
+    emscriptenThread.join();
+#endif
+};
+
+int
+main() { /* tests are statically executed */
+}

--- a/blocks/testing/include/gnuradio-4.0/testing/FunctionBlocks.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/FunctionBlocks.hpp
@@ -264,11 +264,28 @@ struct MessageSender : public gr::Block<MessageSender<T>> {
     }
 };
 
+/**
+ * A convenience class to make writing unit tests easier.
+ * This sink allows to inspect the input port values as a class member.
+ */
+template<typename T>
+class InspectSink : public gr::Block<InspectSink<T>> {
+public:
+    gr::PortIn<T> in;
+    T             value{};
+
+    constexpr void
+    processOne(T val) {
+        value = val;
+    }
+};
+
 } // namespace gr::testing
 
 ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::FunctionSource, out);
 ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::FunctionProcess, in, out);
 ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::FunctionSink, in);
 ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::MessageSender, unused)
+ENABLE_REFLECTION_FOR_TEMPLATE(gr::testing::InspectSink, in, value);
 
 #endif // GNURADIO_TESTING_FUNCTION_BLOCKS_HPP

--- a/core/include/gnuradio-4.0/Port.hpp
+++ b/core/include/gnuradio-4.0/Port.hpp
@@ -20,7 +20,7 @@ using gr::meta::fixed_string;
 #ifndef PMT_SUPPORTED_TYPE // // #### default supported types -- TODO: to be replaced by pmt::pmtv declaration
 #define PMT_SUPPORTED_TYPE
 // Only DataSet<double> and DataSet<float> are added => consider to support more Dataset<T>
-using supported_type = std::variant<uint8_t, uint32_t, int8_t, int16_t, int32_t, float, double, std::complex<float>, std::complex<double>, DataSet<float>, DataSet<double> /*, ...*/>;
+using supported_type = std::variant<uint8_t, uint32_t, int8_t, int16_t, int32_t, float, double, std::complex<float>, std::complex<double>, DataSet<float>, DataSet<double>, pmtv::map_t /*, ...*/>;
 #endif
 
 enum class PortDirection { INPUT, OUTPUT, ANY }; // 'ANY' only for query and not to be used for port declarations

--- a/core/test/qa_DynamicBlock.cpp
+++ b/core/test/qa_DynamicBlock.cpp
@@ -3,6 +3,7 @@
 #include <boost/ut.hpp>
 
 #include <gnuradio-4.0/basic/common_blocks.hpp>
+#include <gnuradio-4.0/testing/FunctionBlocks.hpp>
 #include <gnuradio-4.0/Graph.hpp>
 
 template<typename T>
@@ -29,23 +30,9 @@ static_assert(gr::BlockLike<fixed_source<int>>);
 static_assert(gr::traits::block::stream_input_ports<fixed_source<int>>::size() == 0);
 static_assert(gr::traits::block::stream_output_ports<fixed_source<int>>::size() == 1);
 
-template<typename T>
-struct DebugSink : public gr::Block<DebugSink<T>> {
-    T             lastValue = {};
-    gr::PortIn<T> in;
-
-    void
-    processOne(T value) {
-        lastValue = value;
-    }
-};
-
-static_assert(gr::BlockLike<DebugSink<int>>);
-
-ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (DebugSink<T>), lastValue, in);
-
 const boost::ut::suite DynamicBlocktests = [] {
     using namespace boost::ut;
+    using namespace gr::testing;
     "Change number of ports dynamically"_test = [] {
         constexpr const int         sources_count = 10;
         constexpr const std::size_t events_count  = 5;

--- a/core/test/qa_DynamicBlock.cpp
+++ b/core/test/qa_DynamicBlock.cpp
@@ -56,7 +56,7 @@ const boost::ut::suite DynamicBlocktests = [] {
         // sources_count / 2 inputs on construction, and change the number
         // via settings
         auto &adder = testGraph.addBlock(std::make_unique<multi_adder<double>>(sources_count / 2));
-        auto &sink  = testGraph.emplaceBlock<DebugSink<double>>({});
+        auto &sink  = testGraph.emplaceBlock<InspectSink<double>>({});
 
         // Function that adds a new source node to the graph, and connects
         // it to one of adder's ports
@@ -80,7 +80,7 @@ const boost::ut::suite DynamicBlocktests = [] {
             const auto work = sink.work(1UZ);
             expect(eq(work.performed_work, 1UZ));
 
-            expect(eq(sink.lastValue, static_cast<double>((i + 1) * sources.size())));
+            expect(eq(sink.value, static_cast<double>((i + 1) * sources.size())));
         }
 
         // add yet another sources_count number of ports
@@ -104,7 +104,7 @@ const boost::ut::suite DynamicBlocktests = [] {
             const auto sink_work = sink.work(1UZ);
             expect(eq(sink_work.performed_work, 1UZ));
 
-            expect(eq(sink.lastValue, static_cast<double>((i + 1) * sources_count + (i - events_count + 1) * sources_count)));
+            expect(eq(sink.value, static_cast<double>((i + 1) * sources_count + (i - events_count + 1) * sources_count)));
         }
     };
 };


### PR DESCRIPTION
This implements the `HttpBlock` as described in #236.

The WebAssembly implementation took quite some jumping through hoops to get right.
There are a lot of quirks with regard to threading in emscripten, that make the implementation a minefield of risking getting stuck in infinite loops, because the emscripten thread for various reasons is unable to make any progress.
Unfortunately we cannot use `ASYNCIFY`, because that is incompatible with exceptions support ([that are already enabled](https://github.com/fair-acc/graph-prototype/blob/530ce6298a6138140de5ac6e05eae95703cdc47f/CMakeLists.txt#L84)).

There is also this fun [emscripten regression](https://github.com/emscripten-core/emscripten/issues/8234#issuecomment-1333548834), which means it's currently impossible to cancel asynchronously running fetch requests.

For the unit test the httplib dummy server obviously doesn't work with emscripten, so the [--pre-js](https://emscripten.org/docs/tools_reference/emcc.html#emcc-pre-js) mechanism is used to implement another one with node http, that is automatically injected into the runtime.
Note that in order for the unit test to run, `node` needs to be able to find `xhr2`, so:

```bash
npm install xhr2
```
