### PR TITLE
Messaging fixes

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1130,6 +1130,15 @@ protected:
         } else if (message.cmd == Get) {
             message.data = self().settings().stagedParameters();
             return message;
+        } else if (message.cmd == Subscribe) {
+            fmt::println("subscribing to staged settings: {}", message.clientRequestID);
+            if (!message.clientRequestID.empty()) {
+                propertySubscriptions[std::string(propertyName)].insert(message.clientRequestID);
+            }
+            return std::nullopt;
+        } else if (message.cmd == Unsubscribe) {
+            propertySubscriptions[std::string(propertyName)].erase(message.clientRequestID);
+            return std::nullopt;
         }
 
         throw gr::exception(fmt::format("block {} property {} does not implement command {}, msg: {}", unique_name, propertyName, message.cmd, message));

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1012,9 +1012,7 @@ protected:
             }
             return std::nullopt;
         } else if (message.cmd == Unsubscribe) {
-            if (propertySubscriptions[std::string(propertyName)].contains(message.clientRequestID)) {
-                propertySubscriptions[std::string(propertyName)].erase(message.clientRequestID);
-            }
+            propertySubscriptions[std::string(propertyName)].erase(message.clientRequestID);
             return std::nullopt;
         }
 
@@ -1069,9 +1067,7 @@ protected:
             }
             return std::nullopt;
         } else if (message.cmd == Unsubscribe) {
-            if (propertySubscriptions[std::string(propertyName)].contains(message.clientRequestID)) {
-                propertySubscriptions[std::string(propertyName)].erase(message.clientRequestID);
-            }
+            propertySubscriptions[std::string(propertyName)].erase(message.clientRequestID);
             return std::nullopt;
         }
 
@@ -1100,9 +1096,7 @@ protected:
             }
             return std::nullopt;
         } else if (message.cmd == Unsubscribe) {
-            if (propertySubscriptions[std::string(propertyName)].contains(message.clientRequestID)) {
-                propertySubscriptions[std::string(propertyName)].erase(message.clientRequestID);
-            }
+            propertySubscriptions[std::string(propertyName)].erase(message.clientRequestID);
             return std::nullopt;
         }
 

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1063,6 +1063,16 @@ protected:
         } else if (message.cmd == Get) {
             message.data = { { "state", std::string(magic_enum::enum_name(this->state())) } };
             return message;
+        } else if (message.cmd == Subscribe) {
+            if (!message.clientRequestID.empty()) {
+                propertySubscriptions[std::string(propertyName)].insert(message.clientRequestID);
+            }
+            return std::nullopt;
+        } else if (message.cmd == Unsubscribe) {
+            if (propertySubscriptions[std::string(propertyName)].contains(message.clientRequestID)) {
+                propertySubscriptions[std::string(propertyName)].erase(message.clientRequestID);
+            }
+            return std::nullopt;
         }
 
         throw gr::exception(fmt::format("block {} property {} does not implement command {}, msg: {}", unique_name, propertyName, message.cmd, message));

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1131,7 +1131,6 @@ protected:
             message.data = self().settings().stagedParameters();
             return message;
         } else if (message.cmd == Subscribe) {
-            fmt::println("subscribing to staged settings: {}", message.clientRequestID);
             if (!message.clientRequestID.empty()) {
                 propertySubscriptions[std::string(propertyName)].insert(message.clientRequestID);
             }
@@ -1705,7 +1704,7 @@ public:
             }
 
             if (callback == nullptr) {
-                return; // did not find matching property callback
+                continue; // did not find matching property callback
             }
 
             std::optional<Message> retMessage;
@@ -1723,7 +1722,7 @@ public:
             }
 
             if (!retMessage.has_value()) {
-                return; // function does not produce any return message
+                continue; // function does not produce any return message
             }
 
             retMessage->cmd         = Final; // N.B. could enable/allow for partial if we return multiple messages (e.g. using coroutines?)

--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1418,8 +1418,9 @@ protected:
 
     void
     notifyListeners(std::string_view endpoint, property_map message) noexcept {
-        if (!propertySubscriptions[std::string(endpoint)].empty()) {
-            for (const auto &clientID : propertySubscriptions[std::string(endpoint)]) {
+        const auto it = propertySubscriptions.find(std::string(endpoint));
+        if (it != propertySubscriptions.end()) {
+            for (const auto &clientID : it->second) {
                 emitMessage(endpoint, message, clientID);
             }
         }

--- a/core/include/gnuradio-4.0/Message.hpp
+++ b/core/include/gnuradio-4.0/Message.hpp
@@ -206,7 +206,7 @@ struct fmt::formatter<gr::message::Command> {
     }
 };
 
-std::ostream &
+inline std::ostream &
 operator<<(std::ostream &os, const gr::message::Command &command) {
     return os << magic_enum::enum_name(command);
 }
@@ -228,7 +228,7 @@ struct fmt::formatter<gr::Message> {
     }
 };
 
-std::ostream &
+inline std::ostream &
 operator<<(std::ostream &os, const gr::Message &msg) {
     return os << fmt::format("{}", msg);
 }

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -137,6 +137,7 @@ public:
     std::expected<void, std::string>
     runAndWait() {
         [[maybe_unused]] const auto pe = this->_profiler_handler.startCompleteEvent("scheduler_base.runAndWait");
+        base_t::processScheduledMessages(); // make sure initial subscriptions are processed
         if (this->state() == lifecycle::State::IDLE) {
             if (auto e = this->changeStateTo(lifecycle::State::INITIALISED); !e) {
                 this->emitErrorMessage("runAndWait() -> LifecycleState", e.error());
@@ -209,6 +210,7 @@ protected:
     void
     init() {
         [[maybe_unused]] const auto pe     = _profiler_handler.startCompleteEvent("scheduler_base.init");
+        base_t::processScheduledMessages(); // make sure initial subscriptions are processed
         const auto                  result = _graph.performConnections();
         if (!result) {
             this->emitErrorMessage("init()", gr::Error("Failed to connect blocks in graph"));

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -86,7 +86,7 @@ public:
         });
 
         // Forward any messages to children that were received before the scheduler was initialised
-        _toChildMessagePort.streamWriter().publish([&](auto &out) { std::ranges::copy(_pendingMessagesToChildren, out.begin()); }, _pendingMessagesToChildren.size());
+        _toChildMessagePort.streamWriter().publish([&](auto &out) { std::ranges::move(_pendingMessagesToChildren, out.begin()); }, _pendingMessagesToChildren.size());
         _pendingMessagesToChildren.clear();
     }
 

--- a/core/include/gnuradio-4.0/Scheduler.hpp
+++ b/core/include/gnuradio-4.0/Scheduler.hpp
@@ -79,13 +79,13 @@ public:
         _graph.forEachBlock([this](auto &block) {
             if (ConnectionResult::SUCCESS != _toChildMessagePort.connect(*block.msgIn)) {
                 this->emitErrorMessage("connectBlockMessagePorts()", gr::Error(fmt::format("Failed to connect scheduler input message port to child '{}'", block.uniqueName())));
-            } else {
-                _toChildMessagePort.streamWriter().publish([&](auto &out) { std::ranges::copy(_pendingMessagesToChildren, out.begin()); }, _pendingMessagesToChildren.size());
             }
 
             auto buffer = _fromChildMessagePort.buffer();
             block.msgOut->setBuffer(buffer.streamBuffer, buffer.tagBuffer);
         });
+
+        _toChildMessagePort.streamWriter().publish([&](auto &out) { std::ranges::copy(_pendingMessagesToChildren, out.begin()); }, _pendingMessagesToChildren.size());
         _pendingMessagesToChildren.clear();
     }
 


### PR DESCRIPTION
 * Make sure clients can subscribe to kLifeCycleState and kStagedSetting
 * Make sure messages sent before scheduler initialisation (i.e. before runAndWait()) are not lost. (needed for initial subscriptions, to have the guarantee to receive everything)
 * Minor code cleanup (avoid contains()/empty() checks where unnecessary)