### PR TITLE
Block: fix EoS handling for process bulk not consuming samples

### DIFF
--- a/core/include/gnuradio-4.0/Block.hpp
+++ b/core/include/gnuradio-4.0/Block.hpp
@@ -1559,7 +1559,7 @@ protected:
             static_assert(gr::meta::always_false<gr::traits::block::stream_input_port_types_tuple<Derived>>, "neither processBulk(...) nor processOne(...) implemented");
         }
         forwardTags();
-        if (lifecycle::isShuttingDown(this->state()) || nextEosTag <= processedIn + 1) {
+        if (lifecycle::isShuttingDown(this->state())) {
             if (auto e = this->changeStateTo(lifecycle::State::REQUESTED_STOP); !e) {
                 emitErrorMessage("isShuttingDown -> STOPPED", e.error());
             }
@@ -1586,8 +1586,7 @@ protected:
         // if the block state changed to DONE, publish EOS tag on the next sample
         if (ret == work::Status::DONE) {
             this->setAndNotifyState(lifecycle::State::STOPPED);
-            publishTag({ { gr::tag::END_OF_STREAM, true } }, 1);
-            ret = work::Status::DONE;
+            publishTag({ { gr::tag::END_OF_STREAM, true } }, 0);
         }
         return { requested_work, processedIn, success ? ret : work::Status::ERROR };
     } // end: work_return_t workInternal() noexcept { ..}


### PR DESCRIPTION
@frankosterfeld discovered a regression in one of the out of tree blocks in gr-digitizer, reported [here](https://github.com/fair-acc/graph-prototype/pull/297/files#r1542781655).

If the processBulk function does not consume all samples up to the eos tag, the previous code would terminate processing anyway, leading to the unprocessed samples being dropped.
This is becaue the ConsumableSpan does not provide a way to determine how much the processsing function has actually consumed.

This change solves this by only handling explicitly stopped blocks after the block has processed, which leaves the eos tag handling for the start of the next call, where it is sufficient to check if the eos tag is the first sample.

Also fixes a few minor inconsistencies discovered by @frankosterfeld.