### PR TITLE
wrap user-defined function exceptions to error messages

### DIFF
--- a/core/include/gnuradio-4.0/LifeCycle.hpp
+++ b/core/include/gnuradio-4.0/LifeCycle.hpp
@@ -154,6 +154,9 @@ protected:
         try {
             (static_cast<TDerived *>(this)->*method)();
             return {};
+        } catch (const gr::exception &e) {
+            setAndNotifyState(State::ERROR);
+            return std::unexpected(Error{ fmt::format("Block '{}' throws: {}", getBlockName(), e.what()), e.sourceLocation, e.errorTime });
         } catch (const std::exception &e) {
             setAndNotifyState(State::ERROR);
             return std::unexpected(Error{ fmt::format("Block '{}' throws: {}", getBlockName(), e.what()), location });

--- a/meta/include/gnuradio-4.0/meta/utils.hpp
+++ b/meta/include/gnuradio-4.0/meta/utils.hpp
@@ -523,15 +523,27 @@ namespace detail {
 template<typename T>
 struct is_const_member_function : std::false_type {};
 
-template<typename T, typename U, typename... args>
-struct is_const_member_function<U (T::*)(args...) const> : std::true_type {};
+template<typename T, typename TReturn, typename... Args>
+struct is_const_member_function<TReturn (T::*)(Args...) const> : std::true_type {};
+
+template<typename T, typename TReturn, typename... Args>
+struct is_const_member_function<TReturn (T::*)(Args...) const noexcept> : std::true_type {};
+
+template<typename T>
+struct is_noexcept_member_function : std::false_type {};
+
+template<typename T, typename TReturn, typename... Args>
+struct is_noexcept_member_function<TReturn (T::*)(Args...) noexcept> : std::true_type {};
+
+template<typename T, typename TReturn, typename... Args>
+struct is_noexcept_member_function<TReturn (T::*)(Args...) const noexcept> : std::true_type {};
 } // namespace detail
 
 template<typename T>
-inline constexpr bool
-is_const_member_function(T) noexcept {
-    return std::is_member_function_pointer_v<T> && detail::is_const_member_function<T>::value;
-}
+concept IsConstMemberFunction = std::is_member_function_pointer_v<T> && detail::is_const_member_function<T>::value;
+
+template<typename T>
+concept IsNoexceptMemberFunction = std::is_member_function_pointer_v<T> && detail::is_noexcept_member_function<T>::value;
 
 } // namespace meta
 } // namespace gr

--- a/meta/test/qa_traits.cpp
+++ b/meta/test/qa_traits.cpp
@@ -48,10 +48,22 @@ test() {
     // do nothing
 }
 
-static_assert(!is_const_member_function(&MyClass::nonConstFunc));
-static_assert(is_const_member_function(&MyClass::constFunc));
-static_assert(is_const_member_function(&MyClass::constFunc2));
-static_assert(!is_const_member_function(&test));
+static_assert(!IsConstMemberFunction<decltype(&MyClass::nonConstFunc)>);
+static_assert(IsConstMemberFunction<decltype(&MyClass::constFunc)>);
+static_assert(IsConstMemberFunction<decltype(&MyClass::constFunc2)>);
+static_assert(!IsConstMemberFunction<decltype(&test)>);
+
+struct Test {
+    void func(int, double) noexcept {}
+    void funcNotNoexcept(bool) {}
+    void constFunc(int) const noexcept {}
+    void constFuncNotNoexcept(float, int) const {}
+};
+
+static_assert(IsNoexceptMemberFunction<decltype(&Test::func)>);
+static_assert(!IsNoexceptMemberFunction<decltype(&Test::funcNotNoexcept)>);
+static_assert(IsNoexceptMemberFunction<decltype(&Test::constFunc)>);
+static_assert(!IsNoexceptMemberFunction<decltype(&Test::constFuncNotNoexcept)>);
 
 } // namespace gr::meta
 


### PR DESCRIPTION
While library internal code should be kept exception free, users (often using other C/C++ libraries) are free to throw exceptions to indicate rare errors. 

These exceptions are internally wrapped and passed up the chain to the graph->scheduler. 

In case the scheduler 'msgOut' is not connected these error messages are in turn converted to exceptions again.