### PR TITLE
Implement C++20 Concept to ensure work(std::size_t) function signature in Block classes

### DIFF
--- a/.github/workflows/ci-meson.yml
+++ b/.github/workflows/ci-meson.yml
@@ -35,12 +35,12 @@ jobs:
         meson-build-type: [ release, debug ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 100
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-fetchContent-cache
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-fetchContent-cache
         with:

--- a/.github/workflows/single-header.yml
+++ b/.github/workflows/single-header.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 100
 
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: cache-fetchContent-cache
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ if (ENABLE_TESTING AND UNIX AND NOT APPLE)
         target_compile_options(gnuradio-options INTERFACE --coverage -O0 -g -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0) # fortify_source is not possible without optimization
         target_link_libraries(gnuradio-options INTERFACE --coverage)
         append_coverage_compiler_flags()
+        set(GCOVR_ADDITIONAL_ARGS "--merge-mode-functions=merge-use-line-min")
         setup_target_for_coverage_gcovr_xml(
                 NAME coverage
                 EXECUTABLE ctest

--- a/algorithm/test/qa_algorithm_fourier.cpp
+++ b/algorithm/test/qa_algorithm_fourier.cpp
@@ -85,11 +85,11 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
         typename T::AlgoType fftAlgo{};
         constexpr double     tolerance{ 1.e-5 };
         struct TestParams {
-            std::uint32_t N{ 1024 };           // must be power of 2
-            double        sample_rate{ 128. }; // must be power of 2 (only for the unit test for easy comparison with true result)
-            double        frequency{ 1. };
-            double        amplitude{ 1. };
-            bool          outputInDb{ false };
+            gr::Size_t N{ 1024 };           // must be power of 2
+            double     sample_rate{ 128. }; // must be power of 2 (only for the unit test for easy comparison with true result)
+            double     frequency{ 1. };
+            double     amplitude{ 1. };
+            bool       outputInDb{ false };
         };
 
         std::vector<TestParams> testCases = { { 256, 128., 10., 5., false }, { 512, 4., 1., 1., false }, { 512, 32., 1., 0.1, false }, { 256, 128., 10., 5., false } };
@@ -115,9 +115,9 @@ const boost::ut::suite<"FFT algorithms and window functions"> windowTests = [] {
 
     "FFT algo pattern tests"_test = []<typename T>() {
         using InType = T::InType;
-        typename T::AlgoType    fftAlgo{};
-        constexpr double        tolerance{ 1.e-5 };
-        constexpr std::uint32_t N{ 16 };
+        typename T::AlgoType fftAlgo{};
+        constexpr double     tolerance{ 1.e-5 };
+        constexpr gr::Size_t N{ 16 };
         static_assert(N == 16, "expected values are calculated for N == 16");
 
         std::vector<InType> signal(N);

--- a/blocks/basic/include/gnuradio-4.0/basic/Selector.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/Selector.hpp
@@ -8,8 +8,6 @@
 namespace gr::basic {
 using namespace gr;
 
-
-
 using SelectorDoc = Doc<R""(
 @brief basic multiplexing class to route arbitrary inputs to outputs
 
@@ -69,25 +67,26 @@ struct Selector : Block<Selector<T>, SelectorDoc> {
     using A = Annotated<U, description, Arguments...>;
 
     // port definitions
-    PortIn<std::uint32_t, Async, Optional> selectOut;
-    PortOut<T, Async, Optional>            monitorOut; // optional monitor output (for diagnostics and debugging purposes)
-    std::vector<PortIn<T, Async>>          inputs;     // TODO: need to add exception to pmt_t that this isn't interpreted as a settings type
-    std::vector<PortOut<T, Async>>         outputs;
+    PortIn<gr::Size_t, Async, Optional> selectOut;
+    PortOut<T, Async, Optional>         monitorOut; // optional monitor output (for diagnostics and debugging purposes)
+    std::vector<PortIn<T, Async>>       inputs;     // TODO: need to add exception to pmt_t that this isn't interpreted as a settings type
+    std::vector<PortOut<T, Async>>      outputs;
 
     // settings
-    A<std::uint32_t, "n_inputs", Visible, Doc<"variable number of inputs">, Limits<1U, 32U>>    n_inputs  = 0U;
-    A<std::uint32_t, "n_outputs", Visible, Doc<"variable number of inputs">, Limits<1U, 32U>>   n_outputs = 0U;
-    A<std::vector<std::uint32_t>, "map_in", Visible, Doc<"input port index to route from">>     map_in; // N.B. need two vectors since pmt_t doesn't support pairs (yet!?!)
-    A<std::vector<std::uint32_t>, "map_out", Visible, Doc<"output port index to route to">>     map_out;
+    A<gr::Size_t, "n_inputs", Visible, Doc<"variable number of inputs">, Limits<1U, 32U>>       n_inputs  = 0U;
+    A<gr::Size_t, "n_outputs", Visible, Doc<"variable number of inputs">, Limits<1U, 32U>>      n_outputs = 0U;
+    A<std::vector<gr::Size_t>, "map_in", Visible, Doc<"input port index to route from">>        map_in; // N.B. need two vectors since pmt_t doesn't support pairs (yet!?!)
+    A<std::vector<gr::Size_t>, "map_out", Visible, Doc<"output port index to route to">>        map_out;
     A<bool, "back_pressure", Visible, Doc<"true: do not consume samples from un-routed ports">> back_pressure = false;
-    std::map<std::uint32_t, std::vector<std::uint32_t>>                                         _internalMapping;
-    std::uint32_t                                                                               _selectedSrc = -1U;
+    std::map<gr::Size_t, std::vector<gr::Size_t>>                                               _internalMapping;
+    gr::Size_t                                                                                  _selectedSrc = -1U;
 
     void
     settingsChanged(const gr::property_map &old_settings, const gr::property_map &new_settings) {
         if (new_settings.contains("n_inputs") || new_settings.contains("n_outputs")) {
             fmt::print("{}: configuration changed: n_inputs {} -> {}, n_outputs {} -> {}\n", static_cast<void *>(this), old_settings.at("n_inputs"),
-                       new_settings.contains("n_inputs") ? new_settings.at("n_inputs") : "same", old_settings.at("n_outputs"), new_settings.contains("n_outputs") ? new_settings.at("n_outputs") : "same");
+                       new_settings.contains("n_inputs") ? new_settings.at("n_inputs") : "same", old_settings.at("n_outputs"),
+                       new_settings.contains("n_outputs") ? new_settings.at("n_outputs") : "same");
             inputs.resize(n_inputs);
             outputs.resize(n_outputs);
         }
@@ -105,7 +104,7 @@ struct Selector : Block<Selector<T>, SelectorDoc> {
         }
     }
 
-    using select_reader_t  = typename PortIn<std::uint32_t, Async, Optional>::ReaderType;
+    using select_reader_t  = typename PortIn<gr::Size_t, Async, Optional>::ReaderType;
     using monitor_writer_t = typename PortOut<T, Async, Optional>::WriterType;
     using input_reader_t   = typename PortIn<T, Async>::ReaderType;
     using output_writer_t  = typename PortOut<T, Async>::WriterType;

--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -182,8 +182,8 @@ const boost::ut::suite DataSinkTests = [] {
     using namespace std::string_literals;
 
     "callback continuous mode"_test = [] {
-        constexpr std::uint64_t kSamples   = 200005;
-        constexpr std::size_t   kChunkSize = 1000;
+        constexpr gr::Size_t  kSamples   = 200005;
+        constexpr std::size_t kChunkSize = 1000;
 
         const auto srcTags = makeTestTags(0, 1000);
 
@@ -262,7 +262,7 @@ const boost::ut::suite DataSinkTests = [] {
     };
 
     "blocking polling continuous mode"_test = [] {
-        constexpr std::uint64_t kSamples = 200000;
+        constexpr gr::Size_t kSamples = 200000;
 
         gr::Graph  testGraph;
         const auto tags = makeTestTags(0, 1000);
@@ -339,7 +339,7 @@ const boost::ut::suite DataSinkTests = [] {
     };
 
     "blocking polling trigger mode non-overlapping"_test = [] {
-        constexpr std::uint64_t kSamples = 200000;
+        constexpr gr::Size_t kSamples = 200000;
 
         gr::Graph  testGraph;
         auto      &src  = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({ { "n_samples_max", kSamples }, { "mark_tag", false } });
@@ -401,7 +401,7 @@ const boost::ut::suite DataSinkTests = [] {
     };
 
     "blocking snapshot mode"_test = [] {
-        constexpr std::uint64_t kSamples = 200000;
+        constexpr gr::Size_t kSamples = 200000;
 
         gr::Graph testGraph;
         auto     &src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({ { "n_samples_max", kSamples }, { "mark_tag", false } });
@@ -472,11 +472,11 @@ const boost::ut::suite DataSinkTests = [] {
     "blocking multiplexed mode"_test = [] {
         const auto tags = makeTestTags(0, 10000);
 
-        const std::uint64_t n_samples = static_cast<std::uint64_t>(tags.size() * 10000 + 100000);
-        gr::Graph           testGraph;
-        auto               &src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({ { "n_samples_max", n_samples }, { "mark_tag", false } });
-        src.tags                = tags;
-        auto &sink              = testGraph.emplaceBlock<DataSink<int32_t>>({ { "name", "test_sink" } });
+        const gr::Size_t n_samples = static_cast<gr::Size_t>(tags.size() * 10000 + 100000);
+        gr::Graph        testGraph;
+        auto            &src = testGraph.emplaceBlock<gr::testing::TagSource<int32_t>>({ { "n_samples_max", n_samples }, { "mark_tag", false } });
+        src.tags             = tags;
+        auto &sink           = testGraph.emplaceBlock<DataSink<int32_t>>({ { "name", "test_sink" } });
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).to<"in">(sink)));
 
@@ -552,7 +552,7 @@ const boost::ut::suite DataSinkTests = [] {
     };
 
     "blocking polling trigger mode overlapping"_test = [] {
-        constexpr std::uint64_t kSamples  = 150000;
+        constexpr std::uint32_t kSamples  = 150000;
         constexpr std::size_t   kTriggers = 300;
 
         gr::Graph testGraph;
@@ -607,7 +607,7 @@ const boost::ut::suite DataSinkTests = [] {
     };
 
     "callback trigger mode overlapping"_test = [] {
-        constexpr std::uint64_t kSamples  = 150000;
+        constexpr std::uint32_t kSamples  = 150000;
         constexpr std::size_t   kTriggers = 300;
 
         gr::Graph testGraph;
@@ -647,7 +647,7 @@ const boost::ut::suite DataSinkTests = [] {
     };
 
     "non-blocking polling continuous mode"_test = [] {
-        constexpr std::uint64_t kSamples = 200000;
+        constexpr std::uint32_t kSamples = 200000;
 
         gr::Graph testGraph;
         auto     &src  = testGraph.emplaceBlock<gr::testing::TagSource<float>>({ { "n_samples_max", kSamples }, { "mark_tag", false } });

--- a/blocks/basic/test/qa_Selector.cpp
+++ b/blocks/basic/test/qa_Selector.cpp
@@ -12,8 +12,8 @@
 
 template<typename T>
 struct repeated_source : public gr::Block<repeated_source<T>> {
-    std::uint32_t                  identifier = 0;
-    std::uint32_t                  remaining_events_count;
+    gr::Size_t                     identifier = 0;
+    gr::Size_t                     remaining_events_count;
     std::vector<T>                 values;
     std::vector<T>::const_iterator values_next;
 
@@ -59,7 +59,7 @@ ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (repeated_source<T>), identifi
 
 template<typename T>
 struct validator_sink : public gr::Block<validator_sink<T>> {
-    std::uint32_t identifier = 0;
+    gr::Size_t    identifier = 0;
     gr::PortIn<T> in;
 
     std::vector<T>                 expected_values;
@@ -114,29 +114,29 @@ struct adder : public gr::Block<adder<T>> {
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (adder<T>), addend0, addend1, sum);
 
 struct test_definition {
-    std::uint32_t                                        value_count;
-    std::vector<std::pair<std::uint32_t, std::uint32_t>> mapping;
-    std::vector<std::vector<double>>                     input_values;
-    std::vector<std::vector<double>>                     output_values;
-    std::uint32_t                                        monitor_source;
-    std::vector<double>                                  monitor_values;
-    bool                                                 back_pressure;
+    gr::Size_t                                     value_count;
+    std::vector<std::pair<gr::Size_t, gr::Size_t>> mapping;
+    std::vector<std::vector<double>>               input_values;
+    std::vector<std::vector<double>>               output_values;
+    gr::Size_t                                     monitor_source;
+    std::vector<double>                            monitor_values;
+    bool                                           back_pressure;
 };
 
 void
 execute_selector_test(test_definition definition) {
     using namespace boost::ut;
 
-    const std::uint32_t sources_count = definition.input_values.size();
-    const std::uint32_t sinks_count   = definition.output_values.size();
+    const gr::Size_t sources_count = definition.input_values.size();
+    const gr::Size_t sinks_count   = definition.output_values.size();
 
     gr::Graph                              graph;
     std::vector<repeated_source<double> *> sources;
     std::vector<validator_sink<double> *>  sinks;
     gr::basic::Selector<double>           *selector;
 
-    std::vector<std::uint32_t> mapIn(definition.mapping.size());
-    std::vector<std::uint32_t> map_out(definition.mapping.size());
+    std::vector<gr::Size_t> mapIn(definition.mapping.size());
+    std::vector<gr::Size_t> map_out(definition.mapping.size());
     std::ranges::transform(definition.mapping, mapIn.begin(), [](auto &p) { return p.first; });
     std::ranges::transform(definition.mapping, map_out.begin(), [](auto &p) { return p.second; });
 

--- a/blocks/basic/test/qa_sources.cpp
+++ b/blocks/basic/test/qa_sources.cpp
@@ -43,10 +43,10 @@ const boost::ut::suite TagTests = [] {
         if (verbose) {
             fmt::println("started ClockSource test w/ {}", useIoThreadPool ? "Graph/Block<T> provided-thread" : "user-provided thread");
         }
-        constexpr std::uint32_t n_samples   = 1900;
-        constexpr float         sample_rate = 2000.f;
-        Graph                   testGraph;
-        auto                   &src = testGraph.emplaceBlock<gr::basic::ClockSource<float, useIoThreadPool>>(
+        constexpr gr::Size_t n_samples   = 1900;
+        constexpr float      sample_rate = 2000.f;
+        Graph                testGraph;
+        auto                &src = testGraph.emplaceBlock<gr::basic::ClockSource<float, useIoThreadPool>>(
                 { { "sample_rate", sample_rate }, { "n_samples_max", n_samples }, { "name", "ClockSource" }, { "verbose_console", verbose } });
         src.tags = {
             { 0, { { "key", "value@0" } } },       //
@@ -71,8 +71,8 @@ const boost::ut::suite TagTests = [] {
 
         expect(eq(src.n_samples_max, n_samples)) << "src did not accept require max input samples";
         expect(eq(src.n_samples_produced, n_samples)) << "src did not produce enough output samples";
-        expect(eq(static_cast<std::uint32_t>(sink1.n_samples_produced), n_samples)) << fmt::format("sink1 did not consume enough input samples ({} vs. {})", sink1.n_samples_produced, n_samples);
-        expect(eq(static_cast<std::uint32_t>(sink2.n_samples_produced), n_samples)) << fmt::format("sink2 did not consume enough input samples ({} vs. {})", sink2.n_samples_produced, n_samples);
+        expect(eq(static_cast<gr::Size_t>(sink1.n_samples_produced), n_samples)) << fmt::format("sink1 did not consume enough input samples ({} vs. {})", sink1.n_samples_produced, n_samples);
+        expect(eq(static_cast<gr::Size_t>(sink2.n_samples_produced), n_samples)) << fmt::format("sink2 did not consume enough input samples ({} vs. {})", sink2.n_samples_produced, n_samples);
 
         if (std::getenv("DISABLE_SENSITIVE_TESTS") == nullptr) {
             expect(approx(sink1.effective_sample_rate(), sample_rate, 500.f))
@@ -157,12 +157,12 @@ const boost::ut::suite TagTests = [] {
     };
 
     "SignalGenerator + ClockSource test"_test = [] {
-        constexpr std::uint32_t n_samples   = 200;
-        constexpr float         sample_rate = 1000.f;
-        Graph                   testGraph;
-        auto                   &clockSrc  = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({ { "sample_rate", sample_rate }, { "n_samples_max", n_samples }, { "name", "ClockSource" } });
-        auto                   &signalGen = testGraph.emplaceBlock<SignalGenerator<float>>({ { "sample_rate", sample_rate }, { "name", "SignalGenerator" } });
-        auto                   &sink      = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagSink" }, { "verbose_console", true } });
+        constexpr gr::Size_t n_samples   = 200;
+        constexpr float      sample_rate = 1000.f;
+        Graph                testGraph;
+        auto                &clockSrc  = testGraph.emplaceBlock<gr::basic::ClockSource<float>>({ { "sample_rate", sample_rate }, { "n_samples_max", n_samples }, { "name", "ClockSource" } });
+        auto                &signalGen = testGraph.emplaceBlock<SignalGenerator<float>>({ { "sample_rate", sample_rate }, { "name", "SignalGenerator" } });
+        auto                &sink      = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagSink" }, { "verbose_console", true } });
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(clockSrc).to<"in">(signalGen)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(signalGen).to<"in">(sink)));

--- a/blocks/fourier/include/gnuradio-4.0/fourier/fft.hpp
+++ b/blocks/fourier/include/gnuradio-4.0/fourier/fft.hpp
@@ -100,7 +100,7 @@ On the choice of window (mathematically aka. apodisation) functions
 
     // settings
     const std::string                                                                algorithm = gr::meta::type_name<decltype(_fftImpl)>();
-    Annotated<std::uint32_t, "FFT size", Doc<"FFT size">>                            fftSize{ 1024U };
+    Annotated<gr::Size_t, "FFT size", Doc<"FFT size">>                               fftSize{ 1024U };
     Annotated<std::string, "window type", Doc<gr::algorithm::window::TypeNames>>     window = std::string(magic_enum::enum_name(_windowType));
     Annotated<bool, "output in dB", Doc<"calculate output in decibels">>             outputInDb{ false };
     Annotated<bool, "output in deg", Doc<"calculate phase in degrees">>              outputInDeg{ false };
@@ -108,8 +108,8 @@ On the choice of window (mathematically aka. apodisation) functions
     Annotated<float, "sample rate", Doc<"signal sample rate">, Unit<"Hz">>           sample_rate = 1.f;
     Annotated<std::string, "signal name", Visible>                                   signal_name = "unknown signal";
     Annotated<std::string, "signal unit", Visible, Doc<"signal's physical SI unit">> signal_unit = "a.u.";
-    Annotated<T, "signal min", Doc<"signal physical min. (e.g. DAQ) limit">>         signal_min  = std::numeric_limits<T>::lowest();
-    Annotated<T, "signal max", Doc<"signal physical max. (e.g. DAQ) limit">>         signal_max  = std::numeric_limits<T>::max();
+    Annotated<float, "signal min", Doc<"signal physical min. (e.g. DAQ) limit">>     signal_min  = -std::numeric_limits<float>::max();
+    Annotated<float, "signal max", Doc<"signal physical max. (e.g. DAQ) limit">>     signal_max  = +std::numeric_limits<float>::max();
 
     // semi-private caching vectors (need to be public for unit-test) -> TODO: move to FFT implementations, casting from T -> U::value_type should be done there
     std::vector<InDataType>  _inData             = std::vector<InDataType>(fftSize, 0);

--- a/blocks/fourier/test/qa_fourier.cpp
+++ b/blocks/fourier/test/qa_fourier.cpp
@@ -131,9 +131,9 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
         using InType  = T::InType;
         using OutType = T::OutType;
 
-        constexpr std::uint32_t N{ 16 };
-        constexpr float         sample_rate{ 1.f };
-        FFT<InType, OutType>    fftBlock({ { "fftSize", N }, { "sample_rate", sample_rate } });
+        constexpr gr::Size_t N{ 16 };
+        constexpr float      sample_rate{ 1.f };
+        FFT<InType, OutType> fftBlock({ { "fftSize", N }, { "sample_rate", sample_rate } });
         std::ignore = fftBlock.settings().applyStagedParameters();
 
         expect(eq(fftBlock.algorithm, gr::meta::type_name<algorithm::FFT<InType, std::complex<typename OutType::value_type>>>()));
@@ -163,7 +163,7 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
         auto      threadPool = std::make_shared<gr::thread_pool::BasicThreadPool>("custom pool", gr::thread_pool::CPU_BOUND, 2, 2);
         gr::Graph flow1;
         auto     &source1  = flow1.emplaceBlock<CountSource<float>>();
-        auto     &fftBlock = flow1.emplaceBlock<FFT<float>>({ { "fftSize", static_cast<std::uint32_t>(16) } });
+        auto     &fftBlock = flow1.emplaceBlock<FFT<float>>({ { "fftSize", static_cast<gr::Size_t>(16) } });
         expect(eq(gr::ConnectionResult::SUCCESS, flow1.connect<"out">(source1).to<"in">(fftBlock)));
         auto sched1 = Scheduler(std::move(flow1), threadPool);
 
@@ -171,7 +171,7 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
         for (int i = 0; i < 2; i++) {
             gr::Graph flow2;
             auto     &source2 = flow2.emplaceBlock<CountSource<float>>();
-            auto     &fft2    = flow2.emplaceBlock<FFT<float>>({ { "fftSize", static_cast<std::uint32_t>(16) } });
+            auto     &fft2    = flow2.emplaceBlock<FFT<float>>({ { "fftSize", static_cast<gr::Size_t>(16) } });
             expect(eq(gr::ConnectionResult::SUCCESS, flow2.connect<"out">(source2).to<"in">(fft2)));
             auto sched2 = Scheduler(std::move(flow2), threadPool);
             sched2.runAndWait();
@@ -190,7 +190,7 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
         using value_type = OutType::value_type;
         constexpr value_type tolerance{ value_type(0.00001) };
 
-        constexpr std::uint32_t N{ 8 };
+        constexpr gr::Size_t N{ 8 };
         for (const auto &[window, windowName] : magic_enum::enum_entries<gr::algorithm::window::Type>()) {
             std::ignore = fftBlock.settings().set({ { "fftSize", N } });
             std::ignore = fftBlock.settings().set({ { "window", std::string(windowName) } });

--- a/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/TagMonitors.hpp
@@ -89,8 +89,8 @@ struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
     PortOut<T>       out;
     std::vector<Tag> tags{};
     std::size_t      next_tag{ 0 };
-    std::uint64_t    n_samples_max{ 1024 };
-    std::uint64_t    n_samples_produced{ 0 };
+    gr::Size_t       n_samples_max{ 1024 };
+    gr::Size_t       n_samples_produced{ 0 };
     float            sample_rate     = 1000.0f;
     std::string      signal_name     = "unknown signal";
     bool             verbose_console = false;
@@ -131,7 +131,7 @@ struct TagSource : public Block<TagSource<T, UseProcessVariant>> {
             }
         }
 
-        n_samples_produced += static_cast<std::uint64_t>(nSamples);
+        n_samples_produced += static_cast<gr::Size_t>(nSamples);
         output.publish(nSamples);
         return n_samples_produced < n_samples_max ? work::Status::OK : work::Status::DONE;
     }
@@ -159,8 +159,8 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
     PortOut<T>                               out;
     std::vector<T>                           samples{};
     std::vector<Tag>                         tags{};
-    std::uint64_t                            n_samples_expected{ 0 };
-    std::uint64_t                            n_samples_produced{ 0 };
+    gr::Size_t                               n_samples_expected{ 0 };
+    gr::Size_t                               n_samples_produced{ 0 };
     float                                    sample_rate = 1000.0f;
     std::string                              signal_name;
     bool                                     log_tags         = true;
@@ -222,7 +222,7 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
             }
         }
         if constexpr (gr::meta::any_simd<V>) {
-            n_samples_produced += static_cast<std::uint64_t>(V::size());
+            n_samples_produced += static_cast<gr::Size_t>(V::size());
         } else {
             n_samples_produced++;
         }
@@ -245,7 +245,7 @@ struct TagMonitor : public Block<TagMonitor<T, UseProcessVariant>> {
             samples.insert(samples.cend(), input.begin(), input.end());
         }
 
-        n_samples_produced += static_cast<std::uint64_t>(input.size());
+        n_samples_produced += static_cast<gr::Size_t>(input.size());
         std::memcpy(output.data(), input.data(), input.size() * sizeof(T));
 
         return work::Status::OK;
@@ -258,8 +258,8 @@ struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
     PortIn<T>                                in;
     std::vector<T>                           samples{};
     std::vector<Tag>                         tags{};
-    std::uint64_t                            n_samples_expected{ 0 };
-    std::uint64_t                            n_samples_produced{ 0 };
+    gr::Size_t                               n_samples_expected{ 0 };
+    std::uint32_t                            n_samples_produced{ 0 };
     float                                    sample_rate = 1000.0f;
     std::string                              signal_name;
     bool                                     log_tags         = true;
@@ -331,7 +331,7 @@ struct TagSink : public Block<TagSink<T, UseProcessVariant>> {
         if (log_samples) {
             samples.insert(samples.cend(), input.begin(), input.end());
         }
-        n_samples_produced += static_cast<std::uint64_t>(input.size());
+        n_samples_produced += static_cast<std::uint32_t>(input.size());
         _timeLastSample = ClockSourceType::now();
         return n_samples_expected > 0 && n_samples_produced >= n_samples_expected ? work::Status::DONE : work::Status::OK;
     }

--- a/core/benchmarks/bm_Buffer.cpp
+++ b/core/benchmarks/bm_Buffer.cpp
@@ -2,6 +2,7 @@
 
 #include <barrier>
 #include <chrono>
+#include <cstddef>
 #include <iostream>
 #include <thread>
 
@@ -24,11 +25,11 @@ using namespace gr;
 void
 setCpuAffinity(const int cpuID) // N.B. pthread is not portable
 {
-    const auto nCPU = std::thread::hardware_concurrency();
+    const std::size_t nCPU = std::thread::hardware_concurrency();
     // fmt::print("set CPU affinity to core {}\n", cpuID % nCPU);
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
-    CPU_SET(static_cast<size_t>(cpuID) % nCPU, &cpuset);
+    CPU_SET(static_cast<std::size_t>(cpuID) % nCPU, &cpuset);
     int rc = pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
     if (rc != 0) {
         constexpr auto fmt = "pthread_setaffinity_np({} of {}): {} - {}\n";

--- a/core/benchmarks/bm_fft.cpp
+++ b/core/benchmarks/bm_fft.cpp
@@ -75,11 +75,11 @@ testFFT() {
     using namespace gr;
     using namespace gr::algorithm;
 
-    constexpr std::uint32_t N{ 1024U }; // must be power of 2
-    constexpr double        sampleRate{ 256. };
-    constexpr double        frequency{ 100. };
-    constexpr double        amplitude{ 1. };
-    constexpr int           nRepetitions{ 100 };
+    constexpr gr::Size_t N{ 1024U }; // must be power of 2
+    constexpr double     sampleRate{ 256. };
+    constexpr double     frequency{ 100. };
+    constexpr double     amplitude{ 1. };
+    constexpr int        nRepetitions{ 100 };
 
     using PrecisionType = FFTAlgoPrecision<T>::type;
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -362,10 +362,10 @@ public:
     constexpr static TagPropagationPolicy tag_policy = TagPropagationPolicy::TPP_ALL_TO_ALL;
 
     //
-    using RatioValue = std::conditional_t<Resampling::kIsConst, const std::size_t, std::size_t>;
-    A<RatioValue, "numerator", Doc<"Top of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UZ, std::size_t(-1)>>      numerator   = Resampling::kNumerator;
-    A<RatioValue, "denominator", Doc<"Bottom of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UZ, std::size_t(-1)>> denominator = Resampling::kDenominator;
-    using StrideValue = std::conditional_t<StrideControl::kIsConst, const std::size_t, std::size_t>;
+    using RatioValue = std::conditional_t<Resampling::kIsConst, const std::uint64_t, std::uint64_t>;
+    A<RatioValue, "numerator", Doc<"Top of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UZ, std::uint64_t(-1)>>      numerator   = Resampling::kNumerator;
+    A<RatioValue, "denominator", Doc<"Bottom of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UZ, std::uint64_t(-1)>> denominator = Resampling::kDenominator;
+    using StrideValue = std::conditional_t<StrideControl::kIsConst, const std::uint64_t, std::uint64_t>;
     A<StrideValue, "stride", Doc<"samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.">> stride = StrideControl::kStride;
 
     //

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -132,7 +132,7 @@ outputPorts(Self *self) noexcept {
 namespace work {
 
 class Counter {
-    std::atomic_uint64_t encodedCounter{ static_cast<uint64_t>(std::numeric_limits<std::uint32_t>::max()) << 32 };
+    std::atomic_uint64_t encodedCounter{ static_cast<uint64_t>(std::numeric_limits<gr::Size_t>::max()) << 32 };
 
 public:
     void
@@ -141,12 +141,12 @@ public:
         uint64_t newCounter;
         do {
             oldCounter         = encodedCounter;
-            auto workRequested = static_cast<std::uint32_t>(oldCounter >> 32);
-            auto workDone      = static_cast<std::uint32_t>(oldCounter & 0xFFFFFFFF);
-            if (workRequested != std::numeric_limits<std::uint32_t>::max()) {
-                workRequested = static_cast<uint32_t>(std::min(static_cast<std::uint64_t>(workRequested) + workRequestedInc, static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max())));
+            auto workRequested = static_cast<gr::Size_t>(oldCounter >> 32);
+            auto workDone      = static_cast<gr::Size_t>(oldCounter & 0xFFFFFFFF);
+            if (workRequested != std::numeric_limits<gr::Size_t>::max()) {
+                workRequested = static_cast<uint32_t>(std::min(static_cast<std::uint64_t>(workRequested) + workRequestedInc, static_cast<std::uint64_t>(std::numeric_limits<gr::Size_t>::max())));
             }
-            workDone += static_cast<std::uint32_t>(workDoneInc);
+            workDone += static_cast<gr::Size_t>(workDoneInc);
             newCounter = (static_cast<uint64_t>(workRequested) << 32) | workDone;
         } while (!encodedCounter.compare_exchange_weak(oldCounter, newCounter));
     }
@@ -154,9 +154,9 @@ public:
     std::pair<std::size_t, std::size_t>
     getAndReset() {
         uint64_t oldCounter    = encodedCounter.exchange(0);
-        auto     workRequested = static_cast<std::uint32_t>(oldCounter >> 32);
-        auto     workDone      = static_cast<std::uint32_t>(oldCounter & 0xFFFFFFFF);
-        if (workRequested == std::numeric_limits<std::uint32_t>::max()) {
+        auto     workRequested = static_cast<gr::Size_t>(oldCounter >> 32);
+        auto     workDone      = static_cast<gr::Size_t>(oldCounter & 0xFFFFFFFF);
+        if (workRequested == std::numeric_limits<gr::Size_t>::max()) {
             return { std::numeric_limits<std::size_t>::max(), static_cast<std::size_t>(workDone) };
         }
         return { static_cast<std::size_t>(workRequested), static_cast<std::size_t>(workDone) };
@@ -165,8 +165,8 @@ public:
     std::pair<std::size_t, std::size_t>
     get() {
         uint64_t oldCounter    = std::atomic_load_explicit(&encodedCounter, std::memory_order_acquire);
-        auto     workRequested = static_cast<std::uint32_t>(oldCounter >> 32);
-        auto     workDone      = static_cast<std::uint32_t>(oldCounter & 0xFFFFFFFF);
+        auto     workRequested = static_cast<gr::Size_t>(oldCounter >> 32);
+        auto     workDone      = static_cast<gr::Size_t>(oldCounter & 0xFFFFFFFF);
         if (workRequested == std::numeric_limits<std::uint32_t>::max()) {
             return { std::numeric_limits<std::size_t>::max(), static_cast<std::size_t>(workDone) };
         }
@@ -190,6 +190,11 @@ struct Result {
 } // namespace work
 
 template<typename T>
+concept HasWork = requires(T t, std::size_t requested_work) {
+    { t.work(requested_work) } -> std::same_as<work::Result>;
+};
+
+template<typename T>
 concept BlockLike = requires(T t, std::size_t requested_work) {
     { t.unique_name } -> std::same_as<const std::string &>;
     { unwrap_if_wrapped_t<decltype(t.name)>{} } -> std::same_as<std::string>;
@@ -199,14 +204,11 @@ concept BlockLike = requires(T t, std::size_t requested_work) {
     { t.isBlocking() } noexcept -> std::same_as<bool>;
 
     { t.settings() } -> std::same_as<SettingsBase &>;
-    { t.work(requested_work) } -> std::same_as<work::Result>;
 
     // N.B. TODO discuss these requirements
     requires !std::is_copy_constructible_v<T>;
     requires !std::is_copy_assignable_v<T>;
-    // requires !std::is_move_constructible_v<T>;
-    // requires !std::is_move_assignable_v<T>;
-};
+} && HasWork<T>;
 
 template<typename Derived>
 concept HasProcessOneFunction = traits::block::can_processOne<Derived>;
@@ -219,6 +221,10 @@ concept HasProcessBulkFunction = traits::block::can_processBulk<Derived>;
 
 template<typename Derived>
 concept HasRequiredProcessFunction = (HasProcessBulkFunction<Derived> or HasProcessOneFunction<Derived>) and(HasProcessOneFunction<Derived> + HasProcessBulkFunction<Derived>) == 1;
+
+template<typename TBlock, typename TDecayedBlock = std::remove_cvref_t<TBlock>>
+inline void
+checkBlockContracts();
 
 /**
  * @brief The 'Block<Derived>' is a base class for blocks that perform specific signal processing operations. It stores
@@ -334,8 +340,8 @@ public:
     using ArgumentsTypeList          = typename gr::meta::typelist<Arguments...>;
     using block_template_parameters  = meta::typelist<Arguments...>;
     using Description                = typename block_template_parameters::template find_or_default<is_doc, EmptyDoc>;
-    using Resampling                 = ArgumentsTypeList::template find_or_default<is_resampling_ratio, ResamplingRatio<1UZ, 1UZ, true>>;
-    using StrideControl              = ArgumentsTypeList::template find_or_default<is_stride, Stride<0UZ, true>>;
+    using Resampling                 = ArgumentsTypeList::template find_or_default<is_resampling_ratio, ResamplingRatio<1UL, 1UL, true>>;
+    using StrideControl              = ArgumentsTypeList::template find_or_default<is_stride, Stride<0UL, true>>;
     constexpr static bool blockingIO = std::disjunction_v<std::is_same<BlockingIO<true>, Arguments>...> || std::disjunction_v<std::is_same<BlockingIO<false>, Arguments>...>;
 
     template<typename T>
@@ -362,10 +368,10 @@ public:
     constexpr static TagPropagationPolicy tag_policy = TagPropagationPolicy::TPP_ALL_TO_ALL;
 
     //
-    using RatioValue = std::conditional_t<Resampling::kIsConst, const std::uint64_t, std::uint64_t>;
-    A<RatioValue, "numerator", Doc<"Top of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UZ, std::uint64_t(-1)>>      numerator   = Resampling::kNumerator;
-    A<RatioValue, "denominator", Doc<"Bottom of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UZ, std::uint64_t(-1)>> denominator = Resampling::kDenominator;
-    using StrideValue = std::conditional_t<StrideControl::kIsConst, const std::uint64_t, std::uint64_t>;
+    using RatioValue = std::conditional_t<Resampling::kIsConst, const gr::Size_t, gr::Size_t>;
+    A<RatioValue, "numerator", Doc<"Top of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UL, std::numeric_limits<RatioValue>::max()>>      numerator   = Resampling::kNumerator;
+    A<RatioValue, "denominator", Doc<"Bottom of resampling ratio (<1: Decimate, >1: Interpolate, =1: No change)">, Limits<1UL, std::numeric_limits<RatioValue>::max()>> denominator = Resampling::kDenominator;
+    using StrideValue = std::conditional_t<StrideControl::kIsConst, const gr::Size_t, gr::Size_t>;
     A<StrideValue, "stride", Doc<"samples between data processing. <N for overlap, >N for skip, =0 for back-to-back.">> stride = StrideControl::kStride;
 
     //
@@ -501,10 +507,14 @@ protected:
     }
 
 public:
-    Block() noexcept : Block({}) {}
+    Block() noexcept(false) : Block({}) {} // N.B. throws in case of on contract violations
 
-    Block(std::initializer_list<std::pair<const std::string, pmtv::pmt>> init_parameter)
-        : _settings(std::make_unique<BasicSettings<Derived>>(*static_cast<Derived *>(this))) { // N.B. safe delegated use of this (i.e. not used during construction)
+    Block(std::initializer_list<std::pair<const std::string, pmtv::pmt>> init_parameter) noexcept(false) // N.B. throws in case of on contract violations
+        : _settings(std::make_unique<BasicSettings<Derived>>(*static_cast<Derived *>(this))) {           // N.B. safe delegated use of this (i.e. not used during construction)
+
+        // check Block<T> contracts
+        checkBlockContracts<decltype(*static_cast<Derived *>(this))>();
+
         if (init_parameter.size() != 0) {
             const auto failed = settings().set(init_parameter);
             if (!failed.empty()) {
@@ -709,7 +719,7 @@ public:
             static_assert(!kIsSourceBlock, "Decimation/interpolation is not available for source blocks. Remove 'ResamplingRatio<>' from the block definition.");
             static_assert(HasProcessBulkFunction<Derived>, "Blocks which allow decimation/interpolation must implement processBulk(...) method. Remove 'ResamplingRatio<>' from the block definition.");
         } else {
-            if (numerator != 1UZ || denominator != 1UZ) {
+            if (numerator != 1ULL || denominator != 1ULL) {
                 throw std::runtime_error(fmt::format("Block is not defined as `ResamplingRatio<>`, but numerator = {}, denominator = {}, they both must equal to 1.", numerator, denominator));
             }
         }
@@ -717,7 +727,7 @@ public:
         if constexpr (StrideControl::kEnabled) {
             static_assert(!kIsSourceBlock, "Stride is not available for source blocks. Remove 'Stride<>' from the block definition.");
         } else {
-            if (stride != 0UZ) {
+            if (stride != 0ULL) {
                 throw std::runtime_error(fmt::format("Block is not defined as `Stride<>`, but stride = {}, it must equal to 0.", stride));
             }
         }
@@ -867,7 +877,7 @@ public:
 
     constexpr work::Status
     doResampling() {
-        if (numerator != 1UZ || denominator != 1UZ) {
+        if (numerator != 1UL || denominator != 1UL) {
             // TODO: this ill-defined checks can be done only once after parameters were changed
             const double ratio          = static_cast<double>(numerator) / static_cast<double>(denominator);
             bool         is_ill_defined = (denominator > ports_status.in_max_samples)                                                            //
@@ -1201,7 +1211,7 @@ protected:
 
         std::size_t nSamplesToConsume = ports_status.in_samples; // default stride == 0
         if constexpr (StrideControl::kEnabled) {
-            if (stride != 0UZ) {
+            if (stride != 0UL) {
                 const bool firstTimeStride = stride_counter == 0;
                 if (firstTimeStride) {
                     // sample processing are done as usual, portsStatus.in_samples samples will be processed
@@ -1355,6 +1365,7 @@ public:
      * requested_work limit as an affine relation with the returned performed_work.
      * @return { requested_work, performed_work, status}
      */
+    template<typename = void>
     work::Result
     work(std::size_t requested_work = std::numeric_limits<std::size_t>::max()) noexcept {
         processScheduledMessages();
@@ -1452,6 +1463,144 @@ public:
         }
     }
 };
+
+namespace detail {
+template<typename List, std::size_t Index = 0, typename StringFunction>
+inline constexpr auto
+for_each_type_to_string(StringFunction func) -> std::string {
+    if constexpr (Index < List::size) {
+        using T = typename List::template at<Index>;
+        return std::string(Index > 0 ? ", " : "") + func(Index, T()) + for_each_type_to_string<List, Index + 1>(func);
+    } else {
+        return "";
+    }
+}
+
+template<typename T>
+inline constexpr std::string
+container_type_name() {
+    if constexpr (requires { typename T::allocator_type; }) {
+        return fmt::format("std::vector<{}>", gr::meta::type_name<typename T::value_type>());
+    } else if constexpr (requires { std::tuple_size<T>::value; }) {
+        return fmt::format("std::array<{}, {}>", gr::meta::type_name<typename T::value_type>(), std::tuple_size<T>::value);
+    } else if constexpr (requires(T a) {
+                             { std::real(a) } -> std::convertible_to<typename T::value_type>;
+                             { std::imag(a) } -> std::convertible_to<typename T::value_type>;
+                         }) {
+        return fmt::format("std::complex<{}>", gr::meta::type_name<typename T::value_type>());
+    } else { // fallback
+        return gr::meta::type_name<T>();
+    }
+}
+} // namespace detail
+
+template<typename TBlock, typename TDecayedBlock>
+inline void
+checkBlockContracts() {
+    // N.B. some checks could be evaluated during compile time but the expressed intent is to do this during runtime to allow
+    // for more verbose feedback on method signatures etc.
+    constexpr static auto processMembers = []<typename Func>(Func func) {
+        if constexpr (detail::HasBaseType<TDecayedBlock>) {
+            using BaseType = typename TDecayedBlock::base_t;
+            if constexpr (refl::is_reflectable<BaseType>()) {
+                refl::util::for_each(refl::reflect<BaseType>().members, func);
+            }
+        }
+        if constexpr (refl::is_reflectable<TDecayedBlock>()) {
+            refl::util::for_each(refl::reflect<TDecayedBlock>().members, func);
+        }
+    };
+
+    constexpr static auto shortTypeName = []<typename T>() {
+        if constexpr (std::is_same_v<T, gr::property_map>) {
+            return "gr::property_map";
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            return "std::string";
+        } else if constexpr (requires { typename T::value_type; }) {
+            return detail::container_type_name<T>();
+        } else {
+            return gr::meta::type_name<T>();
+        }
+    };
+
+    constexpr static auto checkSettingsTypes = [](auto member) {
+        using MemberType           = decltype(member)::value_type;
+        using RawType              = std::remove_cvref_t<MemberType>;
+        using Type                 = std::remove_cvref_t<unwrap_if_wrapped_t<RawType>>;
+        constexpr bool isAnnotated = !std::is_same_v<RawType, Type>;
+        // N.B. this function is compile-time ready but static_assert does not allow for configurable error messages
+        if constexpr (!gr::settings::isSupportedType<Type>() && !(traits::port::is_port_v<Type> || traits::port::is_port_collection_v<Type>) ) {
+            throw std::invalid_argument(fmt::format("block {} {}member '{}' has unsupported setting type '{}'", //
+                                                    gr::meta::type_name<TDecayedBlock>(), isAnnotated ? "" : "annotated ", get_display_name(member), shortTypeName.template operator()<Type>()));
+        }
+    };
+    processMembers(checkSettingsTypes);
+
+    using TDerived = typename TDecayedBlock::derived_t;
+    if constexpr (requires { &TDerived::work; }) {
+        [[deprecated("expert-use-only of raw 'gr::work::Result work(std::size_t requested_work)'")]] constexpr static auto warning = []() {
+            // N.B. implementing this is still allowed for workaround but should be discouraged as default API since this often leads to
+            // important variants not being implemented such as lifecycle::State handling, Tag forwarding, etc.
+            fmt::println(stderr, "DEPRECATION WARNING: block {} implements a raw 'gr::work::Result work(std::size_t requested_work)' ", shortTypeName.template operator()<TDecayedBlock>());
+        };
+        warning();
+        return;
+    }
+
+    using TInputTypes  = traits::block::stream_input_port_types<TDerived>;
+    using TOutputTypes = traits::block::stream_output_port_types<TDerived>;
+
+    if constexpr (((TInputTypes::size.value + TOutputTypes::size.value) > 0UZ) && !gr::HasRequiredProcessFunction<TDecayedBlock>) {
+        const auto b1 = (TOutputTypes::size.value == 1UZ) ? "" : "{ "; // optional opening brackets
+        const auto b2 = (TOutputTypes::size.value == 1UZ) ? "" : " }"; // optional closing brackets
+                                                                       // clang-format off
+        std::string signatureProcessOne = fmt::format("* Option Ia (pure function):\n\n{}\n\n* Option Ib (allows modifications: settings, Tags, state, errors,...):\n\n{}\n\n* Option Ic (explicit return types):\n\n{}\n\n", //
+fmt::format(R"(auto processOne({}) const noexcept {{
+    /* add code here */
+    return {}{}{};
+}})",
+    detail::for_each_type_to_string<TInputTypes>([]<typename T>(auto index, T) { return fmt::format("{} in{}", shortTypeName.template operator()<T>(), index); }),
+    b1, detail::for_each_type_to_string<TOutputTypes>([]<typename T>(auto, T) { return fmt::format("{}()", shortTypeName.template operator()<T>()); }), b2),
+fmt::format(R"(auto processOne({}) {{
+    /* add code here */
+    return {}{}{};
+}})",
+    detail::for_each_type_to_string<TInputTypes>([]<typename T>(auto index, T) { return fmt::format("{} in{}", shortTypeName.template operator()<T>(), index); }),
+    b1, detail::for_each_type_to_string<TOutputTypes>([]<typename T>(auto, T) { return fmt::format("{}()", shortTypeName.template operator()<T>()); }), b2),
+fmt::format(R"(std::tuple<{}> processOne({}) {{
+    /* add code here */
+    return {}{}{};
+}})",
+   detail::for_each_type_to_string<TOutputTypes>([]<typename T>(auto, T) { return fmt::format("{}", shortTypeName.template operator()<T>()); }), //
+   detail::for_each_type_to_string<TInputTypes>([]<typename T>(auto index, T) { return fmt::format("{} in{}", shortTypeName.template operator()<T>(), index); }), //
+   b1, detail::for_each_type_to_string<TOutputTypes>([]<typename T>(auto, T) { return fmt::format("{}()", shortTypeName.template operator()<T>()); }), b2)
+);
+
+std::string signaturesProcessBulk = fmt::format("* Option II:\n\n{}\n\nadvanced:* Option III:\n\n{}\n\n\n",
+fmt::format(R"(gr::work::Status processBulk({}{}{}) {{
+    /* add code here */
+    return gr::work::Status::OK;
+}})", //
+    detail::for_each_type_to_string<TInputTypes>([]<typename T>(auto index, T) { return fmt::format("std::span<const {}> in{}", shortTypeName.template operator()<T>(), index); }), //
+    (TInputTypes::size == 0UZ || TOutputTypes::size == 0UZ ? "" : ", "),                                                                             //
+    detail::for_each_type_to_string<TOutputTypes>([]<typename T>(auto index, T) { return fmt::format("std::span<{}> out{}", shortTypeName.template operator()<T>(), index); })),
+fmt::format(R"(gr::work::Status processBulk({}{}{}) {{
+    /* add code here */
+    return gr::work::Status::OK;
+}})", //
+    detail::for_each_type_to_string<TInputTypes>([]<typename T>(auto index, T) { return fmt::format("std::span<const {}> in{}", shortTypeName.template operator()<T>(), index); }), //
+    (TInputTypes::size == 0UZ || TOutputTypes::size == 0UZ ? "" : ", "),                                                                             //
+    detail::for_each_type_to_string<TOutputTypes>([]<typename T>(auto index, T) { return fmt::format("PublishableSpan auto out{}", shortTypeName.template operator()<T>(), index); })));
+        // clang-format on
+
+        bool has_port_collection = false;
+        TInputTypes::for_each([&has_port_collection]<typename T>(auto, T) { has_port_collection |= requires { typename T::value_type; }; });
+        TOutputTypes::for_each([&has_port_collection]<typename T>(auto, T) { has_port_collection |= requires { typename T::value_type; }; });
+        const std::string signatures = (has_port_collection ? "" : signatureProcessOne) + signaturesProcessBulk;
+        throw std::invalid_argument(fmt::format("block {} has neither a valid processOne(...) nor valid processBulk(...) method\nPossible valid signatures (copy-paste):\n\n{}",
+                                                shortTypeName.template operator()<TDecayedBlock>(), signatures));
+    }
+}
 
 template<typename Derived, typename... Arguments>
 inline std::atomic_size_t Block<Derived, Arguments...>::_unique_id_counter{ 0UZ };

--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -158,7 +158,7 @@ class double_mapped_memory_resource : public std::pmr::memory_resource {
 #endif
 
 #ifdef HAS_POSIX_MAP_INTERFACE
-    void  do_deallocate(void* p, std::size_t size, size_t alignment) override { //NOSONAR
+    void  do_deallocate(void* p, std::size_t size, std::size_t alignment) override { //NOSONAR
 
         if (munmap(p, size) == -1) {
             throw std::system_error(errno, std::system_category(), fmt::format("double_mapped_memory_resource::do_deallocate(void*, {}, {}) - munmap(..) failed", size, alignment));

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -1,14 +1,14 @@
 #ifndef GNURADIO_GRAPH_HPP
 #define GNURADIO_GRAPH_HPP
 
+#include <gnuradio-4.0/Block.hpp>
+#include <gnuradio-4.0/Buffer.hpp>
+#include <gnuradio-4.0/CircularBuffer.hpp>
 #include <gnuradio-4.0/meta/typelist.hpp>
-
-#include "Block.hpp"
-#include "Buffer.hpp"
-#include "CircularBuffer.hpp"
-#include "Port.hpp"
-#include "Sequence.hpp"
-#include "thread/thread_pool.hpp"
+#include <gnuradio-4.0/Port.hpp>
+#include <gnuradio-4.0/reflection.hpp>
+#include <gnuradio-4.0/Sequence.hpp>
+#include <gnuradio-4.0/thread/thread_pool.hpp>
 
 #include <algorithm>
 #include <complex>
@@ -1269,5 +1269,7 @@ this_source_location() {
 #endif // HAVE_SOURCE_LOCATION
 
 } // namespace gr
+
+REFL_TYPE(gr::Graph) REFL_END // minimal reflection declaration
 
 #endif // include guard

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -240,8 +240,8 @@ public:
             if (something_happened) { // something happened in this thread => increase progress and reset done count
                 do {
                     progress_local = _progress.load();
-                    progress_count = static_cast<std::uint32_t>((progress_local >> 32) & ((1ULL << 32) - 1));
-                    done           = static_cast<std::uint32_t>(progress_local & ((1ULL << 32) - 1));
+                    progress_count = static_cast<gr::Size_t>((progress_local >> 32) & ((1ULL << 32) - 1));
+                    done           = static_cast<gr::Size_t>(progress_local & ((1ULL << 32) - 1));
                     progress_new   = (progress_count + 1ULL) << 32;
                 } while (!_progress.compare_exchange_strong(progress_local, progress_new));
                 _progress.notify_all();
@@ -249,8 +249,8 @@ public:
                 uint32_t progress_count_old = progress_count;
                 do {
                     progress_local = _progress.load();
-                    progress_count = static_cast<std::uint32_t>((progress_local >> 32) & ((1ULL << 32) - 1));
-                    done           = static_cast<std::uint32_t>(progress_local & ((1ULL << 32) - 1));
+                    progress_count = static_cast<gr::Size_t>((progress_local >> 32) & ((1ULL << 32) - 1));
+                    done           = static_cast<gr::Size_t>(progress_local & ((1ULL << 32) - 1));
                     if (progress_count == progress_count_old) { // nothing happened => increase done count
                         progress_new = ((progress_count + 0ULL) << 32) + done + 1;
                     } else { // something happened in another thread => keep progress and done count and rerun this task without waiting

--- a/core/include/gnuradio-4.0/Settings.hpp
+++ b/core/include/gnuradio-4.0/Settings.hpp
@@ -20,6 +20,14 @@
 
 namespace gr {
 
+namespace settings {
+template<typename T>
+inline constexpr static bool
+isSupportedType() {
+    return std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || gr::meta::vector_type<T> || std::is_same_v<T, property_map>;
+}
+} // namespace settings
+
 namespace detail {
 template<class T>
 inline constexpr void
@@ -273,7 +281,7 @@ public:
                         auto iterate_over_member = [&](auto member) {
                             using RawType = std::remove_cvref_t<decltype(member(*_block))>;
                             using Type    = unwrap_if_wrapped_t<RawType>;
-                            if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && isSupportedType<Type>()) {
+                            if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
                                 if (default_tag == get_display_name(member)) {
                                     _auto_forward.emplace(get_display_name(member));
                                 }
@@ -363,7 +371,7 @@ public:
                 bool        is_set              = false;
                 auto        iterate_over_member = [&, this](auto member) {
                     using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && isSupportedType<Type>()) {
+                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
                             if (_auto_update.contains(key)) {
                                 _auto_update.erase(key);
@@ -428,7 +436,7 @@ public:
                 const auto &value               = localValue;
                 auto        iterate_over_member = [&](auto member) {
                     using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && isSupportedType<Type>()) {
+                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(value)) {
                             _staged.insert_or_assign(key, value);
                             SettingsBase::_changed.store(true);
@@ -518,7 +526,7 @@ public:
                 auto        apply_member_changes = [&key, &staged, &forward_parameters, &staged_value, this](auto member) {
                     using RawType = std::remove_cvref_t<decltype(member(*_block))>;
                     using Type    = unwrap_if_wrapped_t<RawType>;
-                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && isSupportedType<Type>()) {
+                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(staged_value)) {
                             if constexpr (is_annotated<RawType>()) {
                                 if (member(*_block).validate_and_set(std::get<Type>(staged_value))) {
@@ -563,7 +571,7 @@ public:
             // update active parameters
             auto update_active = [this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-                if constexpr (traits::port::is_not_any_port_or_collection<Type> && is_readable(member) && isSupportedType<Type>()) {
+                if constexpr (traits::port::is_not_any_port_or_collection<Type> && is_readable(member) && settings::isSupportedType<Type>()) {
                     _active.insert_or_assign(get_display_name(member), static_cast<Type>(member(*_block)));
                 }
             };
@@ -601,7 +609,7 @@ public:
             std::lock_guard lg(_lock);
             auto            iterate_over_member = [&, this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-                if constexpr (traits::port::is_not_any_port_or_collection<Type> && is_readable(member) && isSupportedType<Type>()) {
+                if constexpr (traits::port::is_not_any_port_or_collection<Type> && is_readable(member) && settings::isSupportedType<Type>()) {
                     _active.insert_or_assign(get_display_name(member), static_cast<Type>(member(*_block)));
                 }
             };
@@ -620,7 +628,7 @@ private:
             auto iterate_over_member = [&, this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
 
-                if constexpr (traits::port::is_not_any_port_or_collection<Type> && is_readable(member) && isSupportedType<Type>()) {
+                if constexpr (traits::port::is_not_any_port_or_collection<Type> && is_readable(member) && settings::isSupportedType<Type>()) {
                     oldSettings.insert_or_assign(get_display_name(member), pmtv::pmt(member(*_block)));
                 }
             };
@@ -629,12 +637,6 @@ private:
             }
             refl::util::for_each(refl::reflect<TBlock>().members, iterate_over_member);
         }
-    }
-
-    template<typename T>
-    inline constexpr static bool
-    isSupportedType() {
-        return std::is_arithmetic_v<T> || std::is_same_v<T, std::string> || gr::meta::vector_type<T> || std::is_same_v<T, property_map>;
     }
 
     template<typename T, typename Func>

--- a/core/include/gnuradio-4.0/Transactions.hpp
+++ b/core/include/gnuradio-4.0/Transactions.hpp
@@ -318,7 +318,7 @@ public:
                 auto        apply_member_changes = [&key, &staged, &forward_parameters, &staged_value, this](auto member) {
                     using RawType = std::remove_cvref_t<decltype(member(*_block))>;
                     using Type    = unwrap_if_wrapped_t<RawType>;
-                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && isSupportedType<Type>()) {
+                    if constexpr (traits::port::is_not_any_port_or_collection<Type> && !std::is_const_v<Type> && is_writable(member) && settings::isSupportedType<Type>()) {
                         if (std::string(get_display_name(member)) == key && std::holds_alternative<Type>(staged_value)) {
                             if constexpr (is_annotated<RawType>()) {
                                 if (member(*_block).validate_and_set(std::get<Type>(staged_value))) {
@@ -363,7 +363,7 @@ public:
             // update active parameters
             auto update_active = [this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
-                if constexpr (is_readable(member) && isSupportedType<Type>()) {
+                if constexpr (is_readable(member) && settings::isSupportedType<Type>()) {
                     _active.insert_or_assign(get_display_name(member), pmtv::pmt(member(*_block)));
                 }
             };
@@ -402,7 +402,7 @@ public:
             auto            iterate_over_member = [&, this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
 
-                if constexpr (is_readable(member) && isSupportedType<Type>()) {
+                if constexpr (is_readable(member) && settings::isSupportedType<Type>()) {
                     _active.insert_or_assign(get_display_name_const(member).str(), member(*_block));
                 }
             };
@@ -436,7 +436,7 @@ private:
             auto iterate_over_member = [&, this](auto member) {
                 using Type = unwrap_if_wrapped_t<std::remove_cvref_t<decltype(member(*_block))>>;
 
-                if constexpr (is_readable(member) && isSupportedType<Type>()) {
+                if constexpr (is_readable(member) && settings::isSupportedType<Type>()) {
                     oldSettings.insert_or_assign(get_display_name(member), pmtv::pmt(member(*_block)));
                 }
             };
@@ -445,12 +445,6 @@ private:
             }
             refl::util::for_each(refl::reflect<TBlock>().members, iterate_over_member);
         }
-    }
-
-    template<typename Type>
-    inline constexpr static bool
-    isSupportedType() {
-        return std::integral<Type> || std::floating_point<Type> || std::is_same_v<Type, std::string> || gr::meta::vector_type<Type> || std::is_same_v<Type, property_map>;
     }
 
     template<typename T, typename Func>

--- a/core/include/gnuradio-4.0/annotated.hpp
+++ b/core/include/gnuradio-4.0/annotated.hpp
@@ -81,13 +81,13 @@ struct BlockingIO {
  * @tparam denominator Bottom number in the input-to-output sample ratio.
  * @tparam isConst Specifies if the resampling ratio is constant or can be modified during run-time.
  */
-template<std::size_t numerator = 1LU, std::size_t denominator = 1LU, bool isConst = false>
+template<gr::Size_t numerator = 1U, gr::Size_t denominator = 1U, bool isConst = false>
 struct ResamplingRatio {
     static_assert(numerator > 0, "Numerator in ResamplingRatio must be >= 0");
-    static constexpr std::size_t kNumerator   = numerator;
-    static constexpr std::size_t kDenominator = denominator;
-    static constexpr bool        kIsConst     = isConst;
-    static constexpr bool        kEnabled     = !isConst || (kNumerator != 1LU) || (kDenominator != 1LU);
+    static constexpr gr::Size_t kNumerator   = numerator;
+    static constexpr gr::Size_t kDenominator = denominator;
+    static constexpr bool       kIsConst     = isConst;
+    static constexpr bool       kEnabled     = !isConst || (kNumerator != 1LU) || (kDenominator != 1LU);
 };
 
 template<typename T>
@@ -115,13 +115,13 @@ static_assert(!is_resampling_ratio<int>::value);
  * @tparam stride The number of samples between data processing events.
  * @tparam isConst Specifies if the stride is constant or can be modified during run-time.
  */
-template<std::size_t stride = 0LU, bool isConst = false>
+template<std::uint64_t stride = 0U, bool isConst = false>
 struct Stride {
-    static_assert(stride >= 0, "Stride must be >= 0");
+    static_assert(stride >= 0U, "Stride must be >= 0");
 
-    static constexpr std::size_t kStride  = stride;
-    static constexpr bool        kIsConst = isConst;
-    static constexpr bool        kEnabled = !isConst || (stride > 0);
+    static constexpr std::uint64_t kStride  = stride;
+    static constexpr bool          kIsConst = isConst;
+    static constexpr bool          kEnabled = !isConst || (stride > 0U);
 };
 
 template<typename T>
@@ -215,7 +215,7 @@ template<auto LowerLimit, decltype(LowerLimit) UpperLimit, auto Validator>
 struct is_limits<Limits<LowerLimit, UpperLimit, Validator>> : std::true_type {};
 
 template<typename T>
-concept Limit    = is_limits<T>::value;
+concept Limit = is_limits<T>::value;
 
 using EmptyLimit = Limits<0, 0>; // nomen-est-omen
 
@@ -236,8 +236,7 @@ struct Annotated {
 
     template<typename U>
         requires std::constructible_from<T, U> && (!std::same_as<std::remove_cvref_t<U>, Annotated>)
-    explicit(false)
-    Annotated(U &&input) noexcept(std::is_nothrow_constructible_v<T, U>) : value(std::forward<U>(input)) {}
+    explicit(false) Annotated(U &&input) noexcept(std::is_nothrow_constructible_v<T, U>) : value(std::forward<U>(input)) {}
 
     template<typename U>
         requires std::assignable_from<T &, U>

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -4,7 +4,6 @@
 
 #include <fmt/format.h>
 
-#include "gnuradio-4.0/basic/clock_source.hpp"
 #include <gnuradio-4.0/Block.hpp>
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
@@ -16,6 +15,168 @@ template<>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
 #endif
 
+template<typename T>
+struct BlockSignaturesNone : public gr::Block<BlockSignaturesNone<T>> {
+    gr::PortIn<T>  in{};
+    gr::PortOut<T> out{};
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE(BlockSignaturesNone, in, out);
+static_assert(!gr::HasRequiredProcessFunction<BlockSignaturesNone<float>>);
+
+template<typename T>
+struct BlockSignaturesVoid : public gr::Block<BlockSignaturesVoid<T>> {
+    T value;
+
+    void
+    processOne() {}
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE(BlockSignaturesVoid, value);
+static_assert(gr::HasRequiredProcessFunction<BlockSignaturesVoid<float>>);
+
+template<typename T>
+struct BlockSignaturesVoid2 : public gr::Block<BlockSignaturesVoid2<T>> {
+    T value;
+
+    gr::work::Status
+    processBulk() {
+        return gr::work::Status::OK;
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE(BlockSignaturesVoid2, value);
+static_assert(gr::HasRequiredProcessFunction<BlockSignaturesVoid2<float>>);
+
+template<typename T>
+struct BlockSignaturesProcessOne : public gr::Block<BlockSignaturesProcessOne<T>> {
+    gr::PortIn<T>  in;
+    gr::PortOut<T> out;
+
+    T
+    processOne(T) {
+        return T();
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE(BlockSignaturesProcessOne, in, out);
+static_assert(gr::HasRequiredProcessFunction<BlockSignaturesProcessOne<float>>);
+static_assert(gr::HasProcessOneFunction<BlockSignaturesProcessOne<float>>);
+static_assert(!gr::HasConstProcessOneFunction<BlockSignaturesProcessOne<float>>);
+static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessOne<float>>);
+
+template<typename T>
+struct BlockSignaturesProcessOneConst : public gr::Block<BlockSignaturesProcessOneConst<T>> {
+    gr::PortIn<T>  in;
+    gr::PortOut<T> out;
+
+    T
+    processOne(T) const {
+        return T();
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE(BlockSignaturesProcessOneConst, in, out);
+static_assert(gr::HasRequiredProcessFunction<BlockSignaturesProcessOneConst<float>>);
+static_assert(gr::HasProcessOneFunction<BlockSignaturesProcessOneConst<float>>);
+static_assert(gr::HasConstProcessOneFunction<BlockSignaturesProcessOneConst<float>>);
+static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessOneConst<float>>);
+
+enum class ProcessBulkVariant { VARIANT_SPAN, VARIANT_PUBLISHABLE_SPAN, VARIANT_PUBLISHABLE_SPAN2, VARIANT_CONSUMABLE_SPAN, VARIANT_CONSUMABLE_SPAN2 };
+
+template<typename T, ProcessBulkVariant processVariant>
+struct BlockSignaturesProcessBulkSpan : public gr::Block<BlockSignaturesProcessBulkSpan<T, processVariant>> {
+    gr::PortIn<T>  in{};
+    gr::PortOut<T> out{};
+
+    gr::work::Status
+    processBulk(std::span<const T>, std::span<T>)
+        requires(processVariant == ProcessBulkVariant::VARIANT_SPAN)
+    {
+        // do some bulk-type processing
+        return gr::work::Status::OK;
+    }
+
+    gr::work::Status
+    processBulk(std::span<const T>, gr::PublishableSpan auto &)
+        requires(processVariant == ProcessBulkVariant::VARIANT_PUBLISHABLE_SPAN)
+    {
+        // do some bulk-type processing
+        return gr::work::Status::OK;
+    }
+
+    gr::work::Status
+    processBulk(std::span<const T>, gr::PublishableSpan auto)
+        requires(processVariant == ProcessBulkVariant::VARIANT_PUBLISHABLE_SPAN2)
+    {
+        // do some bulk-type processing
+        return gr::work::Status::OK;
+    }
+
+    gr::work::Status
+    processBulk(gr::ConsumableSpan auto, std::span<T>)
+        requires(processVariant == ProcessBulkVariant::VARIANT_CONSUMABLE_SPAN)
+    {
+        // do some bulk-type processing
+        return gr::work::Status::OK;
+    }
+
+    gr::work::Status
+    processBulk(gr::ConsumableSpan auto &, std::span<T>)
+        requires(processVariant == ProcessBulkVariant::VARIANT_CONSUMABLE_SPAN2)
+    {
+        // do some bulk-type processing
+        return gr::work::Status::OK;
+    }
+};
+
+ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T, ProcessBulkVariant processVariant), (BlockSignaturesProcessBulkSpan<T, processVariant>), in, out);
+using enum ProcessBulkVariant;
+static_assert(gr::HasRequiredProcessFunction<BlockSignaturesProcessBulkSpan<float, VARIANT_SPAN>>);
+static_assert(!gr::HasProcessOneFunction<BlockSignaturesProcessBulkSpan<float, VARIANT_SPAN>>);
+static_assert(!gr::HasConstProcessOneFunction<BlockSignaturesProcessBulkSpan<float, VARIANT_SPAN>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, VARIANT_SPAN>>);
+static_assert(gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, VARIANT_PUBLISHABLE_SPAN>>);
+static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, VARIANT_PUBLISHABLE_SPAN2>>); // TODO: fix the signature is required to work
+static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, VARIANT_CONSUMABLE_SPAN>>);   // TODO: fix the signature is required to work
+static_assert(!gr::HasProcessBulkFunction<BlockSignaturesProcessBulkSpan<float, VARIANT_CONSUMABLE_SPAN2>>);  // TODO: fix the signature is required to work
+
+struct InvalidSettingBlock : gr::Block<InvalidSettingBlock> {
+    std::tuple<int> tuple; // this type is not supported and should cause the checkBlockContracts<T>() to throw
+};
+
+ENABLE_REFLECTION(InvalidSettingBlock, tuple);
+
+struct MissingProcessSignature1 : gr::Block<MissingProcessSignature1> {
+    gr::PortIn<int>    in;
+    gr::PortOut<int>   out0;
+    gr::PortOut<float> out1;
+};
+
+ENABLE_REFLECTION(MissingProcessSignature1, in, out0, out1);
+
+struct MissingProcessSignature2 : gr::Block<MissingProcessSignature2> {
+    gr::PortIn<int>    in0;
+    gr::PortIn<float>  in1;
+    gr::PortOut<int>   out0;
+    gr::PortOut<float> out1;
+};
+
+ENABLE_REFLECTION(MissingProcessSignature2, in0, in1, out0, out1);
+
+struct MissingProcessSignature3 : gr::Block<MissingProcessSignature3> {
+    std::vector<gr::PortOut<float>>   outA;
+    std::array<gr::PortOut<float>, 2> outB;
+
+    template<typename PublishableSpan2>
+    gr::work::Status
+    processBulk(std::span<std::vector<float>> &, PublishableSpan2 &) { // TODO: needs proper explicit signature
+        return gr::work::Status::OK;
+    }
+};
+
+ENABLE_REFLECTION(MissingProcessSignature3, outA, outB);
+
 struct ProcessStatus {
     std::size_t      n_inputs{ 0 };
     std::size_t      n_outputs{ 0 };
@@ -26,9 +187,9 @@ struct ProcessStatus {
 };
 
 struct IntDecTestData {
-    std::uint64_t n_samples{};
-    std::uint64_t numerator{};
-    std::uint64_t denominator{};
+    gr::Size_t  n_samples{};
+    gr::Size_t  numerator{};
+    gr::Size_t  denominator{};
     int         out_port_min{ -1 }; // -1 for not used
     int         out_port_max{ -1 }; // -1 for not used
     std::size_t exp_in{};
@@ -43,10 +204,10 @@ struct IntDecTestData {
 };
 
 struct StrideTestData {
-    std::size_t      n_samples{};
-    std::size_t      numerator{ 1 };
-    std::size_t      denominator{ 1 };
-    std::size_t      stride{};
+    gr::Size_t       n_samples{};
+    gr::Size_t       numerator{ 1U };
+    gr::Size_t       denominator{ 1U };
+    gr::Size_t       stride{};
     int              in_port_min{ -1 }; // -1 for not used
     int              in_port_max{ -1 }; // -1 for not used
     std::size_t      exp_in{};
@@ -107,13 +268,71 @@ struct AsyncBlock : gr::Block<AsyncBlock<T>> {
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (IntDecBlock<T>), in, out);
 ENABLE_REFLECTION_FOR_TEMPLATE_FULL((typename T), (AsyncBlock<T>), in, out);
 
+const boost::ut::suite _block_signature = [] {
+    using namespace boost::ut;
+
+    "failure"_test = [] {
+        expect(throws([] { throw 0; })) << "throws any exception";
+
+        try {
+            std::ignore = InvalidSettingBlock();
+            expect(false) << "unsupported std::tuple setting not caught";
+        } catch (const std::exception &e) {
+            fmt::println("correctly thrown exception:\n{}", e.what());
+            expect(true);
+        } catch (...) {
+            expect(false);
+        }
+
+        try {
+            std::ignore = BlockSignaturesNone<float>();
+            expect(false) << "missing process function not caught";
+        } catch (const std::exception &e) {
+            fmt::println("correctly thrown exception:\n{}", e.what());
+            expect(true);
+        } catch (...) {
+            expect(false);
+        }
+
+        try {
+            std::ignore = MissingProcessSignature1();
+            expect(false) << "missing process function not caught";
+        } catch (const std::exception &e) {
+            fmt::println("correctly thrown exception:\n{}", e.what());
+            expect(true);
+        } catch (...) {
+            expect(false);
+        }
+
+        try {
+            std::ignore = MissingProcessSignature2();
+            expect(false) << "missing process function not caught";
+        } catch (const std::exception &e) {
+            fmt::println("correctly thrown exception:\n{}", e.what());
+            expect(true);
+        } catch (...) {
+            expect(false);
+        }
+
+        try {
+            std::ignore = MissingProcessSignature3();
+            expect(false) << "missing process function not caught";
+        } catch (const std::exception &e) {
+            fmt::println("correctly thrown exception:\n{}", e.what());
+            expect(true);
+        } catch (...) {
+            expect(false);
+        }
+    };
+};
+
 void
 interpolation_decimation_test(const IntDecTestData &data, std::shared_ptr<gr::thread_pool::BasicThreadPool> thread_pool) {
     using namespace boost::ut;
     using scheduler = gr::scheduler::Simple<>;
 
     gr::Graph flow;
-    auto     &source = flow.emplaceBlock<gr::testing::TagSource<int>>({{"n_samples_max", data.n_samples }, {"mark_tag", false} });
+    auto     &source = flow.emplaceBlock<gr::testing::TagSource<int>>({ { "n_samples_max", data.n_samples }, { "mark_tag", false } });
 
     auto &int_dec_block = flow.emplaceBlock<IntDecBlock<int>>({ { "numerator", data.numerator }, { "denominator", data.denominator } });
     if (data.out_port_max >= 0) int_dec_block.out.max_samples = static_cast<size_t>(data.out_port_max);
@@ -136,9 +355,9 @@ stride_test(const StrideTestData &data, std::shared_ptr<gr::thread_pool::BasicTh
     const bool write_to_vector{ data.exp_in_vector.size() != 0 };
 
     gr::Graph flow;
-    auto     &source = flow.emplaceBlock<gr::testing::TagSource<int>>({{"n_samples_max", data.n_samples }, {"mark_tag", false} });
+    auto     &source = flow.emplaceBlock<gr::testing::TagSource<int>>({ { "n_samples_max", data.n_samples }, { "mark_tag", false } });
 
-    auto &int_dec_block           = flow.emplaceBlock<IntDecBlock<int>>({{"numerator", data.numerator}, {"denominator", data.denominator}, {"stride", data.stride }});
+    auto &int_dec_block           = flow.emplaceBlock<IntDecBlock<int>>({ { "numerator", data.numerator }, { "denominator", data.denominator }, { "stride", data.stride } });
     int_dec_block.write_to_vector = write_to_vector;
     if (data.in_port_max >= 0) int_dec_block.in.max_samples = static_cast<size_t>(data.in_port_max);
     if (data.in_port_min >= 0) int_dec_block.in.min_samples = static_cast<size_t>(data.in_port_min);
@@ -289,15 +508,15 @@ const boost::ut::suite _stride_tests = [] {
     };
     // clang-format on
 
-    "Async ports tests"_test = [&thread_pool] {
+    "Async ports tests"_test = [] {
         using namespace gr;
         using namespace gr::testing;
-        constexpr std::uint64_t n_samples   = 1000;
-        constexpr float         sample_rate = 1000.f;
-        Graph                   testGraph;
-        auto                   &tagSrc     = testGraph.emplaceBlock<TagSource<float>>({ { "sample_rate", sample_rate }, { "n_samples_max", n_samples }, { "name", "TagSource" } });
-        auto                   &asyncBlock = testGraph.emplaceBlock<AsyncBlock<float>>({ { "name", "AsyncBlock" } });
-        auto                   &sink       = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagSink" }, { "verbose_console", true } });
+        constexpr gr::Size_t n_samples   = 1000;
+        constexpr float      sample_rate = 1000.f;
+        Graph                testGraph;
+        auto                &tagSrc     = testGraph.emplaceBlock<TagSource<float>>({ { "sample_rate", sample_rate }, { "n_samples_max", n_samples }, { "name", "TagSource" } });
+        auto                &asyncBlock = testGraph.emplaceBlock<AsyncBlock<float>>({ { "name", "AsyncBlock" } });
+        auto                &sink       = testGraph.emplaceBlock<TagSink<float, ProcessFunction::USE_PROCESS_ONE>>({ { "name", "TagSink" }, { "verbose_console", true } });
 
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(tagSrc).to<"in">(asyncBlock)));
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(asyncBlock).to<"in">(sink)));
@@ -305,7 +524,7 @@ const boost::ut::suite _stride_tests = [] {
         scheduler::Simple sched{ std::move(testGraph) };
         sched.runAndWait();
 
-        expect(eq(n_samples, static_cast<std::uint32_t>(sink.n_samples_produced))) << "Number of samples does not match";
+        expect(eq(n_samples, static_cast<gr::Size_t>(sink.n_samples_produced))) << "Number of samples does not match";
     };
 };
 

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -85,7 +85,7 @@ const boost::ut::suite TagPropagation = [] {
     using namespace gr::testing;
 
     auto runTest = []<auto srcType>(bool verbose = true) {
-        std::uint64_t      n_samples = 1024;
+        gr::Size_t         n_samples = 1024;
         Graph              testGraph;
         const property_map srcParameter = { { "n_samples_max", n_samples }, { "name", "TagSource" }, { "signal_name", "tagStream" }, { "verbose_console", true && verbose } };
         auto              &src          = testGraph.emplaceBlock<TagSource<float, srcType>>(srcParameter);

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -13,6 +13,12 @@ template<typename T>
 struct ArraySource : public gr::Block<ArraySource<T>> {
     std::array<gr::PortOut<T>, 2> outA;
     std::array<gr::PortOut<T>, 2> outB;
+
+    template<typename PublishableSpan1, typename PublishableSpan2>
+    gr::work::Status
+    processBulk(PublishableSpan1&, PublishableSpan2& ) { //TODO: needs proper explicit signature
+        return gr::work::Status::OK;
+    }
 };
 
 ENABLE_REFLECTION_FOR_TEMPLATE(ArraySource, outA, outB);
@@ -27,6 +33,12 @@ struct ArraySink : public gr::Block<ArraySink<T>> {
     gr::Annotated<std::vector<std::string>, "String vector setting"> string_vector;
     gr::Annotated<std::vector<double>, "Double vector setting">      double_vector;
     gr::Annotated<std::vector<int16_t>, "int16_t vector setting">    int16_vector;
+
+    template<typename ConsumableSpan1, typename ConsumableSpan2>
+    gr::work::Status
+    processBulk(ConsumableSpan1&, ConsumableSpan2&) { //TODO: needs proper explicit signature
+        return gr::work::Status::OK;
+    }
 };
 
 ENABLE_REFLECTION_FOR_TEMPLATE(ArraySink, inA, inB, bool_setting, string_setting, bool_vector, string_vector, double_vector, int16_vector);

--- a/core/test/qa_port_array.cpp
+++ b/core/test/qa_port_array.cpp
@@ -12,15 +12,15 @@ using namespace std::string_literals;
 
 template<typename T>
 struct RepeatedSource : public gr::Block<RepeatedSource<T>> {
-    std::uint32_t  identifier = 0;
-    std::uint32_t  remaining_events_count;
+    gr::Size_t     identifier = 0;
+    gr::Size_t     remaining_events_count;
     std::vector<T> values;
     std::size_t    values_next = 0;
 
     gr::PortOut<T> out;
 
     void
-    settingsChanged(const gr::property_map & /*old_settings*/, const gr::property_map &new_settings) noexcept {}
+    settingsChanged(const gr::property_map & /*old_settings*/, const gr::property_map & /*new_settings*/) noexcept {}
 
     gr::work::Result
     work(std::size_t requested_work) {
@@ -60,7 +60,7 @@ ENABLE_REFLECTION_FOR_TEMPLATE(RepeatedSource, identifier, remaining_events_coun
 
 template<typename T>
 struct ValidatorSink : public gr::Block<ValidatorSink<T>> {
-    std::uint32_t identifier = 0;
+    gr::Size_t    identifier = 0;
     gr::PortIn<T> in;
 
     std::vector<T>                 expected_values;
@@ -147,7 +147,7 @@ execute_selector_test() {
 
     using TestNode = ArrayPortsNode<double>;
 
-    const std::uint32_t value_count = 5;
+    const gr::Size_t value_count = 5;
 
     gr::Graph                               graph;
     std::array<RepeatedSource<double> *, 4> sources;

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -2,6 +2,7 @@
 #define GNURADIO_GRAPH_UTILS_HPP
 
 #include <complex>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -27,7 +28,11 @@
 #define DISABLE_SIMD 0
 #endif
 
-namespace gr::meta {
+namespace gr {
+
+using Size_t = std::uint32_t; // strict type definition in view of cross-platform/cross-compiler/cross-network portability similar to 'std::size_t' (N.B. which is not portable)
+
+namespace meta {
 
 struct null_type {};
 
@@ -536,6 +541,7 @@ is_const_member_function(T) noexcept {
     return std::is_member_function_pointer_v<T> && detail::is_const_member_function<T>::value;
 }
 
-} // namespace gr::meta
+} // namespace meta
+} // namespace gr
 
 #endif // include guard


### PR DESCRIPTION
This PR addresses issue https://github.com/fair-acc/graph-prototype/issues/229

While there are compile-time concepts that check the correct signature, these checks are being implemented/tested during runtime and thrown during `Block<T>` construction to provide some more user-palatable warning messages and first-order remedies.

1. clean-up qa_Block
  * replace custom CountSource with TagSource
  * replace direct block settings access with Block(initialiser list)
2. added checkBlockContracts<TBlock>() checker

Block<T>() default constructor checks, throws, and provides first-order remedies for:
* unsupported settings type
* missing or wrong process[One, Bulk] signatures
* added deprecation warning if raw `work(...)` is being implemented
* added unit-tests to specifically test the settings and signatures

Examples of new warning/`std::exception`s that are thrown in case the contracts are violated:
```text
block InvalidSettingBlock annotated member 'tuple' has unsupported setting type 'std::tuple<int>'
```
```text
block MissingProcessSignature1 has neither a valid processOne(...) nor valid processBulk(...) method
Possible valid signatures (copy-paste):

* Option Ia (pure function):

auto processOne(int in0) const noexcept {
    /* add code here */
    return { int(), float() };
}

* Option Ib (allows modifications: settings, Tags, state, errors,...):

auto processOne(int in0) {
    /* add code here */
    return { int(), float() };
}

* Option Ic (explicit return types):

std::tuple<int, float> processOne(int in0) {
    /* add code here */
    return { int(), float() };
}

* Option II:

gr::work::Status processBulk(std::span<const int> in0, std::span<int> out0, std::span<float> out1) {
    /* add code here */
    return gr::work::Status::OK;
}

advanced:* Option III:

gr::work::Status processBulk(std::span<const int> in0, PublishableSpan auto outint, PublishableSpan auto outfloat) {
    /* add code here */
    return gr::work::Status::OK;
}

```
```text
DEPRECATION WARNING: block good::fixed_source<double> implements a raw 'gr::work::Result work(std::size_t requested_work)' 
```

The examples are supposed to be copy-pasted by the user... hope this helps with the most common errors, but this can be certainly improved upon.

N.B. the process[One, Bulk] API refactoring w.r.t. the ConsumableSpan and PublishableSpan concepts and implementations is of out scope for the commit.
