### PR TITLE
Use properly formed messages for scheduler state notifications

### DIFF
--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -85,7 +85,7 @@ public:
 
     void
     stateChanged(lifecycle::State newState) {
-        emitMessage(msgOut, { { kind::SchedulerStateUpdate, std::string(magic_enum::enum_name(newState)) } });
+        emitMessage(msgOut, { { key::Kind, kind::SchedulerStateUpdate }, { key::Data, std::string(magic_enum::enum_name(newState)) } });
     }
 
     void
@@ -110,15 +110,15 @@ public:
             for (const auto &msg : input) {
                 const auto kind = gr::messageField<std::string>(msg, key::Kind);
                 if (kind == message::kind::SchedulerStateChangeRequest) {
-                    const auto whatStr = gr::messageField<std::string>(msg, key::What).value_or("");
-                    const auto what    = magic_enum::enum_cast<lifecycle::State>(whatStr);
-                    if (!what || (what != lifecycle::State::RUNNING && what != lifecycle::State::REQUESTED_STOP && what != lifecycle::State::REQUESTED_PAUSE)) {
+                    const auto dataStr        = gr::messageField<std::string>(msg, key::Data).value_or("");
+                    const auto requestedState = magic_enum::enum_cast<lifecycle::State>(dataStr);
+                    if (!requestedState || (requestedState != lifecycle::State::RUNNING && requestedState != lifecycle::State::REQUESTED_STOP && requestedState != lifecycle::State::REQUESTED_PAUSE)) {
                         emitMessage(msgOut, { { key::Kind, kind::Error },
-                                              { key::ErrorInfo, fmt::format("Invalid command '{}'", whatStr) },
+                                              { key::ErrorInfo, fmt::format("Invalid command '{}'", dataStr) },
                                               { key::Location, fmt::format("{}", std::source_location::current()) } });
                         continue;
                     }
-                    if (auto e = this->changeStateTo(*what); !e) {
+                    if (auto e = this->changeStateTo(*requestedState); !e) {
                         emitMessage(msgOut, { { key::Kind, kind::Error }, { key::ErrorInfo, e.error().message }, { key::Location, e.error().srcLoc() } });
                     }
                 } else {

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -450,25 +450,25 @@ testSchedulerControl() {
         const std::string REQUESTED_STOP  = std::string(magic_enum::enum_name(State::REQUESTED_STOP));
         const std::string STOPPED         = std::string(magic_enum::enum_name(State::STOPPED));
 
-        waitForMessages(reader, { { { kind::SchedulerStateUpdate, RUNNING } } });
+        waitForMessages(reader, { { { key::Kind, kind::SchedulerStateUpdate }, { key::Data, RUNNING } } });
         if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
             expect(scheduler.isProcessing());
         }
 
-        sendMessage(toScheduler, { { key::Kind, kind::SchedulerStateChangeRequest }, { key::What, REQUESTED_PAUSE } });
-        waitForMessages(reader, { { { kind::SchedulerStateUpdate, REQUESTED_PAUSE } }, { { kind::SchedulerStateUpdate, PAUSED } } });
+        sendMessage(toScheduler, { { key::Kind, kind::SchedulerStateChangeRequest }, { key::Data, REQUESTED_PAUSE } });
+        waitForMessages(reader, { { { key::Kind, kind::SchedulerStateUpdate }, { key::Data, REQUESTED_PAUSE } }, { { key::Kind, kind::SchedulerStateUpdate }, { key::Data, PAUSED } } });
         if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
             expect(!scheduler.isProcessing());
         }
 
-        sendMessage(toScheduler, { { key::Kind, kind::SchedulerStateChangeRequest }, { key::What, RUNNING } });
-        waitForMessages(reader, { { { kind::SchedulerStateUpdate, RUNNING } } });
+        sendMessage(toScheduler, { { key::Kind, kind::SchedulerStateChangeRequest }, { key::Data, RUNNING } });
+        waitForMessages(reader, { { { key::Kind, kind::SchedulerStateUpdate }, { key::Data, RUNNING } } });
         if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
             expect(scheduler.isProcessing());
         }
 
-        sendMessage(toScheduler, { { key::Kind, kind::SchedulerStateChangeRequest }, { key::What, REQUESTED_STOP } });
-        waitForMessages(reader, { { { kind::SchedulerStateUpdate, REQUESTED_STOP } }, { { kind::SchedulerStateUpdate, STOPPED } } });
+        sendMessage(toScheduler, { { key::Kind, kind::SchedulerStateChangeRequest }, { key::Data, REQUESTED_STOP } });
+        waitForMessages(reader, { { { key::Kind, kind::SchedulerStateUpdate }, { key::Data, REQUESTED_STOP } }, { { key::Kind, kind::SchedulerStateUpdate }, { key::Data, STOPPED } } });
         if constexpr (Scheduler::executionPolicy() == scheduler::multiThreaded) {
             expect(!scheduler.isProcessing());
         }


### PR DESCRIPTION
Make sure the messages follow the intended pattern, using the Kind/Data keys.