### PR TITLE
std::span<std::span<...>> & Port<T>: enable std::any & meta-data

### DIFF
--- a/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/ImChart.hpp
@@ -269,8 +269,8 @@ public:
         _n_datasets++;
         if (axis_min_x == axis_max_x) {
             const auto [minX, maxX] = std::ranges::minmax_element(xValues);
-            axis_min_x              = *minX;
-            axis_max_x              = *maxX;
+            axis_min_x              = static_cast<double>(*minX);
+            axis_max_x              = static_cast<double>(*maxX);
             if (axis_min_x == axis_max_x) {
                 axis_max_x += 1.0; // safe fall back for x-range
             }

--- a/algorithm/include/gnuradio-4.0/algorithm/fourier/fftw.hpp
+++ b/algorithm/include/gnuradio-4.0/algorithm/fourier/fftw.hpp
@@ -1,6 +1,8 @@
 #ifndef GNURADIO_ALGORITHM_FFTW_HPP
 #define GNURADIO_ALGORITHM_FFTW_HPP
 
+#include <mutex>
+
 #include <fftw3.h>
 
 #include "window.hpp"
@@ -144,7 +146,9 @@ public:
 
         static_assert(sizeof(TOutput) == sizeof(OutAlgoDataType), "Sizes of TOutput type and OutAlgoDataType are not equal.");
 #pragma GCC diagnostic push
+#ifndef __clang__
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
         // Switch off warning: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘class std::complex<float>’ from an array of ‘float [2]’
         std::memcpy(out.data(), fftwOut.get(), sizeof(TOutput) * getOutputSize());
 #pragma GCC diagnostic pop

--- a/bench/benchmark.hpp
+++ b/bench/benchmark.hpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <iostream>
 #include <map>
+#include <mutex>
 #include <numeric>
 #include <ranges>
 #include <string>

--- a/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/FunctionGenerator.hpp
@@ -252,7 +252,7 @@ public:
 private:
     void
     applyFunctionSettings(const property_map &properties) {
-        auto getProperty = [&properties]<typename U>(const property_map &m, function_generator::ParameterType paramType, U &&) -> std::optional<U> {
+        auto getProperty = []<typename U>(const property_map &m, function_generator::ParameterType paramType, U &&) -> std::optional<U> {
             const auto it = m.find(function_generator::toString(paramType));
             if (it == m.end()) {
                 return std::nullopt;

--- a/blocks/basic/include/gnuradio-4.0/basic/Selector.hpp
+++ b/blocks/basic/include/gnuradio-4.0/basic/Selector.hpp
@@ -106,7 +106,7 @@ you can set the `backPressure` property to false.
 
     template<gr::ConsumableSpan TInSpan, gr::PublishableSpan TOutSpan>
     gr::work::Status
-    processBulk(const ConsumableSpan auto &selectSpan, const std::vector<TInSpan> &ins, PublishableSpan auto &monOut, std::vector<TOutSpan> &outs) {
+    processBulk(const ConsumableSpan auto &selectSpan, const std::span<TInSpan> &ins, PublishableSpan auto &monOut, std::span<TOutSpan> &outs) {
         if (_internalMapping.empty()) {
             if (back_pressure) {
                 std::for_each(ins.begin(), ins.end(), [](auto &input) { std::ignore = input.consume(0UZ); });

--- a/core/benchmarks/bm-nosonar_node_api.cpp
+++ b/core/benchmarks/bm-nosonar_node_api.cpp
@@ -163,7 +163,7 @@ public:
     template<gr::meta::t_or_simd<T> V>
     [[nodiscard]] constexpr V
     processOne(const V &a) const noexcept {
-        return a + addend;
+        return a + static_cast<T>(addend);
     }
 };
 

--- a/core/include/gnuradio-4.0/BlockTraits.hpp
+++ b/core/include/gnuradio-4.0/BlockTraits.hpp
@@ -377,15 +377,15 @@ port_to_processBulk_argument_helper() {
                   }) {
         if constexpr (Port::value_type::kIsInput) {
             if constexpr (isVectorOfSpansReturned) {
-                return static_cast<std::vector<std::span<const typename Port::value_type::value_type>> *>(nullptr);
+                return static_cast<std::span<std::span<const typename Port::value_type::value_type>> *>(nullptr);
             } else {
-                return static_cast<std::vector<DummyConsumableSpan<typename Port::value_type::value_type>> *>(nullptr);
+                return static_cast<std::span<DummyConsumableSpan<typename Port::value_type::value_type>> *>(nullptr);
             }
         } else if constexpr (Port::value_type::kIsOutput) {
             if constexpr (isVectorOfSpansReturned) {
-                return static_cast<std::vector<std::span<typename Port::value_type::value_type>> *>(nullptr);
+                return static_cast<std::span<std::span<typename Port::value_type::value_type>> *>(nullptr);
             } else {
-                return static_cast<std::vector<DummyPublishableSpan<typename Port::value_type::value_type>> *>(nullptr);
+                return static_cast<std::span<DummyPublishableSpan<typename Port::value_type::value_type>> *>(nullptr);
             }
         }
 

--- a/core/include/gnuradio-4.0/CircularBuffer.hpp
+++ b/core/include/gnuradio-4.0/CircularBuffer.hpp
@@ -366,7 +366,9 @@ class CircularBuffer
     [[nodiscard]] constexpr std::size_t size() const noexcept { return _parent->_internalSpan.size(); };
     [[nodiscard]] constexpr std::size_t size_bytes() const noexcept { return size() * sizeof(T); };
     [[nodiscard]] constexpr bool empty() const noexcept { return _parent->_internalSpan.empty(); }
+    [[nodiscard]] constexpr iterator cbegin() const noexcept { return _parent->_internalSpan.cbegin(); }
     [[nodiscard]] constexpr iterator begin() const noexcept { return _parent->_internalSpan.begin(); }
+    [[nodiscard]] constexpr iterator cend() const noexcept { return _parent->_internalSpan.cend(); }
     [[nodiscard]] constexpr iterator end() const noexcept { return _parent->_internalSpan.end(); }
     [[nodiscard]] constexpr reverse_iterator rbegin() const noexcept { return _parent->_internalSpan.rbegin(); }
     [[nodiscard]] constexpr reverse_iterator rend() const noexcept { return _parent->_internalSpan.rend(); }
@@ -614,7 +616,9 @@ class CircularBuffer
     [[nodiscard]] constexpr std::size_t size() const noexcept { return _internalSpan.size(); }
     [[nodiscard]] constexpr std::size_t size_bytes() const noexcept { return size() * sizeof(T); }
     [[nodiscard]] constexpr bool empty() const noexcept { return _internalSpan.empty(); }
+    [[nodiscard]] constexpr iterator cbegin() const noexcept { return _internalSpan.cbegin(); }
     [[nodiscard]] constexpr iterator begin() const noexcept { return _internalSpan.begin(); }
+    [[nodiscard]] constexpr iterator cend() const noexcept { return _internalSpan.cend(); }
     [[nodiscard]] constexpr iterator end() const noexcept { return _internalSpan.end(); }
     [[nodiscard]] constexpr const T& front() const noexcept { return _internalSpan.front(); }
     [[nodiscard]] constexpr const T& back() const noexcept { return _internalSpan.back(); }

--- a/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
+++ b/core/include/gnuradio-4.0/Graph_yaml_importer.hpp
@@ -3,11 +3,15 @@
 
 #include <charconv>
 
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wshadow"
+#endif
 #include <yaml-cpp/yaml.h>
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 #include "Graph.hpp"
 #include "PluginLoader.hpp"

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -72,8 +72,8 @@ const boost::ut::suite BasicConceptsTests = [] {
                 expect(eq(reader.available(), std::size_t{ 0 }));
                 expect(eq(reader.position(), std::make_signed_t<std::size_t>{ -1 }));
                 gr::ConsumableSpan auto data = reader.get(std::size_t{ 0 });
-                expect(nothrow([&reader, &data] { expect(eq(data.size(), std::size_t{ 0 })); })) << typeName << "throws";
-                expect(nothrow([&reader, &data] { expect(data.consume(std::size_t{ 0 })); }));
+                expect(nothrow([&data] { expect(eq(data.size(), std::size_t{ 0 })); })) << typeName << "throws";
+                expect(nothrow([&data] { expect(data.consume(std::size_t{ 0 })); }));
 
                 expect(writer.available() >= buffer.size());
                 expect(nothrow([&writer] { writer.publish([](const std::span<int32_t> &) { /* noop */ }, 0); }));
@@ -167,7 +167,7 @@ const boost::ut::suite DoubleMappedAllocatorTests = [] {
         std::vector<int32_t, Allocator> vec(size, doubleMappedAllocator);
         expect(eq(vec.size(), size));
         std::iota(vec.begin(), vec.end(), 1);
-        for (std::size_t i = 0U; i < vec.size(); ++i) {
+        for (std::size_t i = 0UZ; i < vec.size(); ++i) {
             expect(eq(vec[i], static_cast<std::int32_t>(i + 1)));
             // to note: can safely read beyond size for this special vector
             expect(eq(vec[size + i], vec[i])); // identical to mirrored copy
@@ -620,7 +620,7 @@ const boost::ut::suite NonPowerTwoTests = [] {
         BufferReader auto reader = buffer.new_reader();
 
         const auto genSamples = [&buffer, &writer] {
-            for (std::size_t i = 0; i < buffer.size() - 10; i++) { // write-only worker (source) mock-up
+            for (std::size_t i = 0UZ; i < buffer.size() - 10UZ; i++) { // write-only worker (source) mock-up
                 auto lambda = [](auto vectors) {
                     static int offset = 0;
                     for (auto &vector : vectors) {


### PR DESCRIPTION
## Expose only std::span<..> and [Consuamble. Producable]Span to processBulk(...)

* hides the internal std::vector/std::array implementation to indicate more clearly to the user that the user code only gets a non-owning reference to the input and output port data. This should make the user API safer and allow changing the internal implementation without breaking the user code.

## Port<T>: enable std::any & meta-data for increased type and physical-unit safety

**Some example usages:**
  * prevents accidentally connecting ports with incompatible sampling rates, quantity- and unit types.
  * used to condition graphs/charts (notably the min/max range),
  * detect saturation/LNA non-linearities,
  * detect computation errors
  * ...

Follows the ISO 80000-1:2022 Quantities and Units conventions:
  * https://www.iso.org/standard/76921.html
  * https://en.wikipedia.org/wiki/ISO/IEC_80000
  * https://blog.ansi.org/iso-80000-1-2022-quantities-and-units/

*long-term goal: enable compile-time checks based on https://github.com/mpusz/mp-units (N.B. will become part of C++26)*

Added definitions for:
```cpp
Annotated<float, "sample rate", Visible, Doc<"sampling rate in samples per second (Hz)">>                        sample_rate = 1.f;
Annotated<std::string, "signal name", Doc<"name of the signal">>                                                 signal_name = "<unnamed>";
Annotated<std::string, "signal quantity", Doc<"physical quantity (e.g., 'voltage'). Follows ISO 80000-1:2022.">> signal_quantity{};
Annotated<std::string, "signal unit", Doc<"unit of measurement (e.g., '[V]', '[m]'). Follows ISO 80000-1:2022">> signal_unit{};
Annotated<float, "signal min,", Doc<"minimum expected signal value">>                                            signal_min = std::numeric_limits<float>::lowest();
Annotated<float, "signal max,", Doc<"maximum expected signal value">>                                            signal_max = std::numeric_limits<float>::max();
```


## Miscellaneous:
   * minor compiler warning fixes (now there should be only the `Graph`-constructor one remain to be fixed)