### PR TITLE
Wrapped schduler.runAndWait() calls

### DIFF
--- a/blocks/basic/test/qa_Selector.cpp
+++ b/blocks/basic/test/qa_Selector.cpp
@@ -64,7 +64,7 @@ execute_selector_test(TestParams params) {
     expect(gr::ConnectionResult::SUCCESS == graph.connect<"monitor">(*selector).to<"in">(*monitorSink));
 
     gr::scheduler::Simple sched{ std::move(graph) };
-    sched.runAndWait();
+    expect(sched.runAndWait().has_value());
 
     if (!params.backPressure) {
         for (const auto &input : selector->inputs) {

--- a/blocks/basic/test/qa_sources.cpp
+++ b/blocks/basic/test/qa_sources.cpp
@@ -58,7 +58,7 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(src).template to<"in">(sink2)));
 
         scheduler::Simple sched{ std::move(testGraph) };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         if (verbose) {
             fmt::println("finished ClockSource sched.runAndWait() w/ {}", useIoThreadPool ? "Graph/Block<T> provided-thread" : "user-provided thread");
         }
@@ -164,7 +164,7 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(signalGen).to<"in">(sink)));
 
         scheduler::Simple sched{ std::move(testGraph) };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
 
         expect(eq(n_samples, static_cast<std::uint32_t>(sink.n_samples_produced))) << "Number of samples does not match";
     };
@@ -221,7 +221,7 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(sink)));
 
         scheduler::Simple sched{ std::move(testGraph) };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         expect(eq(N, static_cast<std::uint32_t>(sink.samples.size()))) << "Number of samples does not match";
 
         std::vector<double> xValues(N);
@@ -296,7 +296,7 @@ const boost::ut::suite TagTests = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(funcGen).to<"in">(sink)));
 
         scheduler::Simple sched{ std::move(testGraph) };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         expect(eq(N, static_cast<std::uint32_t>(sink.samples.size()))) << "Number of samples does not match";
 
         std::vector<double> xValues(N);

--- a/blocks/fourier/test/qa_fourier.cpp
+++ b/blocks/fourier/test/qa_fourier.cpp
@@ -140,22 +140,23 @@ const boost::ut::suite<"Fourier Transforms"> fftTests = [] {
         using Scheduler      = gr::scheduler::Simple<>;
         auto      threadPool = std::make_shared<gr::thread_pool::BasicThreadPool>("custom pool", gr::thread_pool::CPU_BOUND, 2, 2);
         gr::Graph flow1;
-        auto     &source1 = flow1.emplaceBlock<gr::testing::TagSource<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({ { "n_samples_max", static_cast<gr::Size_t>(1024) }, { "mark_tag", false } });
-        auto     &fftBlock = flow1.emplaceBlock<FFT<float>>({ { "fftSize", static_cast<gr::Size_t>(16) } });
+        auto &source1 = flow1.emplaceBlock<gr::testing::TagSource<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({ { "n_samples_max", static_cast<gr::Size_t>(1024) }, { "mark_tag", false } });
+        auto &fftBlock = flow1.emplaceBlock<FFT<float>>({ { "fftSize", static_cast<gr::Size_t>(16) } });
         expect(eq(gr::ConnectionResult::SUCCESS, flow1.connect<"out">(source1).to<"in">(fftBlock)));
         auto sched1 = Scheduler(std::move(flow1), threadPool);
 
         // run 2 times to check potential memory problems
         for (int i = 0; i < 2; i++) {
             gr::Graph flow2;
-            auto     &source2 = flow2.emplaceBlock<gr::testing::TagSource<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>({ { "n_samples_max", static_cast<gr::Size_t>(1024) }, { "mark_tag", false } });
-            auto     &fft2    = flow2.emplaceBlock<FFT<float>>({ { "fftSize", static_cast<gr::Size_t>(16) } });
+            auto     &source2 = flow2.emplaceBlock<gr::testing::TagSource<float, gr::testing::ProcessFunction::USE_PROCESS_BULK>>(
+                    { { "n_samples_max", static_cast<gr::Size_t>(1024) }, { "mark_tag", false } });
+            auto &fft2 = flow2.emplaceBlock<FFT<float>>({ { "fftSize", static_cast<gr::Size_t>(16) } });
             expect(eq(gr::ConnectionResult::SUCCESS, flow2.connect<"out">(source2).to<"in">(fft2)));
             auto sched2 = Scheduler(std::move(flow2), threadPool);
-            sched2.runAndWait();
+            expect(sched2.runAndWait().has_value());
             expect(eq(source2.n_samples_produced, source2.n_samples_max));
         }
-        sched1.runAndWait();
+        expect(sched1.runAndWait().has_value());
         expect(eq(source1.n_samples_produced, source1.n_samples_max));
     };
 

--- a/blocks/http/test/qa_HttpBlock.cpp
+++ b/blocks/http/test/qa_HttpBlock.cpp
@@ -93,7 +93,7 @@ const boost::ut::suite HttpBlocktests = [] {
         // make a request
         source.trigger();
         httpBlock.processScheduledMessages();
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         expect(eq(std::get<std::string>(sink.value.at("raw-data")), "Hello world!"sv));
 
 #ifndef __EMSCRIPTEN__
@@ -122,7 +122,7 @@ const boost::ut::suite HttpBlocktests = [] {
         auto sched    = gr::scheduler::Simple<>(std::move(graph));
         sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         httpBlock.trigger();
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         expect(eq(std::get<int>(sink.value.at("status")), 404));
 
 #ifndef __EMSCRIPTEN__
@@ -151,7 +151,7 @@ const boost::ut::suite HttpBlocktests = [] {
         auto sched    = gr::scheduler::Simple<>(std::move(graph));
         sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
         httpBlock.trigger();
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         expect(eq(std::get<std::string>(sink.value.at("raw-data")), "OK"sv));
 
 #ifndef __EMSCRIPTEN__
@@ -192,7 +192,7 @@ const boost::ut::suite HttpBlocktests = [] {
 
         auto sched    = gr::scheduler::Simple<>(std::move(graph));
         sink.stopFunc = [&]() { expect(sched.changeStateTo(lifecycle::State::REQUESTED_STOP).has_value()); };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         expect(eq(std::get<std::string>(sink.value.at("raw-data")), "event"sv));
 
 #ifndef __EMSCRIPTEN__

--- a/blocks/testing/test/qa_UI_Integration.cpp
+++ b/blocks/testing/test/qa_UI_Integration.cpp
@@ -103,7 +103,7 @@ const boost::ut::suite TagTests = [] {
             std::this_thread::sleep_for(std::chrono::seconds(2)); // wait for another 2 seconds before closing down
             fmt::println("finished UI thread");
         });
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         expect(eq(N, static_cast<std::uint32_t>(sink.samples.size()))) << "Number of samples does not match";
         uiLoop.join();
     };

--- a/core/benchmarks/bm-nosonar_node_api.cpp
+++ b/core/benchmarks/bm-nosonar_node_api.cpp
@@ -479,7 +479,7 @@ invoke_work(auto &sched) {
     using namespace benchmark;
     test::n_samples_produced = 0LU;
     test::n_samples_consumed = 0LU;
-    sched.runAndWait();
+    expect(sched.runAndWait().has_value());
     expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
     expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
 }
@@ -605,7 +605,7 @@ inline const boost::ut::suite _runtime_tests = [] {
         ::benchmark::benchmark<1LU>{ test_name }.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
-            sched.runAndWait();
+            expect(sched.runAndWait().has_value());
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };
@@ -636,7 +636,7 @@ inline const boost::ut::suite _simd_tests = [] {
         "runtime   src->mult(2.0)->mult(0.5)->add(-1)->sink (SIMD)"_benchmark.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
-            sched.runAndWait();
+            expect(sched.runAndWait().has_value());
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };
@@ -701,7 +701,7 @@ inline const boost::ut::suite _sample_by_sample_vs_bulk_access_tests = [] {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
             gr::scheduler::Simple sched{ std::move(testGraph) };
-            sched.runAndWait();
+            expect(sched.runAndWait().has_value());
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };
@@ -727,7 +727,7 @@ inline const boost::ut::suite _sample_by_sample_vs_bulk_access_tests = [] {
         ::benchmark::benchmark<1LU>{ test_name }.repeat<N_ITER>(N_SAMPLES) = [&sched]() {
             test::n_samples_produced = 0LU;
             test::n_samples_consumed = 0LU;
-            sched.runAndWait();
+            expect(sched.runAndWait().has_value());
             expect(eq(test::n_samples_produced, N_SAMPLES)) << "did not produce enough output samples";
             expect(eq(test::n_samples_consumed, N_SAMPLES)) << "did not consume enough input samples";
         };

--- a/core/benchmarks/bm_Scheduler.cpp
+++ b/core/benchmarks/bm_Scheduler.cpp
@@ -101,7 +101,7 @@ exec_bm(auto &scheduler, const std::string &test_case) {
     using namespace benchmark;
     test::n_samples_produced = 0LU;
     test::n_samples_consumed = 0LU;
-    scheduler.runAndWait();
+    expect(scheduler.runAndWait().has_value());
     expect(eq(test::n_samples_produced, N_SAMPLES)) << fmt::format("did not produce enough output samples for {}", test_case);
     expect(ge(test::n_samples_consumed, N_SAMPLES)) << fmt::format("did not consume enough input samples for {}", test_case);
 }

--- a/core/test/qa_DynamicBlock.cpp
+++ b/core/test/qa_DynamicBlock.cpp
@@ -11,9 +11,9 @@ const boost::ut::suite DynamicBlocktests = [] {
     using namespace boost::ut;
     using namespace gr::testing;
     "Change number of ports dynamically"_test = [] {
-        const gr::Size_t nInputs           = 5;
+        const gr::Size_t nInputs = 5;
         // const gr::Size_t nAdditionalInputs = 10; // total inputs = nInputs + nAdditionalInputs
-        const gr::Size_t nSamples          = 5;
+        const gr::Size_t nSamples = 5;
 
         gr::Graph graph;
 
@@ -31,7 +31,7 @@ const boost::ut::suite DynamicBlocktests = [] {
 
         gr::scheduler::Simple sched(std::move(graph));
 
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
 
         expect(eq(sink.samples, std::vector<double>{ 0., 5., 10., 15., 20 })) << "sinks samples does not match to expected values";
 

--- a/core/test/qa_DynamicPort.cpp
+++ b/core/test/qa_DynamicPort.cpp
@@ -191,7 +191,7 @@ const boost::ut::suite PortApiTests = [] {
         expect(eq(ConnectionResult::SUCCESS, flow.connect<"sum">(added).to<"sink">(out)));
 
         gr::scheduler::Simple sched{ std::move(flow) };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
     };
 
 #ifdef ENABLE_DYNAMIC_PORTS

--- a/core/test/qa_Messages.cpp
+++ b/core/test/qa_Messages.cpp
@@ -548,9 +548,7 @@ const boost::ut::suite MessagesTests = [] {
                 }
             }
         });
-
-        scheduler.runAndWait();
-
+        expect(scheduler.runAndWait().has_value());
         testWorker.join();
 
         fmt::println("##### finished test for scheduler {} - produced {} samples", gr::meta::type_name<decltype(scheduler)>(), sink.n_samples_produced);
@@ -629,7 +627,7 @@ const boost::ut::suite MessagesTests = [] {
 
         auto client = std::thread([&fromScheduler, &toScheduler, blockName = testBlock.unique_name, schedulerName = scheduler.unique_name] {
             sendMessage<Command::Set>(toScheduler, blockName, block::property::kStagedSetting, { { "factor", 43.0f } });
-            bool seenUpdate = false;
+            bool       seenUpdate = false;
             const auto startTime  = std::chrono::steady_clock::now();
             auto       isExpired  = [&startTime] { return std::chrono::steady_clock::now() - startTime > 3s; };
             bool       expired    = false;

--- a/core/test/qa_Scheduler.cpp
+++ b/core/test/qa_Scheduler.cpp
@@ -312,7 +312,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::Simple<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphLinear(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 8u);
         expect(boost::ut::that % t == TraceVectorType{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
@@ -322,7 +322,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::BreadthFirst<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphLinear(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 8u);
         expect(boost::ut::that % t == TraceVectorType{ "s1", "mult1", "mult2", "out", "s1", "mult1", "mult2", "out" });
@@ -332,7 +332,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::Simple<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphParallel(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 14u);
         expect(boost::ut::that % t == TraceVectorType{ "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb", "s1", "mult1a", "mult2a", "outa", "mult1b", "mult2b", "outb" });
@@ -342,7 +342,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::BreadthFirst<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphParallel(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 14u);
         expect(boost::ut::that % t
@@ -369,7 +369,7 @@ const boost::ut::suite SchedulerTests = [] {
         // construct an example graph and get an adjacency list for it
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphScaledSum(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 10u);
         expect(boost::ut::that % t == TraceVectorType{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out" });
@@ -379,7 +379,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::BreadthFirst<>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphScaledSum(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() == 10u);
         expect(boost::ut::that % t == TraceVectorType{ "s1", "s2", "mult", "add", "out", "s1", "s2", "mult", "add", "out" });
@@ -389,7 +389,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphLinear(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(that % t.size() >= 8u);
     };
@@ -402,7 +402,7 @@ const boost::ut::suite SchedulerTests = [] {
         expect(sched.jobs().size() == 2u);
         checkBlockNames(sched.jobs()[0], { "s1", "mult2" });
         checkBlockNames(sched.jobs()[1], { "mult1", "out" });
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() >= 8u) << fmt::format("execution order incomplete: {}", fmt::join(t, ", "));
     };
@@ -411,7 +411,7 @@ const boost::ut::suite SchedulerTests = [] {
         using scheduler               = gr::scheduler::Simple<gr::scheduler::ExecutionPolicy::multiThreaded>;
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphParallel(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() >= 14u) << fmt::format("execution order incomplete: {}", fmt::join(t, ", "));
     };
@@ -424,7 +424,7 @@ const boost::ut::suite SchedulerTests = [] {
         expect(sched.jobs().size() == 2u);
         checkBlockNames(sched.jobs()[0], { "s1", "mult1b", "mult2b", "outb" });
         checkBlockNames(sched.jobs()[1], { "mult1a", "mult2a", "outa" });
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() >= 14u);
     };
@@ -434,7 +434,7 @@ const boost::ut::suite SchedulerTests = [] {
         // construct an example graph and get an adjacency list for it
         std::shared_ptr<Tracer> trace = std::make_shared<Tracer>();
         auto                    sched = scheduler{ getGraphScaledSum(trace), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() >= 10u);
     };
@@ -447,7 +447,7 @@ const boost::ut::suite SchedulerTests = [] {
         expect(sched.jobs().size() == 2u);
         checkBlockNames(sched.jobs()[0], { "s1", "mult", "out" });
         checkBlockNames(sched.jobs()[1], { "s2", "add" });
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         auto t = trace->getVector();
         expect(boost::ut::that % t.size() >= 10u);
     };
@@ -461,7 +461,7 @@ const boost::ut::suite SchedulerTests = [] {
         expect(eq(gr::ConnectionResult::SUCCESS, flow.connect<"out">(lifecycleSource).to<"in">(lifecycleBlock)));
 
         auto sched = scheduler{ std::move(flow), threadPool };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
         expect(sched.changeStateTo(gr::lifecycle::State::INITIALISED).has_value());
 
         expect(eq(lifecycleSource.n_samples_produced, lifecycleSource.n_samples_max)) << "Source n_samples_produced != n_samples_max";

--- a/core/test/qa_Tags.cpp
+++ b/core/test/qa_Tags.cpp
@@ -137,7 +137,7 @@ const boost::ut::suite TagPropagation = [] {
         expect(eq(ConnectionResult::SUCCESS, testGraph.connect<"out">(monitorOneSIMD).to<"in">(sinkOne)));
 
         scheduler::Simple sched{ std::move(testGraph) };
-        sched.runAndWait();
+        expect(sched.runAndWait().has_value());
 
         // settings forwarding
         expect(eq("tagStream"s, src.signal_name)) << "src signal_name -> needed for setting-via-tag forwarding";

--- a/core/test/qa_grc.cpp
+++ b/core/test/qa_grc.cpp
@@ -107,17 +107,17 @@ const boost::ut::suite GrcTests = [] {
         auto graph              = gr::load_grc(context.loader, graph_source);
         auto graph_saved_source = gr::save_grc(graph);
 
-        auto checkAndPrintMissingLines = [](const std::string& first, const std::string& second) -> bool {
-            std::istringstream ssSecond(second);
+        auto checkAndPrintMissingLines = [](const std::string &first, const std::string &second) -> bool {
+            std::istringstream              ssSecond(second);
             std::unordered_set<std::string> linesSecond;
-            std::string line;
+            std::string                     line;
             while (std::getline(ssSecond, line)) {
                 linesSecond.insert(line);
             }
 
             std::istringstream ssFirst(first);
-            bool allLinesFound = true;
-            size_t lineNumber = 0;
+            bool               allLinesFound = true;
+            size_t             lineNumber    = 0;
             while (std::getline(ssFirst, line)) {
                 ++lineNumber;
                 if (!linesSecond.contains(line)) {
@@ -134,7 +134,7 @@ const boost::ut::suite GrcTests = [] {
         expect(checkAndPrintMissingLines(graph_source, graph_saved_source));
 
         gr::scheduler::Simple scheduler(std::move(graph));
-        scheduler.runAndWait();
+        expect(scheduler.runAndWait().has_value());
     };
 
     "Save and load"_test = [] {


### PR DESCRIPTION
Wrapped `schduler.runAndWait()` calls with `expect()`  to ensure return value presence.
