### PR TITLE
ut: remove clang workaround after upstream fixes

### DIFF
--- a/blocks/basic/test/qa_DataSink.cpp
+++ b/blocks/basic/test/qa_DataSink.cpp
@@ -18,12 +18,6 @@
 
 using namespace std::chrono_literals;
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 template<>
 struct fmt::formatter<gr::Tag> {
     template<typename ParseContext>

--- a/blocks/basic/test/qa_sources.cpp
+++ b/blocks/basic/test/qa_sources.cpp
@@ -11,12 +11,6 @@
 #include <gnuradio-4.0/basic/SignalGenerator.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 15
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 template<typename T>
 constexpr void
 addTimeTagEntry(gr::basic::ClockSource<T> &clockSource, std::uint64_t timeInNanoseconds, const std::string &value) {

--- a/blocks/filter/test/qa_filter.cpp
+++ b/blocks/filter/test/qa_filter.cpp
@@ -6,12 +6,6 @@
 
 #include <gnuradio-4.0/filter/time_domain_filter.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 template<typename T, typename Range>
     requires std::floating_point<T>
 constexpr size_t

--- a/blocks/fourier/test/qa_fourier.cpp
+++ b/blocks/fourier/test/qa_fourier.cpp
@@ -15,12 +15,6 @@
 
 #include <gnuradio-4.0/fourier/fft.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 template<typename T>
 std::vector<T>
 generateSinSample(std::size_t N, double sample_rate, double frequency, double amplitude) {

--- a/blocks/http/test/qa_HttpBlock.cpp
+++ b/blocks/http/test/qa_HttpBlock.cpp
@@ -13,12 +13,6 @@
 
 #include <gnuradio-4.0/http/HttpBlock.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 template<typename T>
 class FixedSource : public gr::Block<FixedSource<T>> {
     using super_t = gr::Block<FixedSource<T>>;

--- a/blocks/testing/test/qa_UI_Integration.cpp
+++ b/blocks/testing/test/qa_UI_Integration.cpp
@@ -11,12 +11,6 @@
 #include "gnuradio-4.0/testing/ImChartMonitor.hpp"
 #include "gnuradio-4.0/testing/TagMonitors.hpp"
 
-#if defined(__clang__) && __clang_major__ >= 15
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 const boost::ut::suite TagTests = [] {
     using namespace boost::ut;
     using namespace gr;

--- a/core/test/qa_Block.cpp
+++ b/core/test/qa_Block.cpp
@@ -10,12 +10,6 @@
 #include <gnuradio-4.0/Scheduler.hpp>
 #include <gnuradio-4.0/testing/TagMonitors.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 #if !DISABLE_SIMD
 namespace gr::test {
 struct copy : public Block<copy> {

--- a/core/test/qa_DynamicPort.cpp
+++ b/core/test/qa_DynamicPort.cpp
@@ -8,12 +8,6 @@
 
 #include <gnuradio-4.0/meta/utils.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 using namespace std::string_literals;
 
 #ifdef ENABLE_DYNAMIC_PORTS

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -10,12 +10,6 @@
 
 #include <optional>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 using namespace std::chrono_literals;
 using namespace std::string_literals;
 

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -2,12 +2,6 @@
 
 #include <gnuradio-4.0/Scheduler.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 using TraceVectorType = std::vector<std::string>;
 
 class Tracer {

--- a/core/test/qa_Settings.cpp
+++ b/core/test/qa_Settings.cpp
@@ -17,12 +17,6 @@
 
 using namespace std::string_literals;
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 namespace gr::setting_test {
 
 namespace utils {

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -32,12 +32,6 @@ static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCE
 static_assert(HasRequiredProcessFunction<TagSink<int, ProcessFunction::USE_PROCESS_BULK>>);
 } // namespace gr::testing
 
-#if defined(__clang__) && __clang_major__ >= 15
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 const boost::ut::suite TagTests = [] {
     using namespace boost::ut;
     using namespace gr;

--- a/core/test/qa_buffer.cpp
+++ b/core/test/qa_buffer.cpp
@@ -17,12 +17,6 @@
 #include <gnuradio-4.0/Sequence.hpp>
 #include <gnuradio-4.0/WaitStrategy.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 template<gr::WaitStrategy auto wait = gr::NoWaitStrategy()>
 struct TestStruct {
     [[nodiscard]] constexpr bool

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <ranges>
@@ -16,7 +15,7 @@
 #include <boost/ut.hpp>
 
 #if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
+// for clang there seems to be some static initialisation problem which leads to segfaults in gr::registerBlock
 template<>
 auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
 #endif

--- a/core/test/qa_plugins_test.cpp
+++ b/core/test/qa_plugins_test.cpp
@@ -10,12 +10,6 @@
 #include <gnuradio-4.0/BlockRegistry.hpp>
 #include <gnuradio-4.0/PluginLoader.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 using namespace std::chrono_literals;
 
 template<typename T>

--- a/core/test/qa_reader_writer_lock.cpp
+++ b/core/test/qa_reader_writer_lock.cpp
@@ -2,12 +2,6 @@
 
 #include <gnuradio-4.0/reader_writer_lock.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 namespace gr::reader_writer_lock_test {
 
 const boost::ut::suite basicTests = [] {

--- a/core/test/qa_thread_affinity.cpp
+++ b/core/test/qa_thread_affinity.cpp
@@ -4,12 +4,6 @@
 
 #include <gnuradio-4.0/thread/thread_affinity.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 const boost::ut::suite ThreadAffinityTests = [] {
     using namespace boost::ut;
 

--- a/core/test/qa_thread_pool.cpp
+++ b/core/test/qa_thread_pool.cpp
@@ -2,12 +2,6 @@
 
 #include <gnuradio-4.0/thread/thread_pool.hpp>
 
-#if defined(__clang__) && __clang_major__ >= 16
-// clang 16 does not like ut's default reporter_junit due to some issues with stream buffers and output redirection
-template<>
-auto boost::ut::cfg<boost::ut::override> = boost::ut::runner<boost::ut::reporter<>>{};
-#endif
-
 const boost::ut::suite ThreadPoolTests = [] {
     using namespace boost::ut;
 


### PR DESCRIPTION
UT fixed the initialisation of the command line arguments for clang in https://github.com/boost-ext/ut/commit/3cfd9937e1d4c9375f7d7904a5ba6a1926f7161f. This change removes the special case which disables the junit style ut reporter in most unit tests.

For qa_grc there is still a segfault if the junit reporter is enablet but this seems to be a slightly different case. The segfault occurs in the static initialisation of the block registy in gr::registerBlock.