### PR TITLE
added Drawable<UICategory, ToolKit> block annotation

### DIFF
--- a/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/common_blocks.hpp
@@ -187,6 +187,9 @@ public:
         return { requested_work, available_samples, gr::work::Status::OK };
     }
 
+    gr::work::Status
+    draw() {}
+
     void
     processScheduledMessages() override {}
 

--- a/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
+++ b/blocks/testing/include/gnuradio-4.0/testing/ImChartMonitor.hpp
@@ -13,7 +13,7 @@
 namespace gr::testing {
 
 template<typename T>
-struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>> {
+struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>, Drawable<UICategory::ChartPane, "console">> {
     using ClockSourceType = std::chrono::system_clock;
     PortIn<T>   in;
     float       sample_rate = 1000.0f;

--- a/blocks/testing/test/qa_UI_Integration.cpp
+++ b/blocks/testing/test/qa_UI_Integration.cpp
@@ -96,6 +96,7 @@ const boost::ut::suite TagTests = [] {
         // but the present 'connect' API assumes it to be part of the Graph
         auto &uiSink = testGraph.emplaceBlock<testing::ImChartMonitor<float>>({ { "name", "BasicImChartSink" } });
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(uiSink)));
+        expect(uiSink.meta_information.value.contains("Drawable")) << "drawable";
 
         scheduler::Simple sched{ std::move(testGraph) };
 

--- a/core/include/gnuradio-4.0/Graph.hpp
+++ b/core/include/gnuradio-4.0/Graph.hpp
@@ -267,6 +267,10 @@ public:
     work(std::size_t requested_work)
             = 0;
 
+    [[nodiscard]] virtual work::Status
+    draw()
+            = 0;
+
     virtual void
     processScheduledMessages()
             = 0;
@@ -407,6 +411,14 @@ public:
     [[nodiscard]] constexpr work::Result
     work(std::size_t requested_work = std::numeric_limits<std::size_t>::max()) override {
         return blockRef().work(requested_work);
+    }
+
+    constexpr work::Status
+    draw() override {
+        if constexpr ( requires { blockRef().draw(); } ) {
+            return blockRef().draw();
+        }
+        return work::Status::ERROR;
     }
 
     void

--- a/core/include/gnuradio-4.0/annotated.hpp
+++ b/core/include/gnuradio-4.0/annotated.hpp
@@ -137,6 +137,40 @@ using is_stride = std::bool_constant<IsStride<T>>;
 static_assert(is_stride<Stride<10, true>>::value);
 static_assert(!is_stride<int>::value);
 
+enum class UICategory {
+    None,
+    Toolbar,
+    ChartPane,
+    StatusBar,
+    Menu
+};
+
+/**
+ * @brief Annotates block, indicating that it is drawable and provides a  mandatory `void draw()` method.
+ *
+ * @tparam category_ ui category where it
+ * @tparam toolkit_ specifies the applicable UI toolkit (e.g. 'console', 'ImGui', 'Qt', etc.)
+ */
+template<UICategory category_, gr::meta::fixed_string toolkit_ = "">
+struct Drawable {
+    static constexpr UICategory             kCategorgy = category_;
+    static constexpr gr::meta::fixed_string kToolkit   = toolkit_;
+};
+
+template<typename T>
+concept IsDrawable = requires {
+    T::kCategorgy;
+    T::kToolkit;
+} && std::is_base_of_v<Drawable<T::kCategorgy, T::kToolkit>, T>;
+
+template<typename T>
+using is_drawable = std::bool_constant<IsDrawable<T>>;
+
+using NotDrawable = Drawable<UICategory::None, "">; // nomen-est-omen
+static_assert(is_drawable<NotDrawable>::value);
+static_assert(is_drawable<Drawable<UICategory::ChartPane, "console">>::value);
+static_assert(!is_drawable<int>::value);
+
 /**
  * @brief Annotates templated block, indicating which port data types are supported.
  */

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -580,6 +580,28 @@ const boost::ut::suite _stride_tests = [] {
     };
 };
 
+const boost::ut::suite _drawableAnnotations = [] {
+    using namespace boost::ut;
+    using namespace std::string_literals;
+
+    "drawable"_test = [] {
+        struct TestBlock0 : gr::Block<TestBlock0> {
+        } testBlock0;
+        expect(!testBlock0.meta_information.value.contains("Drawable")) << "not drawable";
+
+        struct TestBlock1 : gr::Block<TestBlock1, gr::Drawable<gr::UICategory::Toolbar, "console">> {
+            gr::work::Status draw() {}
+        } testBlock1;
+        expect(testBlock1.meta_information.value.contains("Drawable")) << "drawable";
+        const auto &drawableConfigMap = std::get<gr::property_map>(testBlock1.meta_information.value.at("Drawable"s));
+        expect(drawableConfigMap.contains("Category"));
+        expect(eq(std::get<std::string>(drawableConfigMap.at("Category")), "Toolbar"s));
+        expect(drawableConfigMap.contains("Toolkit"));
+        expect(eq(std::get<std::string>(drawableConfigMap.at("Toolkit")), "console"s));
+    };
+
+};
+
 int
 main() { /* not needed for UT */
 }

--- a/core/test/qa_HierBlock.cpp
+++ b/core/test/qa_HierBlock.cpp
@@ -115,6 +115,9 @@ public:
         return { requested_work, requested_work, ok ? gr::work::Status::DONE : gr::work::Status::ERROR };
     }
 
+    gr::work::Status
+    draw() {}
+
     void
     processScheduledMessages() override {
         // TODO


### PR DESCRIPTION
This adds default `Drawable` annotation in view of issue https://github.com/fair-acc/opendigitizer/issues/131 to declare whether a block supports rendering UI content that -- if declared -- must be drawn/processed through a mandatory `void draw() {...}` function, e.g.: 

```cpp
template<typename T>
struct ImChartMonitor : public Block<ImChartMonitor<T>, BlockingIO<false>, Drawable<UICategory::ChartPane, "console">> {
    PortIn<T>   in;
    float       sample_rate = 1000.0f;
    std::string signal_name = "unknown signal";

    constexpr void processOne(const T &input) noexcept { /*  ... as before ... */    }

    work::Status draw() noexcept {
        [[maybe_unused]] const work::Status status = this->invokeWork(); // calls work(...) -> processOne(...) (all in the same thread as this 'draw()'
        // handle drawing code
        return status;
    }
};
```

From the unit test:
```cpp
"drawable"_test = [] {
        struct TestBlock0 : gr::Block<TestBlock0> {
        } testBlock0;
        expect(!testBlock0.meta_information.value.contains("Drawable")) << "not drawable";

        struct TestBlock1 : gr::Block<TestBlock1, gr::Drawable<gr::UICategory::Toolbar, "console">> {
            void draw() {}
        } testBlock1;
        expect(testBlock1.meta_information.value.contains("Drawable")) << "drawable";
        const auto &drawableConfigMap = std::get<gr::property_map>(testBlock1.meta_information.value.at("Drawable"s));
        expect(drawableConfigMap.contains("Category"));
        expect(eq(std::get<std::string>(drawableConfigMap.at("Category")), "Toolbar"s));
        expect(drawableConfigMap.contains("Toolkit"));
        expect(eq(std::get<std::string>(drawableConfigMap.at("Toolkit")), "console"s));
    };
```