### PR TITLE
Fix runaway multiplication of messages

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -161,6 +161,7 @@ public:
             if (const auto available = reader.available(); available > 0) {
                 const auto &input = reader.get(available);
                 outPort.streamWriter().publish([&](auto &output) { std::ranges::copy(input, output.begin()); }, available);
+                reader.consume(available);
             }
         };
 


### PR DESCRIPTION
This commit fixes runaway spamming of messages as soon as one is sent to/from the scheduler.