### PR TITLE
Create the maximum number of threads when the task type is CPU_BOUND

### DIFF
--- a/core/include/gnuradio-4.0/thread/thread_pool.hpp
+++ b/core/include/gnuradio-4.0/thread/thread_pool.hpp
@@ -405,7 +405,8 @@ public:
                     uint32_t max = std::thread::hardware_concurrency())
         : _poolName(name), _taskType(taskType), _minThreads(std::min(min, max)), _maxThreads(max) {
         assert(min > 0 && "minimum number of threads must be > 0");
-        for (uint32_t i = 0; i < _minThreads; ++i) {
+        uint32_t num = _taskType == TaskType::IO_BOUND ? _minThreads : _maxThreads;
+        for (uint32_t i = 0; i < num; ++i) {
             createWorkerThread();
         }
     }


### PR DESCRIPTION
This fixes the scheduler not working properly because it divides the blocks among the maximum number of threads but the thread pool was only creating the minimum amount of threads.
When minimum and maximum are not the same that resulted in only part of the blocks being executed, in case of a flowgraph that keeps running.

This makes the flowgraph in opendigitizer work again.