### PR TITLE
Frank/messages scheduler control

### DIFF
--- a/blocks/http/test/qa_HttpBlock.cpp
+++ b/blocks/http/test/qa_HttpBlock.cpp
@@ -5,21 +5,22 @@
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 
-#include <gnuradio-4.0/testing/FunctionBlocks.hpp>
 #include <gnuradio-4.0/Block.hpp>
 #include <gnuradio-4.0/Buffer.hpp>
 #include <gnuradio-4.0/Graph.hpp>
 #include <gnuradio-4.0/reflection.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/testing/FunctionBlocks.hpp>
 
 #include <gnuradio-4.0/http/HttpBlock.hpp>
 
 template<typename T>
 class FixedSource : public gr::Block<FixedSource<T>> {
     using super_t = gr::Block<FixedSource<T>>;
+
 public:
     gr::PortOut<T> out;
-    T value       = 1;
+    T              value = 1;
 
     [[nodiscard]] constexpr auto
     processOne() noexcept {
@@ -51,7 +52,8 @@ public:
         }
     }
 
-    void reset() {
+    void
+    reset() {
         value = {};
     }
 };
@@ -90,7 +92,7 @@ const boost::ut::suite HttpBlocktests = [] {
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
 
         auto sched    = gr::scheduler::Simple<>(std::move(graph));
-        sink.stopFunc = [&]() { sched.stop(); };
+        sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         // make a request
         source.trigger();
         httpBlock.processScheduledMessages();
@@ -121,7 +123,7 @@ const boost::ut::suite HttpBlocktests = [] {
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
 
         auto sched    = gr::scheduler::Simple<>(std::move(graph));
-        sink.stopFunc = [&]() { sched.stop(); };
+        sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         httpBlock.trigger();
         sched.runAndWait();
         expect(eq(std::get<int>(sink.value.at("status")), 404));
@@ -150,7 +152,7 @@ const boost::ut::suite HttpBlocktests = [] {
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
 
         auto sched    = gr::scheduler::Simple<>(std::move(graph));
-        sink.stopFunc = [&]() { sched.stop(); };
+        sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         httpBlock.trigger();
         sched.runAndWait();
         expect(eq(std::get<std::string>(sink.value.at("raw-data")), "OK"sv));
@@ -192,7 +194,7 @@ const boost::ut::suite HttpBlocktests = [] {
         expect(eq(ConnectionResult::SUCCESS, graph.connect<"out">(httpBlock).template to<"in">(sink)));
 
         auto sched    = gr::scheduler::Simple<>(std::move(graph));
-        sink.stopFunc = [&]() { sched.stop(); };
+        sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         sched.runAndWait();
         expect(eq(std::get<std::string>(sink.value.at("raw-data")), "event"sv));
 

--- a/core/benchmarks/bm-nosonar_node_api.cpp
+++ b/core/benchmarks/bm-nosonar_node_api.cpp
@@ -672,8 +672,8 @@ inline const boost::ut::suite _simd_tests = [] {
         "runtime   src->(mult(2.0)->mult(0.5)->add(-1))^10->sink (SIMD)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
-            sched.runAndWait();
-            sched.reset();
+            expect(sched.runAndWait().has_value());
+            expect(sched.changeStateTo(gr::lifecycle::INITIALISED).has_value());
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };

--- a/core/include/gnuradio-4.0/Message.hpp
+++ b/core/include/gnuradio-4.0/Message.hpp
@@ -23,24 +23,9 @@ const std::string Error           = "ERROR_KIND";
 const std::string Graph_update    = "GRAPH_UPDATE_KIND";
 const std::string UpdateSettings  = "UPDATE_SETTINGS_KIND";
 const std::string SettingsChanged = "SETTINGS_CHANGED_KIND";
-const std::string SchedulerUpdate = "SCHEDULER_UPDATE_KIND";
+const std::string SchedulerStateUpdate        = "SCHEDULER_UPDATE_KIND";
+const std::string SchedulerStateChangeRequest = "SCHEDULER_COMMAND_KIND";
 } // namespace message::kind
-
-namespace message::scheduler::command {
-const std::string Start  = "gr::scheduler::command::START";
-const std::string Stop   = "gr::scheduler::command::STOP";
-const std::string Pause  = "gr::scheduler::command::PAUSE";
-const std::string Resume = "gr::scheduler::command::RESUME";
-} // namespace message::scheduler::command
-
-namespace message::scheduler::update {
-const std::string Started  = "gr::scheduler::update::STARTED";
-const std::string Stopping = "gr::scheduler::update::STOPPING";
-const std::string Stopped  = "gr::scheduler::update::STOPPED";
-const std::string Pausing  = "gr::scheduler::update::PAUSING";
-const std::string Paused   = "gr::scheduler::update::PAUSED";
-const std::string Error    = "gr::scheduler::update::ERROR";
-} // namespace message::scheduler::update
 
 using Message = property_map;
 

--- a/core/include/gnuradio-4.0/Message.hpp
+++ b/core/include/gnuradio-4.0/Message.hpp
@@ -39,6 +39,7 @@ const std::string Stopping = "gr::scheduler::update::STOPPING";
 const std::string Stopped  = "gr::scheduler::update::STOPPED";
 const std::string Pausing  = "gr::scheduler::update::PAUSING";
 const std::string Paused   = "gr::scheduler::update::PAUSED";
+const std::string Error    = "gr::scheduler::update::ERROR";
 } // namespace message::scheduler::update
 
 using Message = property_map;

--- a/core/include/gnuradio-4.0/Message.hpp
+++ b/core/include/gnuradio-4.0/Message.hpp
@@ -23,7 +23,23 @@ const std::string Error           = "ERROR_KIND";
 const std::string Graph_update    = "GRAPH_UPDATE_KIND";
 const std::string UpdateSettings  = "UPDATE_SETTINGS_KIND";
 const std::string SettingsChanged = "SETTINGS_CHANGED_KIND";
+const std::string SchedulerUpdate = "SCHEDULER_UPDATE_KIND";
 } // namespace message::kind
+
+namespace message::scheduler::command {
+const std::string Start  = "gr::scheduler::command::START";
+const std::string Stop   = "gr::scheduler::command::STOP";
+const std::string Pause  = "gr::scheduler::command::PAUSE";
+const std::string Resume = "gr::scheduler::command::RESUME";
+} // namespace message::scheduler::command
+
+namespace message::scheduler::update {
+const std::string Started  = "gr::scheduler::update::STARTED";
+const std::string Stopping = "gr::scheduler::update::STOPPING";
+const std::string Stopped  = "gr::scheduler::update::STOPPED";
+const std::string Pausing  = "gr::scheduler::update::PAUSING";
+const std::string Paused   = "gr::scheduler::update::PAUSED";
+} // namespace message::scheduler::update
 
 using Message = property_map;
 

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -9,6 +9,7 @@
 #include <queue>
 
 #include <gnuradio-4.0/Graph.hpp>
+#include <gnuradio-4.0/LifeCycle.hpp>
 #include <gnuradio-4.0/Message.hpp>
 #include <gnuradio-4.0/Port.hpp>
 #include <gnuradio-4.0/Profiler.hpp>
@@ -23,146 +24,72 @@ enum ExecutionPolicy { singleThreaded, multiThreaded };
 
 constexpr std::chrono::milliseconds kMessagePollInterval{ 10 };
 
-template<typename Derived, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
-class SchedulerBase {
-    lifecycle::State _state = lifecycle::State::IDLE;
+template<typename Derived, ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
+class SchedulerBase : public lifecycle::StateMachine<Derived> {
+    friend class lifecycle::StateMachine<Derived>;
 
 protected:
-    gr::Graph                           _graph;
-    TProfiler                           _profiler;
-    decltype(_profiler.forThisThread()) _profiler_handler;
-    std::shared_ptr<BasicThreadPool>    _pool;
-    std::atomic_size_t                  _running_jobs;
-    std::atomic_bool                    _stop_requested;
+    gr::Graph                              _graph;
+    TProfiler                              _profiler;
+    decltype(_profiler.forThisThread())    _profiler_handler;
+    std::shared_ptr<BasicThreadPool>       _pool;
+    std::atomic_size_t                     _running_jobs;
+    std::atomic_bool                       _stop_requested;
+    std::vector<std::vector<BlockModel *>> _job_lists;
 
     MsgPortOutNamed<"__ForChildren"> _toChildMessagePort;
     MsgPortInNamed<"__FromChildren"> _fromChildMessagePort;
 
     std::string unique_name = gr::meta::type_name<Derived>(); // TODO: to be replaced if scheduler derives from Block<T>
 
-    [[nodiscard]] constexpr lifecycle::State
-    state() const {
-        return _state;
-    }
-
-    void
-    emitMessage(auto &port, Message message) { // TODO: to be replaced if scheduler derives from Block<T>
-        message[gr::message::key::Sender] = unique_name;
-        port.streamWriter().publish([&](auto &out) { out[0] = std::move(message); }, 1);
-    }
-
-    void
-    emitError(auto &port, const lifecycle::ErrorType &error) {
-        using namespace gr::message;
-        emitMessage(port, { { key::Kind, kind::Error }, { key::ErrorInfo, error.message }, { key::Location, error.srcLoc() } });
-    }
-
 public:
     MsgPortInNamed<"__Builtin">  msgIn;
     MsgPortOutNamed<"__Builtin"> msgOut;
+
+    [[nodiscard]] static constexpr auto
+    executionPolicy() {
+        return execution;
+    }
 
     explicit SchedulerBase(gr::Graph &&graph, std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("simple-scheduler-pool", thread_pool::CPU_BOUND),
                            const profiling::Options &profiling_options = {})
         : _graph(std::move(graph)), _profiler{ profiling_options }, _profiler_handler{ _profiler.forThisThread() }, _pool(std::move(thread_pool)) {}
 
-    ~SchedulerBase() { stop(); }
+    ~SchedulerBase() { std::ignore = this->changeStateTo(lifecycle::State::REQUESTED_STOP); }
 
-    bool
-    canInit() {
-        return _state == lifecycle::State::IDLE;
-    }
-
-    bool
-    canStart() {
-        return _state == lifecycle::State::INITIALISED;
-    }
-
-    bool
-    canStop() {
-        return _state == lifecycle::State::RUNNING || _state == lifecycle::State::REQUESTED_PAUSE || _state == lifecycle::State::PAUSED;
-    }
-
-    bool
-    canPause() {
-        return _state == lifecycle::State::RUNNING;
-    }
-
-    bool
-    canResume() {
-        return _state == lifecycle::State::PAUSED;
-    }
-
-    bool
-    canReset() {
-        return _state == lifecycle::State::STOPPED || _state == lifecycle::State::ERROR;
+    [[nodiscard]] bool
+    isProcessing() const
+        requires(executionPolicy() == multiThreaded)
+    {
+        return _running_jobs.load() > 0;
     }
 
     void
-    stop() {
-        if (!canStop()) {
-            return;
+    stateChanged(lifecycle::State newState) {
+        const auto stateStr = [](lifecycle::State s) {
+            using enum lifecycle::State;
+            using namespace message::scheduler::update;
+            switch (s) {
+            case RUNNING: return Started;
+            case REQUESTED_PAUSE: return Pausing;
+            case PAUSED: return Paused;
+            case REQUESTED_STOP: return Stopping;
+            case STOPPED: return Stopped;
+            case ERROR: return Error;
+            default: return std::string{};
+            }
+        }(newState);
+
+        if (!stateStr.empty()) {
+            emitMessage(msgOut, { { kind::SchedulerUpdate, stateStr } });
         }
-        requestStop();
-        waitJobsDone();
-        _graph.forEachBlock([this](auto &block) {
-            if (auto e = block.changeState(lifecycle::State::REQUESTED_STOP); !e) {
-                auto                       &port  = msgOut;
-                const lifecycle::ErrorType &error = e.error();
-                emitMessage(port, { { key::Kind, kind::Error }, { key::ErrorInfo, error.message }, { key::Location, error.srcLoc() } });
-            }
-            if (!block.isBlocking()) { // N.B. no other thread/constraint to consider before shutting down
-                if (auto e = block.changeState(lifecycle::State::STOPPED); !e) {
-                    auto                       &port  = msgOut;
-                    const lifecycle::ErrorType &error = e.error();
-                    emitMessage(port, { { key::Kind, kind::Error }, { key::ErrorInfo, error.message }, { key::Location, error.srcLoc() } });
-                }
-            }
-        });
-        changeStateTo(lifecycle::State::STOPPED);
-    }
-
-    void
-    pause() {
-        if (!canPause()) {
-            return;
-        }
-        requestPause();
-        waitJobsDone();
-        _graph.forEachBlock([this](auto &block) {
-            if (auto e = block.changeState(lifecycle::State::REQUESTED_PAUSE); !e) {
-                auto                       &port  = msgOut;
-                const lifecycle::ErrorType &error = e.error();
-                this->emitMessage(port, { { key::Kind, kind::Error }, { key::ErrorInfo, error.message }, { key::Location, error.srcLoc() } });
-            }
-            if (!block.isBlocking()) { // N.B. no other thread/constraint to consider before shutting down
-                if (auto e = block.changeState(lifecycle::State::PAUSED); !e) {
-                    using namespace gr::message;
-                    emitError(msgOut, e.error());
-                }
-            }
-        });
-        changeStateTo(lifecycle::State::PAUSED);
-    }
-
-    void
-    requestStop() {
-        _stop_requested = true;
-        changeStateTo(lifecycle::State::REQUESTED_STOP);
-    }
-
-    void
-    requestPause() {
-        _stop_requested = true;
-        changeStateTo(lifecycle::State::REQUESTED_PAUSE);
     }
 
     void
     connectBlockMessagePorts() {
         _graph.forEachBlock([this](auto &block) {
             if (ConnectionResult::SUCCESS != _toChildMessagePort.connect(*block.msgIn)) {
-                this->emitMessage(msgOut, { { key::Kind, kind::Error },
-                                            { key::ErrorInfo, fmt::format("Failed to connect scheduler input message port to child '{}'", block.uniqueName()) },
-                                            { key::Location, fmt::format("{}", std::source_location::current()) } });
+                emitError(msgOut, lifecycle::ErrorType(fmt::format("Failed to connect scheduler input message port to child '{}'", block.uniqueName()), std::source_location::current()));
             }
 
             auto buffer = _fromChildMessagePort.buffer();
@@ -176,17 +103,19 @@ public:
         if (const auto available = msgInReader.available(); available > 0) {
             const auto &input = msgInReader.get(available);
             for (const auto &msg : input) {
-                const auto kind = std::get<std::string>(msg.at(gr::message::key::Kind));
-                if (kind == gr::message::scheduler::command::Start) {
-                    self().start();
+                const auto                                kind = std::get<std::string>(msg.at(key::Kind));
+                std::expected<void, lifecycle::ErrorType> e;
+                if (kind == gr::message::scheduler::command::Start || kind == gr::message::scheduler::command::Resume) {
+                    e = this->changeStateTo(lifecycle::State::RUNNING);
                 } else if (kind == gr::message::scheduler::command::Stop) {
-                    self().stop();
+                    e = this->changeStateTo(lifecycle::State::REQUESTED_STOP);
                 } else if (kind == gr::message::scheduler::command::Pause) {
-                    self().pause();
-                } else if (kind == gr::message::scheduler::command::Resume) {
-                    self().resume();
+                    e = this->changeStateTo(lifecycle::State::REQUESTED_PAUSE);
                 } else {
                     _toChildMessagePort.streamWriter().publish([&](auto &output) { output[0] = msg; });
+                }
+                if (!e) {
+                    emitError(msgOut, e.error());
                 }
             }
 
@@ -211,33 +140,145 @@ public:
         }
     }
 
-    void
-    init() {
-        [[maybe_unused]] const auto pe = _profiler_handler.startCompleteEvent("scheduler_base.init");
-        if (!canInit()) {
-            return;
-        }
-        const auto result = _graph.performConnections();
-
-        connectBlockMessagePorts();
-
-        if (result) {
-            changeStateTo(lifecycle::State::INITIALISED);
-        } else {
-            changeStateTo(lifecycle::State::ERROR);
-        }
-    }
-
-    auto &
+    [[nodiscard]] constexpr auto &
     graph() {
         return _graph;
     }
 
+    std::expected<void, std::string>
+    runAndWait() {
+        [[maybe_unused]] const auto pe = this->_profiler_handler.startCompleteEvent("scheduler_base.runAndWait");
+        if (this->state() == lifecycle::State::IDLE) {
+            if (auto e = this->changeStateTo(lifecycle::State::INITIALISED); !e) {
+                emitError(msgOut, e.error());
+                return std::unexpected(e.error().message);
+            }
+        }
+        if (auto e = this->changeStateTo(lifecycle::State::RUNNING); !e) {
+            emitError(msgOut, e.error());
+            return std::unexpected(e.error().message);
+        }
+
+        if constexpr (executionPolicy() == ExecutionPolicy::multiThreaded) {
+            waitDone();
+
+            if (this->state() == lifecycle::State::RUNNING) {
+                if (auto e = this->changeStateTo(lifecycle::State::REQUESTED_STOP); !e) {
+                    emitError(msgOut, e.error());
+                    return std::unexpected(e.error().message);
+                }
+            }
+        }
+        return {};
+    }
+
+    void
+    waitDone() {
+        [[maybe_unused]] const auto pe = _profiler_handler.startCompleteEvent("scheduler_base.waitDone");
+        for (auto running = _running_jobs.load(); this->state() == lifecycle::REQUESTED_PAUSE || this->state() == lifecycle::PAUSED || running > 0ul; running = _running_jobs.load()) {
+            std::this_thread::sleep_for(kMessagePollInterval);
+            processScheduledMessages();
+        }
+        processScheduledMessages();
+    }
+
+    [[nodiscard]] const std::vector<std::vector<BlockModel *>> &
+    jobs() const {
+        return _job_lists;
+    }
+
+protected:
+    void
+    emitMessage(auto &port, Message message) { // TODO: to be replaced if scheduler derives from Block<T>
+        message[key::Sender] = unique_name;
+        port.streamWriter().publish([&](auto &out) { out[0] = std::move(message); }, 1);
+    }
+
+    void
+    emitError(auto &port, const lifecycle::ErrorType &error) {
+        emitMessage(port, { { key::Kind, kind::Error }, { key::ErrorInfo, error.message }, { key::Location, error.srcLoc() } });
+    }
+
+    void
+    setBlocksState(lifecycle::State state) {
+        _graph.forEachBlock([state, this](auto &block) {
+            if (auto e = block.changeState(state); !e) {
+                emitError(msgOut, e.error());
+            }
+        });
+    }
+
+    template<typename block_type>
+    work::Result
+    workOnce(const std::span<block_type> &blocks) {
+        constexpr std::size_t requestedWorkAllBlocks = std::numeric_limits<std::size_t>::max();
+        std::size_t           performedWorkAllBlocks = 0UZ;
+        bool                  something_happened     = false;
+        for (auto &currentBlock : blocks) {
+            currentBlock->processScheduledMessages();
+            const auto [requested_work, performed_work, status] = currentBlock->work(requestedWorkAllBlocks);
+            performedWorkAllBlocks += performed_work;
+            if (status == work::Status::ERROR) {
+                return { requested_work, performed_work, work::Status::ERROR };
+            } else if (status != work::Status::DONE) {
+                something_happened = true;
+            }
+        }
+
+        return { requestedWorkAllBlocks, performedWorkAllBlocks, something_happened ? work::Status::OK : work::Status::DONE };
+    }
+
+    void
+    init() {
+        [[maybe_unused]] const auto pe     = _profiler_handler.startCompleteEvent("scheduler_base.init");
+        const auto                  result = _graph.performConnections();
+        if (!result) {
+            emitError(msgOut, lifecycle::ErrorType("Failed to connect blocks in graph", std::source_location::current()));
+        }
+        connectBlockMessagePorts();
+    }
+
+private:
+    void
+    stop() {
+        _stop_requested = true;
+        waitJobsDone();
+        _graph.forEachBlock([this](auto &block) {
+            if (auto e = block.changeState(lifecycle::State::REQUESTED_STOP); !e) {
+                emitError(msgOut, e.error());
+            }
+            if (!block.isBlocking()) { // N.B. no other thread/constraint to consider before shutting down
+                if (auto e = block.changeState(lifecycle::State::STOPPED); !e) {
+                    emitError(msgOut, e.error());
+                }
+            }
+        });
+        if (auto e = this->changeStateTo(lifecycle::State::STOPPED); !e) {
+            emitError(msgOut, e.error());
+        }
+    }
+
+    void
+    pause() {
+        _stop_requested = true;
+        waitJobsDone();
+        _graph.forEachBlock([this](auto &block) {
+            if (auto e = block.changeState(lifecycle::State::REQUESTED_PAUSE); !e) {
+                emitError(msgOut, e.error());
+            }
+            if (!block.isBlocking()) { // N.B. no other thread/constraint to consider before shutting down
+                if (auto e = block.changeState(lifecycle::State::PAUSED); !e) {
+                    emitError(msgOut, e.error());
+                }
+            }
+        });
+        if (auto e = this->changeStateTo(lifecycle::State::PAUSED); !e) {
+            emitError(msgOut, e.error());
+        }
+    }
+
     void
     reset() {
-        if (!canReset()) {
-            return;
-        }
         setBlocksState(lifecycle::INITIALISED);
 
         // since it is not possible to set up the graph connections a second time, this method leaves the graph in the initialized state with clear buffers.
@@ -245,25 +286,35 @@ public:
         // std::for_each(_graph.edges().begin(), _graph.edges().end(), [](auto &edge) {
         //
         // });
-        changeStateTo(lifecycle::State::INITIALISED);
     }
 
     void
-    runAndWait() {
-        [[maybe_unused]] const auto pe = this->_profiler_handler.startCompleteEvent("scheduler_base.runAndWait");
-        self().start();
-        waitDone();
-        stop();
-    }
-
-    void
-    waitDone() {
-        [[maybe_unused]] const auto pe = _profiler_handler.startCompleteEvent("scheduler_base.waitDone");
-        for (auto running = _running_jobs.load(); _state == lifecycle::REQUESTED_PAUSE || _state == lifecycle::PAUSED || running > 0ul; running = _running_jobs.load()) {
-            std::this_thread::sleep_for(kMessagePollInterval);
-            processScheduledMessages();
+    resume() {
+        _stop_requested = false;
+        setBlocksState(lifecycle::RUNNING);
+        if (executionPolicy() == ExecutionPolicy::multiThreaded) {
+            // TODO review _job_lists usage
+            this->runOnPool(_job_lists, [this](auto &job) { return this->workOnce(job); });
         }
-        processScheduledMessages();
+    }
+
+    void
+    start() {
+        // TODO merge with resume?
+        _stop_requested = false;
+        setBlocksState(lifecycle::RUNNING);
+        if constexpr (executionPolicy() == singleThreaded) {
+            self().runSingleThreaded();
+        } else {
+            runOnPool(_job_lists, [this](auto &job) { return this->workOnce(job); });
+        }
+    }
+
+    void
+    waitJobsDone() {
+        for (auto running = _running_jobs.load(); running > 0ul; running = _running_jobs.load()) {
+            _running_jobs.wait(running);
+        }
     }
 
     void
@@ -290,50 +341,6 @@ public:
         _running_jobs.notify_all();
     }
 
-protected:
-    void
-    changeStateTo(lifecycle::State state) {
-        if (_state == state) {
-            return;
-        }
-
-        _state = state;
-
-        const auto stateStr = [](lifecycle::State s) {
-            using enum lifecycle::State;
-            using namespace message::scheduler::update;
-            switch (s) {
-            case RUNNING: return Started;
-            case REQUESTED_PAUSE: return Pausing;
-            case PAUSED: return Paused;
-            case REQUESTED_STOP: return Stopping;
-            case STOPPED: return Stopped;
-            default: return std::string{};
-            }
-        }(_state);
-
-        if (!stateStr.empty()) {
-            emitMessage(msgOut, { { gr::message::kind::SchedulerUpdate, stateStr } });
-        }
-    }
-
-    void
-    setBlocksState(lifecycle::State state) {
-        _graph.forEachBlock([state, this](auto &block) {
-            if (auto e = block.changeState(state); !e) {
-                emitError(msgOut, e.error());
-            }
-        });
-    }
-
-private:
-    void
-    waitJobsDone() {
-        for (auto running = _running_jobs.load(); running > 0ul; running = _running_jobs.load()) {
-            _running_jobs.wait(running);
-        }
-    }
-
     [[nodiscard]] constexpr auto &
     self() noexcept {
         return *static_cast<Derived *>(this);
@@ -349,37 +356,24 @@ private:
  * Trivial loop based scheduler, which iterates over all blocks in definition order in the graph until no node did any processing
  */
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
-class Simple : public SchedulerBase<Simple<execution, TProfiler>, TProfiler> {
+class Simple : public SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler> {
+    friend class lifecycle::StateMachine<Simple<execution, TProfiler>>;
+    friend class SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler>;
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
-    using base_t = SchedulerBase<Simple<execution, TProfiler>, TProfiler>;
-    std::vector<std::vector<BlockModel *>> _job_lists{};
+    using base_t = SchedulerBase<Simple<execution, TProfiler>, execution, TProfiler>;
 
 public:
-    static constexpr ExecutionPolicy
-    executionPolicy() {
-        return execution;
-    }
-
     explicit Simple(gr::Graph &&graph, std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("simple-scheduler-pool", thread_pool::CPU_BOUND),
                     const profiling::Options &profiling_options = {})
         : base_t(std::move(graph), thread_pool, profiling_options) {}
 
-    bool
-    isProcessing() const
-        requires(executionPolicy() == multiThreaded)
-    {
-        return this->_running_jobs.load() > 0;
-    }
-
+private:
     void
     init() {
-        if (!this->canInit()) {
-            return;
-        }
         base_t::init();
         [[maybe_unused]] const auto pe = this->_profiler_handler.startCompleteEvent("scheduler_simple.init");
         // generate job list
-        if constexpr (executionPolicy() == ExecutionPolicy::multiThreaded) {
+        if constexpr (base_t::executionPolicy() == ExecutionPolicy::multiThreaded) {
             const auto n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), this->_graph.blocks().size());
             this->_job_lists.reserve(n_batches);
             for (std::size_t i = 0; i < n_batches; i++) {
@@ -393,71 +387,30 @@ public:
         }
     }
 
-    template<typename block_type>
-    work::Result
-    workOnce(const std::span<block_type> &blocks) {
-        constexpr std::size_t requestedWorkAllBlocks = std::numeric_limits<std::size_t>::max();
-        std::size_t           performedWorkAllBlocks = 0UZ;
-        bool                  something_happened     = false;
-        for (auto &currentBlock : blocks) {
-            currentBlock->processScheduledMessages();
-            const auto [requested_work, performed_work, status] = currentBlock->work(requestedWorkAllBlocks);
-            performedWorkAllBlocks += performed_work;
-            if (status == work::Status::ERROR) {
-                return { requested_work, performed_work, work::Status::ERROR };
-            } else if (status != work::Status::DONE) {
-                something_happened = true;
-            }
-        }
-
-        return { requestedWorkAllBlocks, performedWorkAllBlocks, something_happened ? work::Status::OK : work::Status::DONE };
-    }
-
     void
-    resume() {
-        if (!this->canResume()) {
-            return;
-        }
-
-        this->_stop_requested = false;
-        this->setBlocksState(lifecycle::RUNNING);
-        if (executionPolicy() == ExecutionPolicy::multiThreaded) {
-            this->runOnPool(this->_job_lists, [this](auto &job) { return this->workOnce(job); });
-        }
-        this->changeStateTo(lifecycle::State::RUNNING);
-    }
-
-    void
-    start() {
-        if (!this->canInit() && !this->canStart()) {
-            return;
-        }
-
-        if (this->canInit()) {
-            this->init();
-        }
-
-        this->setBlocksState(lifecycle::RUNNING);
-
-        if constexpr (executionPolicy() == singleThreaded) {
-            this->changeStateTo(lifecycle::State::RUNNING);
-            work::Result result;
-            auto         blocklist = std::span{ this->_graph.blocks() };
-            do {
-                this->processScheduledMessages();
-                if (this->state() == lifecycle::State::RUNNING) {
-                    result = workOnce(blocklist);
-                    if (result.status == work::Status::ERROR) {
-                        this->changeStateTo(lifecycle::State::ERROR);
+    runSingleThreaded()
+        requires(base_t::executionPolicy() == ExecutionPolicy::singleThreaded)
+    {
+        work::Result result;
+        auto         blocklist = std::span{ this->_graph.blocks() };
+        do {
+            this->processScheduledMessages();
+            if (this->state() == lifecycle::State::RUNNING) {
+                result = this->workOnce(blocklist);
+                if (result.status == work::Status::ERROR) {
+                    if (auto e = this->changeStateTo(lifecycle::State::ERROR); !e) {
+                        this->emitError(this->msgOut, e.error());
                     }
-                } else {
-                    std::this_thread::sleep_for(kMessagePollInterval);
-                    result = { 0, 0, work::Status::OK };
                 }
-            } while (result.status == work::Status::OK && this->state() != lifecycle::State::ERROR && this->state() != lifecycle::State::STOPPED);
-        } else {
-            this->runOnPool(this->_job_lists, [this](auto &job) { return this->workOnce(job); });
-            this->changeStateTo(lifecycle::State::RUNNING);
+            } else {
+                std::this_thread::sleep_for(kMessagePollInterval);
+                result = { 0, 0, work::Status::OK };
+            }
+        } while (result.status == work::Status::OK && this->state() != lifecycle::State::ERROR && this->state() != lifecycle::State::STOPPED);
+        if (this->state() == lifecycle::State::RUNNING) {
+            if (auto e = this->changeStateTo(lifecycle::State::REQUESTED_STOP); !e) {
+                this->emitError(this->msgOut, e.error());
+            }
         }
     }
 };
@@ -467,34 +420,21 @@ public:
  * detecting cycles and blocks which can be reached from several source blocks.
  */
 template<ExecutionPolicy execution = ExecutionPolicy::singleThreaded, profiling::ProfilerLike TProfiler = profiling::null::Profiler>
-class BreadthFirst : public SchedulerBase<BreadthFirst<execution, TProfiler>, TProfiler> {
+class BreadthFirst : public SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler> {
+    friend class lifecycle::StateMachine<BreadthFirst<execution, TProfiler>>;
+    friend class SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler>;
     static_assert(execution == ExecutionPolicy::singleThreaded || execution == ExecutionPolicy::multiThreaded, "Unsupported execution policy");
-    using base_t = SchedulerBase<BreadthFirst<execution, TProfiler>, TProfiler>;
-    std::vector<BlockModel *>              _blocklist;
-    std::vector<std::vector<BlockModel *>> _job_lists{};
+    using base_t = SchedulerBase<BreadthFirst<execution, TProfiler>, execution, TProfiler>;
+    std::vector<BlockModel *> _blocklist;
 
 public:
-    static constexpr ExecutionPolicy
-    executionPolicy() {
-        return execution;
-    }
-
     explicit BreadthFirst(gr::Graph &&graph, std::shared_ptr<BasicThreadPool> thread_pool = std::make_shared<BasicThreadPool>("breadth-first-pool", thread_pool::CPU_BOUND),
                           const profiling::Options &profiling_options = {})
         : base_t(std::move(graph), thread_pool, profiling_options) {}
 
-    bool
-    isProcessing() const
-        requires(executionPolicy() == multiThreaded)
-    {
-        return this->_running_jobs.load() > 0;
-    }
-
+private:
     void
     init() {
-        if (!this->canInit()) {
-            return;
-        }
         [[maybe_unused]] const auto pe = this->_profiler_handler.startCompleteEvent("breadth_first.init");
         using block_t                  = BlockModel *;
         base_t::init();
@@ -534,7 +474,7 @@ public:
             }
         }
         // generate job list
-        if constexpr (executionPolicy() == ExecutionPolicy::multiThreaded) {
+        if constexpr (base_t::executionPolicy() == ExecutionPolicy::multiThreaded) {
             const auto n_batches = std::min(static_cast<std::size_t>(this->_pool->maxThreads()), _blocklist.size());
             this->_job_lists.reserve(n_batches);
             for (std::size_t i = 0; i < n_batches; i++) {
@@ -548,76 +488,31 @@ public:
         }
     }
 
-    template<typename block_type>
-    work::Result
-    workOnce(const std::span<block_type> &blocks) {
-        constexpr std::size_t requested_work     = std::numeric_limits<std::size_t>::max();
-        bool                  something_happened = false;
-        std::size_t           performed_work     = 0UZ;
-
-        for (auto &currentBlock : blocks) {
-            currentBlock->processScheduledMessages();
-            gr::work::Result result = currentBlock->work(requested_work);
-            performed_work += result.performed_work;
-            if (result.status == work::Status::ERROR) {
-                return { requested_work, performed_work, work::Status::ERROR };
-            } else if (result.status != work::Status::DONE) {
-                something_happened = true;
+    void
+    runSingleThreaded()
+        requires(base_t::executionPolicy() == ExecutionPolicy::singleThreaded)
+    {
+        work::Result result;
+        auto         blocklist = std::span{ this->_blocklist };
+        do {
+            this->processScheduledMessages();
+            if (this->state() == lifecycle::State::RUNNING) {
+                result = this->workOnce(blocklist);
+                if (result.status == work::Status::ERROR) {
+                    if (auto e = this->changeStateTo(lifecycle::State::ERROR); !e) {
+                        this->emitError(this->msgOut, e.error());
+                    }
+                }
+            } else {
+                std::this_thread::sleep_for(kMessagePollInterval);
+                result = { 0, 0, work::Status::OK };
+            }
+        } while (result.status == work::Status::OK && this->state() != lifecycle::State::ERROR && this->state() != lifecycle::State::STOPPED);
+        if (this->state() == lifecycle::State::RUNNING) {
+            if (auto e = this->changeStateTo(lifecycle::State::REQUESTED_STOP); !e) {
+                this->emitError(this->msgOut, e.error());
             }
         }
-
-        return { requested_work, performed_work, something_happened ? work::Status::OK : work::Status::DONE };
-    }
-
-    void
-    resume() {
-        if (!this->canResume()) {
-            return;
-        }
-        this->_stop_requested = false;
-        this->setBlocksState(lifecycle::State::RUNNING);
-        if constexpr (executionPolicy() == multiThreaded) {
-            this->runOnPool(this->_job_lists, [this](auto &job) { return this->workOnce(job); });
-        }
-        this->changeStateTo(lifecycle::State::RUNNING);
-    }
-
-    void
-    start() {
-        if (!this->canInit() && !this->canStart()) {
-            return;
-        }
-
-        if (this->canInit()) {
-            this->init();
-        }
-
-        this->setBlocksState(lifecycle::State::RUNNING);
-        if constexpr (executionPolicy() == singleThreaded) {
-            this->changeStateTo(lifecycle::State::RUNNING);
-            work::Result result;
-            auto         blocklist = std::span{ this->_blocklist };
-            do {
-                this->processScheduledMessages();
-                if (this->state() == lifecycle::State::RUNNING) {
-                    result = workOnce(blocklist);
-                    if (result.status == work::Status::ERROR) {
-                        this->changeStateTo(lifecycle::State::ERROR);
-                    }
-                } else {
-                    std::this_thread::sleep_for(kMessagePollInterval);
-                    result = { 0, 0, work::Status::OK };
-                }
-            } while (result.status == work::Status::OK && this->state() != lifecycle::State::ERROR && this->state() != lifecycle::State::STOPPED);
-        } else {
-            this->runOnPool(this->_job_lists, [this](auto &job) { return this->workOnce(job); });
-            this->changeStateTo(lifecycle::State::RUNNING);
-        }
-    }
-
-    [[nodiscard]] const std::vector<std::vector<BlockModel *>> &
-    jobs() const {
-        return _job_lists;
     }
 };
 } // namespace gr::scheduler

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -287,14 +287,12 @@ private:
             }
         });
         if (executionPolicy() == ExecutionPolicy::multiThreaded) {
-            // TODO review _job_lists usage
             this->runOnPool(_job_lists, [this](auto &job) { return this->workOnce(job); });
         }
     }
 
     void
     start() {
-        // TODO merge with resume?
         _stop_requested = false;
         _graph.forEachBlock([this](auto &block) {
             if (auto e = block.changeState(lifecycle::RUNNING); !e) {

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -397,7 +397,7 @@ testMessagesWithoutRunningScheduler() {
         }
     });
 
-    scheduler.init();
+    expect(scheduler.changeStateTo(lifecycle::State::INITIALISED).has_value());
     while (!isDone()) {
         scheduler.processScheduledMessages();
     }

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -440,7 +440,7 @@ testSchedulerControl() {
         }
 
         sendMessage(toScheduler, { { key::Kind, kind::SchedulerStateChangeRequest }, { key::What, REQUESTED_PAUSE } });
-        waitForMessages(reader, { { { kind::SchedulerStateUpdate, REQUESTED_PAUSE }, { kind::SchedulerStateUpdate, PAUSED } } });
+        waitForMessages(reader, { { { kind::SchedulerStateUpdate, REQUESTED_PAUSE } }, { { kind::SchedulerStateUpdate, PAUSED } } });
         if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
             expect(!scheduler.isProcessing());
         }

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -85,7 +85,7 @@ namespace {
  * Returns all received messages.
  */
 std::vector<pmtv::map_t>
-waitForMessages(auto &messageReader, std::vector<pmtv::map_t> expectedMessages, std::chrono::milliseconds timeout = 1s) {
+waitForMessages(auto &messageReader, std::vector<pmtv::map_t> expectedMessages, std::chrono::milliseconds timeout = 3s) {
     using namespace boost::ut;
 
     std::vector<pmtv::map_t> received;

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -1,11 +1,13 @@
-#include "gnuradio-4.0/basic/common_blocks.hpp"
 #include <boost/ut.hpp>
 
+#include "gnuradio-4.0/Message.hpp"
+#include <gnuradio-4.0/basic/common_blocks.hpp>
+#include <gnuradio-4.0/basic/DataSink.hpp>
 #include <gnuradio-4.0/Scheduler.hpp>
+#include <gnuradio-4.0/testing/FunctionBlocks.hpp>
+
 #include <magic_enum.hpp>
 #include <magic_enum_utility.hpp>
-
-#include <gnuradio-4.0/testing/FunctionBlocks.hpp>
 
 #if defined(__clang__) && __clang_major__ >= 16
 // clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
@@ -76,6 +78,49 @@ struct ProcessMessageConsumableSpanBlock : gr::Block<ProcessMessageConsumableSpa
     void
     processMessages(gr::MsgPortInNamed<"__Builtin"> &port, gr::ConsumableSpan auto message);
 };
+
+namespace {
+/**
+ * Waits for messages matching a message in expectedMessages, where matching means that all key-value pairs in the expected message are present in the received message.
+ * Returns all received messages.
+ */
+std::vector<pmtv::map_t>
+waitForMessages(auto &messageReader, std::vector<pmtv::map_t> expectedMessages, std::chrono::milliseconds timeout = 1s) {
+    using namespace boost::ut;
+
+    std::vector<pmtv::map_t> received;
+    auto                     start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < timeout && !expectedMessages.empty()) {
+        const auto available = messageReader.available();
+        if (available == 0) {
+            std::this_thread::sleep_for(20ms);
+            continue;
+        }
+        const auto messages = messageReader.get(available);
+        received.insert(received.end(), messages.begin(), messages.end());
+        std::erase_if(expectedMessages, [&messages](const auto &expected) {
+            return std::ranges::any_of(messages, [&expected](const auto &rec) {
+                return std::ranges::all_of(expected, [&rec](const auto &pair) { return rec.contains(pair.first) && rec.at(pair.first) == pair.second; });
+            });
+        });
+        std::ignore = messageReader.consume(available);
+    }
+
+    for (const auto &expected : expectedMessages) {
+        fmt::println("Expected message not received: {}", expected);
+    }
+    expect(expectedMessages.empty()) << fmt::format("Expected messages not received: {} received: {}", expectedMessages.size(), received.size());
+    return received;
+}
+
+void
+sendMessage(auto &outPort, pmtv::map_t message) {
+    auto out = outPort.streamWriter().reserve(1);
+    out[0]   = std::move(message);
+    out.publish(1);
+}
+
+} // namespace
 
 static_assert(gr::traits::block::can_processMessagesForPortConsumableSpan<ProcessMessageConsumableSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
 static_assert(!gr::traits::block::can_processMessagesForPortStdSpan<ProcessMessageConsumableSpanBlock<int>, gr::MsgPortInNamed<"__Builtin">>);
@@ -359,6 +404,56 @@ testMessagesWithoutRunningScheduler() {
     messenger.join();
 }
 
+template<typename Scheduler>
+void
+testSchedulerControl() {
+    auto isDone    = [] { return false; };
+    auto scheduler = [&] {
+        gr::Graph flow;
+        auto     &source = flow.emplaceBlock<gr::testing::FunctionSource<float>>();
+        source.generator = createOnesGenerator(isDone);
+        auto     &sink   = flow.emplaceBlock<gr::basic::DataSink<float>>();
+
+        expect(eq(ConnectionResult::SUCCESS, flow.connect<"out">(source).to<"in">(sink)));
+
+        return Scheduler(std::move(flow));
+    }();
+
+    gr::MsgPortIn  fromScheduler;
+    gr::MsgPortOut toScheduler;
+    expect(eq(ConnectionResult::SUCCESS, scheduler.msgOut.connect(fromScheduler)));
+    expect(eq(ConnectionResult::SUCCESS, toScheduler.connect(scheduler.msgIn)));
+
+    auto client = std::thread([&scheduler, &fromScheduler, &toScheduler] {
+        auto &reader = fromScheduler.streamReader();
+
+        waitForMessages(reader, { { { message::kind::SchedulerUpdate, message::scheduler::update::Started } } });
+        if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
+            expect(scheduler.isProcessing());
+        }
+
+        sendMessage(toScheduler, { { message::key::Kind, message::scheduler::command::Pause } });
+        waitForMessages(reader, { { { message::kind::SchedulerUpdate, message::scheduler::update::Pausing } }, { { message::kind::SchedulerUpdate, message::scheduler::update::Paused } } });
+        if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
+            expect(!scheduler.isProcessing());
+        }
+
+        sendMessage(toScheduler, { { message::key::Kind, message::scheduler::command::Resume } });
+        waitForMessages(reader, { { { message::kind::SchedulerUpdate, message::scheduler::update::Started } } });
+        if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
+            expect(scheduler.isProcessing());
+        }
+
+        sendMessage(toScheduler, { { message::key::Kind, message::scheduler::command::Stop } });
+        waitForMessages(reader, { { { message::kind::SchedulerUpdate, message::scheduler::update::Stopping } }, { { message::kind::SchedulerUpdate, message::scheduler::update::Stopped } } });
+        if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
+            expect(!scheduler.isProcessing());
+        }
+    });
+    scheduler.runAndWait();
+    client.join();
+}
+
 const boost::ut::suite MessagesTests = [] {
     using namespace boost::ut;
     using namespace gr;
@@ -395,6 +490,14 @@ const boost::ut::suite MessagesTests = [] {
         testMessagesWithoutRunningScheduler<scheduler::BreadthFirst<>>();
         testMessagesWithoutRunningScheduler<scheduler::Simple<scheduler::multiThreaded>>();
         testMessagesWithoutRunningScheduler<scheduler::BreadthFirst<scheduler::multiThreaded>>();
+    };
+
+    // Testing controlling the scheduler via messages
+    "SchedulerControl"_test = [] {
+        testSchedulerControl<scheduler::Simple<>>();
+        testSchedulerControl<scheduler::BreadthFirst<>>();
+        testSchedulerControl<scheduler::Simple<scheduler::multiThreaded>>();
+        testSchedulerControl<scheduler::BreadthFirst<scheduler::multiThreaded>>();
     };
 };
 

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -404,7 +404,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphLinear(trace), threadPool };
-        sched.init();
+        expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
         expect(sched.jobs().size() == 2u);
         checkBlockNames(sched.jobs()[0], { "s1", "mult2" });
         checkBlockNames(sched.jobs()[1], { "mult1", "out" });
@@ -426,7 +426,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphParallel(trace), threadPool };
-        sched.init();
+        expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
         expect(sched.jobs().size() == 2u);
         checkBlockNames(sched.jobs()[0], { "s1", "mult1b", "mult2b", "outb" });
         checkBlockNames(sched.jobs()[1], { "mult1a", "mult2a", "outa" });
@@ -449,7 +449,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::BreadthFirst<gr::scheduler::ExecutionPolicy::multiThreaded>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphScaledSum(trace), threadPool };
-        sched.init();
+        expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
         expect(sched.jobs().size() == 2u);
         checkBlockNames(sched.jobs()[0], { "s1", "mult", "out" });
         checkBlockNames(sched.jobs()[1], { "s2", "add" });
@@ -468,7 +468,7 @@ const boost::ut::suite SchedulerTests = [] {
 
         auto sched = scheduler{ std::move(flow), threadPool };
         sched.runAndWait();
-        sched.reset();
+        expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
 
         expect(eq(lifecycleSource.n_samples_produced, lifecycleSource.n_samples_max)) << "Source n_samples_produced != n_samples_max";
         expect(eq(lifecycleBlock.process_one_count, lifecycleSource.n_samples_max)) << "process_one_count != n_samples_produced";


### PR DESCRIPTION
Scheduler: Allow lifecycle control via messages
    
Allow the remote control (start, stop, pause, resume) via messages.
    
For that, implement pause/resume, refactor the schedulers to use CRTP (so all lifecycle methods can be called from the base class).
