### PR TITLE
CI: fix docker step for main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       packages: write
 
     steps:
+      - uses: actions/checkout@v4
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
+
       - name: Check if dockerfile was modified
         id: changes
         uses: dorny/paths-filter@v3


### PR DESCRIPTION
Followup/fixup of #309 which broke the build on the main branch.

The docker step for branches needs a git checkout. For PRs this is not needed because the docker step does its own checkout and the path-filter uses the github API for PRs but needs a checkout for 'push' events.