### PR TITLE
Fix race condition in multi-producer CircularBuffer

### DIFF
--- a/core/include/gnuradio-4.0/ClaimStrategy.hpp
+++ b/core/include/gnuradio-4.0/ClaimStrategy.hpp
@@ -24,12 +24,12 @@ struct NoCapacityException : public std::runtime_error {
 
 template<typename T>
 concept ClaimStrategy = requires(T /*const*/ t, const std::vector<std::shared_ptr<Sequence>> &dependents, const std::size_t requiredCapacity,
-        const std::make_signed_t<std::size_t> cursorValue, const std::make_signed_t<std::size_t> sequence, const std::make_signed_t<std::size_t> availableSequence, const std::size_t n_slots_to_claim) {
+        const std::make_signed_t<std::size_t> cursorValue, const std::make_signed_t<std::size_t> sequence, const std::make_signed_t<std::size_t> offset, const std::make_signed_t<std::size_t> availableSequence, const std::size_t n_slots_to_claim) {
     { t.hasAvailableCapacity(dependents, requiredCapacity, cursorValue) } -> std::same_as<bool>;
     { t.next(dependents, n_slots_to_claim) } -> std::same_as<std::make_signed_t<std::size_t>>;
     { t.tryNext(dependents, n_slots_to_claim) } -> std::same_as<std::make_signed_t<std::size_t>>;
     { t.getRemainingCapacity(dependents) } -> std::same_as<std::make_signed_t<std::size_t>>;
-    { t.publish(sequence) } -> std::same_as<void>;
+    { t.publish(offset, n_slots_to_claim) } -> std::same_as<void>;
     { t.isAvailable(sequence) } -> std::same_as<bool>;
     { t.getHighestPublishedSequence(sequence, availableSequence) } -> std::same_as<std::make_signed_t<std::size_t>>;
 };
@@ -108,7 +108,8 @@ public:
         return static_cast<signed_index_type>(_size) - (produced - consumed);
     }
 
-    void publish(signed_index_type sequence) {
+    void publish(signed_index_type offset, std::size_t n_slots_to_claim) {
+        const auto sequence = offset + static_cast<signed_index_type>(n_slots_to_claim);
         _cursor.setValue(sequence);
         _nextValue = sequence;
         if constexpr (hasSignalAllWhenBlocking<WAIT_STRATEGY>) {
@@ -125,8 +126,9 @@ static_assert(ClaimStrategy<SingleThreadedStrategy<1024, NoWaitStrategy>>);
 template <std::size_t Size>
 struct MultiThreadedStrategySizeMembers
 {
+    static_assert(std::has_single_bit(Size));
     static constexpr std::int32_t _size = Size;
-    static constexpr std::int32_t _indexShift = std::bit_width(Size);
+    static constexpr std::int32_t _indexShift = std::bit_width(Size - 1);
 };
 
 template <>
@@ -135,13 +137,15 @@ struct MultiThreadedStrategySizeMembers<std::dynamic_extent> {
     const std::int32_t _indexShift;
 
     #ifdef __clang__
-    explicit MultiThreadedStrategySizeMembers(std::size_t size) : _size(static_cast<std::int32_t>(size)), _indexShift(static_cast<std::int32_t>(std::bit_width(size))) {} //NOSONAR
+    explicit MultiThreadedStrategySizeMembers(std::size_t size) : _size(static_cast<std::int32_t>(size)), _indexShift(static_cast<std::int32_t>(std::bit_width(size - 1))) {} //NOSONAR
     #else
     #pragma GCC diagnostic push // std::bit_width seems to be compiler and platform specific
     #ifndef __clang__
     #pragma GCC diagnostic ignored "-Wuseless-cast"
     #endif
-    explicit MultiThreadedStrategySizeMembers(std::size_t size) : _size(static_cast<std::int32_t>(size)), _indexShift(static_cast<std::int32_t>(std::bit_width(size))) {} //NOSONAR
+    explicit MultiThreadedStrategySizeMembers(std::size_t size) : _size(static_cast<std::int32_t>(size)), _indexShift(static_cast<std::int32_t>(std::bit_width(size - 1))) {
+        assert(std::has_single_bit(size));
+    } //NOSONAR
     #pragma GCC diagnostic pop
     #endif
 };
@@ -160,7 +164,11 @@ class alignas(hardware_constructive_interference_size) MultiThreadedStrategy
 : private MultiThreadedStrategySizeMembers<SIZE> {
     Sequence &_cursor;
     WAIT_STRATEGY &_waitStrategy;
+#if (__cpp_lib_atomic_ref >= 201806L)
     std::vector<std::int32_t> _availableBuffer; // tracks the state of each ringbuffer slot
+#else // clang's libc++ does not yet support std::atomic_ref
+    std::unique_ptr<std::atomic<std::int32_t>[]> _availableBuffer; // tracks the state of each ringbuffer slot
+#endif
     std::shared_ptr<Sequence> _gatingSequenceCache = std::make_shared<Sequence>();
     using MultiThreadedStrategySizeMembers<SIZE>::_size;
     using MultiThreadedStrategySizeMembers<SIZE>::_indexShift;
@@ -171,14 +179,26 @@ public:
 
     explicit
     MultiThreadedStrategy(Sequence &cursor, WAIT_STRATEGY &waitStrategy) requires (SIZE != std::dynamic_extent)
-    : _cursor(cursor), _waitStrategy(waitStrategy), _availableBuffer(SIZE, -1) {
+    : _cursor(cursor), _waitStrategy(waitStrategy) {
+#if (__cpp_lib_atomic_ref >= 201806L)
+        _availableBuffer = std::vector<std::int32_t>(SIZE, -1);
+#else // clang's libc++ does not yet support std::atomic_ref
+        _availableBuffer = std::make_unique<std::atomic<std::int32_t>[]>(SIZE);
+        std::fill(_availableBuffer.get(), _availableBuffer.get() + SIZE, -1);
+#endif
     }
 
     explicit
     MultiThreadedStrategy(Sequence &cursor, WAIT_STRATEGY &waitStrategy, std::size_t buffer_size)
     requires (SIZE == std::dynamic_extent)
     : MultiThreadedStrategySizeMembers<SIZE>(buffer_size),
-      _cursor(cursor), _waitStrategy(waitStrategy), _availableBuffer(buffer_size, -1) {
+      _cursor(cursor), _waitStrategy(waitStrategy) {
+#if (__cpp_lib_atomic_ref >= 201806L)
+        _availableBuffer = std::vector<std::int32_t>(buffer_size, -1);
+#else // clang's libc++ does not yet support std::atomic_ref
+        _availableBuffer = std::make_unique<std::atomic<std::int32_t>[]>(buffer_size);
+        std::fill(_availableBuffer.get(), _availableBuffer.get() + buffer_size, -1);
+#endif
     }
 
     MultiThreadedStrategy(const MultiThreadedStrategy &)  = delete;
@@ -258,8 +278,10 @@ public:
         return static_cast<signed_index_type>(_size) - (produced - consumed);
     }
 
-    void publish(signed_index_type sequence) {
-        setAvailable(sequence);
+    void publish(signed_index_type offset, std::size_t n_slots_to_claim) {
+        for (std::size_t i = 0; i < n_slots_to_claim; i++) {
+            setAvailable(offset + static_cast<signed_index_type>(i) + 1);
+        }
         if constexpr (hasSignalAllWhenBlocking<WAIT_STRATEGY>) {
             _waitStrategy.signalAllWhenBlocking();
         }
@@ -268,8 +290,11 @@ public:
     [[nodiscard]] forceinline bool isAvailable(signed_index_type sequence) const noexcept {
         const auto index = calculateIndex(sequence);
         const auto flag  = calculateAvailabilityFlag(sequence);
-
-        return _availableBuffer[static_cast<std::size_t>(index)] == flag;
+#if (__cpp_lib_atomic_ref >= 201806L)
+        return std::atomic_ref{_availableBuffer[index]} == flag;
+#else // clang's libc++ does not yet support std::atomic_ref
+        return _availableBuffer[index] == flag;
+#endif
     }
 
     [[nodiscard]] forceinline signed_index_type getHighestPublishedSequence(const signed_index_type lowerBound, const signed_index_type availableSequence) const noexcept {
@@ -284,8 +309,14 @@ public:
 
 private:
     void                      setAvailable(signed_index_type sequence) noexcept { setAvailableBufferValue(calculateIndex(sequence), calculateAvailabilityFlag(sequence)); }
-    forceinline void          setAvailableBufferValue(std::size_t index, std::int32_t flag) noexcept { _availableBuffer[index] = flag; }
-    [[nodiscard]] forceinline std::int32_t calculateAvailabilityFlag(const signed_index_type sequence) const noexcept { return static_cast<std::int32_t>(static_cast<signed_index_type>(sequence) >> _indexShift); }
+    forceinline void          setAvailableBufferValue(std::size_t index, std::int32_t flag) noexcept {
+#if (__cpp_lib_atomic_ref >= 201806L)
+        std::atomic_ref{_availableBuffer[index]} = flag;
+#else // clang's libc++ does not yet support std::atomic_ref
+        _availableBuffer[index] = flag;
+#endif
+    }
+    [[nodiscard]] forceinline std::int32_t calculateAvailabilityFlag(const signed_index_type sequence) const noexcept { return static_cast<std::int32_t>(sequence >> _indexShift); }
     [[nodiscard]] forceinline std::size_t calculateIndex(const signed_index_type sequence) const noexcept { return static_cast<std::size_t>(static_cast<std::int32_t>(sequence) & (_size - 1)); }
 };
 

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+#include <array>
 #include <complex>
 #include <numeric>
 #include <ranges>
@@ -173,6 +175,24 @@ const boost::ut::suite DoubleMappedAllocatorTests = [] {
     };
 };
 #endif
+
+template<typename Writer, std::size_t N>
+void
+varyingSizedChunksWriter(Writer &writer) {
+    std::size_t pos    = 0;
+    std::size_t iWrite = 0;
+    while (pos < N) {
+        constexpr auto kChunkSizes = std::array{ 1UZ, 2UZ, 3UZ, 5UZ, 7UZ, 42UZ };
+        const auto     chunkSize   = std::min(kChunkSizes[iWrite % kChunkSizes.size()], N - pos);
+        auto           out         = writer.reserve_output_range(chunkSize);
+        for (auto i = 0UZ; i < out.size(); i++) {
+            out[i] = { { 0, static_cast<int>(pos + i) } };
+        }
+        out.publish(out.size());
+        pos += chunkSize;
+        ++iWrite;
+    }
+}
 
 const boost::ut::suite WaitStrategiesTests = [] {
     using namespace boost::ut;
@@ -376,6 +396,100 @@ const boost::ut::suite CircularBufferTests = [] {
 #endif
                   Allocator()
               };
+
+    "MultiProducerStdMapSingleWriter"_test = [] {
+        // Using std::map exposed some race conditions in the multi-producer buffer implementation
+        // that did not surface with trivial types. (two readers for good measure, issues occurred also
+        // with single reader)
+        gr::CircularBuffer<std::map<int, int>, std::dynamic_extent, gr::ProducerType::Multi> buffer(1024);
+
+        gr::BufferWriter auto writer  = buffer.new_writer();
+        gr::BufferReader auto reader1 = buffer.new_reader();
+        gr::BufferReader auto reader2 = buffer.new_reader();
+
+        constexpr auto kWrites      = 200000UZ;
+        auto           writerThread = std::thread(&varyingSizedChunksWriter<decltype(writer), kWrites>, std::ref(writer));
+
+        auto readerFnc = [](auto reader) {
+            std::size_t i = 0;
+            while (i < kWrites) {
+                auto       in        = reader.get().get();
+                for (auto j = 0UZ; j < in.size(); j++) {
+                    auto vIt = in[j].find(0);
+                    expect(vIt != in[j].end());
+                    if (vIt != in[j].end()) {
+                        expect(eq(vIt->second, static_cast<int>(i)));
+                    }
+                    i++;
+                }
+                if (!in.empty()) {
+                    expect(reader.get().consume(in.size()));
+                }
+            }
+        };
+
+        auto reader1Thread = std::thread(readerFnc, std::ref(reader1));
+        auto reader2Thread = std::thread(readerFnc, std::ref(reader2));
+        writerThread.join();
+        reader1Thread.join();
+        reader2Thread.join();
+    };
+
+    "MultiProducerStdMapMultipleWriters"_test = [] {
+        // now actually use multiple writers, and ensure we see all expected values, in a valid order.
+        constexpr auto kNWriters = 5UZ;
+        constexpr auto kWrites   = 20000UZ;
+
+        gr::CircularBuffer<std::map<int, int>, std::dynamic_extent, gr::ProducerType::Multi> buffer(1024);
+        using WriterType              = decltype(buffer.new_writer());
+        gr::BufferReader auto reader1 = buffer.new_reader();
+        gr::BufferReader auto reader2 = buffer.new_reader();
+
+        std::vector<WriterType> writers;
+        for (std::size_t i = 0; i < kNWriters; i++) {
+            writers.push_back(buffer.new_writer());
+        }
+
+        std::array<std::thread, kNWriters> writerThreads;
+        for (std::size_t i = 0; i < kNWriters; i++) {
+            writerThreads[i] = std::thread(&varyingSizedChunksWriter<decltype(writers[i]), kWrites>, std::ref(writers[i]));
+        }
+
+        auto readerFnc = [](auto reader) {
+            std::array<int, kNWriters> next;
+            std::ranges::fill(next, 0);
+            std::size_t read = 0;
+            while (read < kWrites * kNWriters) {
+                auto in = reader.get().get();
+                for (const auto &map : in) {
+                    auto vIt = map.find(0);
+                    expect(vIt != map.end());
+                    if (vIt == map.end()) {
+                        continue;
+                    }
+                    const auto value = vIt->second;
+                    expect(ge(value, 0));
+                    expect(le(value, static_cast<int>(kWrites)));
+                    const auto nextIt = std::ranges::find(next, value);
+                    expect(nextIt != next.end());
+                    if (nextIt == next.end()) continue;
+                    *nextIt = value + 1;
+                }
+                if (!in.empty()) {
+                    read += in.size();
+                    expect(reader.get().consume(in.size()));
+                }
+            }
+        };
+
+        auto reader1Thread = std::thread(readerFnc, std::ref(reader1));
+        auto reader2Thread = std::thread(readerFnc, std::ref(reader2));
+        for (std::size_t i = 0; i < kNWriters; i++) {
+            writerThreads[i].join();
+        }
+        reader1Thread.join();
+        reader2Thread.join();
+    };
 };
 
 const boost::ut::suite CircularBufferExceptionTests = [] {

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -178,7 +178,7 @@ const boost::ut::suite DoubleMappedAllocatorTests = [] {
 
 template<typename Writer, std::size_t N>
 void
-varyingSizedChunksWriter(Writer &writer) {
+writeVaryingChunkSizes(Writer &writer) {
     std::size_t pos    = 0;
     std::size_t iWrite = 0;
     while (pos < N) {
@@ -408,7 +408,7 @@ const boost::ut::suite CircularBufferTests = [] {
         gr::BufferReader auto reader2 = buffer.new_reader();
 
         constexpr auto kWrites      = 200000UZ;
-        auto           writerThread = std::thread(&varyingSizedChunksWriter<decltype(writer), kWrites>, std::ref(writer));
+        auto           writerThread = std::thread(&writeVaryingChunkSizes<decltype(writer), kWrites>, std::ref(writer));
 
         auto readerFnc = [](auto reader) {
             std::size_t i = 0;
@@ -452,7 +452,7 @@ const boost::ut::suite CircularBufferTests = [] {
 
         std::array<std::thread, kNWriters> writerThreads;
         for (std::size_t i = 0; i < kNWriters; i++) {
-            writerThreads[i] = std::thread(&varyingSizedChunksWriter<decltype(writers[i]), kWrites>, std::ref(writers[i]));
+            writerThreads[i] = std::thread(&writeVaryingChunkSizes<decltype(writers[i]), kWrites>, std::ref(writers[i]));
         }
 
         auto readerFnc = [](auto reader) {


### PR DESCRIPTION
Fix race condition in multi-producer CircularBuffer

In MultithreadedStrategy, the _cursor is pushed by the writers on reserve, i.e. points to the next's write's start position. Do not use by the readers to determine the number slots available for reading, but track that as a separate readCursor.
    
To update the readCursor safely when publishing a range, let a writer wait for any previous ranges to be published first. This trades correctness and simpler implementation for some performance.
    
These issues somehow surface with T=std::map (gr::Message), so add tests for that.